### PR TITLE
Some fixes to json files.

### DIFF
--- a/ClanTechModule/mech/mechdef_Bane.json
+++ b/ClanTechModule/mech/mechdef_Bane.json
@@ -381,7 +381,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        }	
+        },
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2_double",

--- a/ClanTechModule/mech/mechdef_Bane_XR.json
+++ b/ClanTechModule/mech/mechdef_Bane_XR.json
@@ -317,7 +317,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        }	
+        },
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2_double",

--- a/ColoMechDefs/chassis/chassisdef_raven_RVN-2X.json
+++ b/ColoMechDefs/chassis/chassisdef_raven_RVN-2X.json
@@ -16,7 +16,7 @@
     "UIName": "Raven",
     "Id": "chassisdef_raven_RVN-2X",
     "Name": "Raven",
-    "Details": "Many of the Ravens captured by the Federated Suns in the Fourth Succession War were refitted in 3030 to the 2X standard. This variant replaced the EW equipment with a Large Laser.<b><color=#53ff1a>Restricted Actuators- Left: Upper, Right: Upper</color></b>"
+    "Details": "Many of the Ravens captured by the Federated Suns in the Fourth Succession War were refitted in 3030 to the 2X standard. This variant replaced the EW equipment with a Large Laser.<b><color=#53ff1a>Restricted Actuators- Left: Upper, Right: Upper</color></b>",
     "Icon": "Raven2"
   },
     "MovementCapDefID": "movedef_raven",

--- a/ColoMechDefs/mech/mechdef_kitfox_A.json
+++ b/ColoMechDefs/mech/mechdef_kitfox_A.json
@@ -150,7 +150,7 @@
       "DamageLevel": "Functional",
       "prefabName": null,
       "hasPrefabName": false
-    }			
+    },
         {
             "MountedLocation" : "CenterTorso",
             "ComponentDefID" : "emod_armorslots_clanferrosfibrous",

--- a/ColoMechDefs/mech/mechdef_kitfox_PRIME.json
+++ b/ColoMechDefs/mech/mechdef_kitfox_PRIME.json
@@ -160,7 +160,7 @@
       "DamageLevel": "Functional",
       "prefabName": null,
       "hasPrefabName": false
-    }		
+    },
         {
             "MountedLocation" : "CenterTorso",
             "ComponentDefID" : "emod_armorslots_clanferrosfibrous",

--- a/ColoMechDefs/mech/mechdef_wolfhound_WLF-1.json
+++ b/ColoMechDefs/mech/mechdef_wolfhound_WLF-1.json
@@ -7,7 +7,7 @@
             "unit_light",
             "unit_ready",
             "unit_lance_vanguard",
-            "unit_role_scout"
+            "unit_role_scout",
 			"unit_generic",
 			"unit_bracket_low",
 			"nautilus",

--- a/ColoMechDefs/mech/mechdef_wolfhound_WLF-4WB.json
+++ b/ColoMechDefs/mech/mechdef_wolfhound_WLF-4WB.json
@@ -31,7 +31,7 @@
       "axumite",
       "auriganpirates",
       "locals",
-      "magistracyofcanopus",,
+      "magistracyofcanopus",
       "rasalhague",
       "ives",
 	  "FlakJackals",

--- a/ElitePilots/DuelContracts/Duel_Coupe.json
+++ b/ElitePilots/DuelContracts/Duel_Coupe.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "6",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_Coupe_hard.json
+++ b/ElitePilots/DuelContracts/Duel_Coupe_hard.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. I wouldn't trust these Guys to play fair, Boss."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. I wouldn't trust these Guys to play fair, Boss.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "7",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_Coupe_solo.json
+++ b/ElitePilots/DuelContracts/Duel_Coupe_solo.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. Rumours have it they hired some specilaists."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. Rumours have it they hired some specilaists.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "7",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_EnGarde.json
+++ b/ElitePilots/DuelContracts/Duel_EnGarde.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "4",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_EnGarde_hard.json
+++ b/ElitePilots/DuelContracts/Duel_EnGarde_hard.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. I wouldn't trust these Guys to play fair, Boss."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. I wouldn't trust these Guys to play fair, Boss.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "5",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_EnGarde_solo.json
+++ b/ElitePilots/DuelContracts/Duel_EnGarde_solo.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. Rumours have it they hired some specilaists."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. Rumours have it they hired some specilaists.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "5",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_Riposte.json
+++ b/ElitePilots/DuelContracts/Duel_Riposte.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "5",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_Riposte_hard.json
+++ b/ElitePilots/DuelContracts/Duel_Riposte_hard.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. I wouldn't trust these Guys to play fair, Boss."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. I wouldn't trust these Guys to play fair, Boss.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "6",
     "requirementList": [],

--- a/ElitePilots/DuelContracts/Duel_Riposte_solo.json
+++ b/ElitePilots/DuelContracts/Duel_Riposte_solo.json
@@ -6,7 +6,7 @@
     "weight": 1,
     "scope": "STANDARD",
     "finalDifficulty": 0,
-    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. Rumours have it they hired some specialists."
+    "shortDescription": "A group of Pilots from {TEAM_TAR.FactionDef.Name} have issued a direct Challenge versus your lance. They are sporting Advanced Equipment. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the Broadcast right of this Battle. Rumours have it they hired some specialists.",
     "longDescription": "If they want to show military strength here in {TGT_SYSTEM.Name}, we can do that for them.",
     "salvagePotential": "6",
     "requirementList": [],

--- a/ElitePilots/ElitePilots/pilot_d10_HostileElitist.json
+++ b/ElitePilots/ElitePilots/pilot_d10_HostileElitist.json
@@ -34,7 +34,7 @@
 		"TraitAID8",
 "TraitAID9",
 "TraitAID10",
-"TraitAID11" 
+"TraitAID11",
 	"TraitDefUnsteadySet60",
 	"TraitDefHealthAddOne",
 	"TraitDefIndirectReduceOne",

--- a/ElitePilots/EliteTraits/TraitPayloadClanner.json
+++ b/ElitePilots/EliteTraits/TraitPayloadClanner.json
@@ -64,7 +64,7 @@
                 "modType" : "System.Single",
 			},
 			"nature" : "Buff"
-		}		
+		},
         {
 			"durationData" :
 			{

--- a/ExperimentalWeapons/internals/emod_armorslots_NullSignatureSystem_CLAN.json
+++ b/ExperimentalWeapons/internals/emod_armorslots_NullSignatureSystem_CLAN.json
@@ -32,7 +32,7 @@
 				"StealthShort: 1",
 				"StealthMid: 2",
 				"StealthLong: 3",
-				"StealthExt: 4"
+				"StealthExt: 4",
 				"StealthMove: 3",
 				"StealthDistance: 3",
 				"EvaMax: +1",
@@ -312,7 +312,7 @@
             "component_type_stock",
 			"lv-stealth_t2",
 			"lv-stealth-range-mod_s1_m2_l3_e4",
-			"lv-stealth-move-mod_m3_s3"
+			"lv-stealth-move-mod_m3_s3",
 			"ClanArmor"
         ],
         "tagSetSourceFile" : ""

--- a/ExperimentalWeapons/internals/emod_armorslots_stealth_CLAN.json
+++ b/ExperimentalWeapons/internals/emod_armorslots_stealth_CLAN.json
@@ -32,7 +32,7 @@
 				"StealthShort: 1",
 				"StealthMid: 1",
 				"StealthLong: 2",
-				"StealthExt: 3"
+				"StealthExt: 3",
 				"StealthMove: 3",
 				"StealthDistance: 2",
 				"EvaMax: +1",
@@ -260,7 +260,7 @@
             "component_type_stock",
 			"lv-stealth_t1",
 			"lv-stealth-range-mod_s1_m1_l2_e3",
-			"lv-stealth-move-mod_m3_s2"
+			"lv-stealth-move-mod_m3_s2",
 			"ClanArmor"
         ],
         "tagSetSourceFile" : ""

--- a/ExperimentalWeapons/mech/mechdef_bloodasp_S.json
+++ b/ExperimentalWeapons/mech/mechdef_bloodasp_S.json
@@ -295,7 +295,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        }	
+        },	
 	{
       "MountedLocation": "LeftLeg",
       "ComponentDefID": "Gear_Coolantpod_Clan",

--- a/ExperimentalWeapons/weapon/Weapon_HGauss_SB_CLAN.json
+++ b/ExperimentalWeapons/weapon/Weapon_HGauss_SB_CLAN.json
@@ -9,7 +9,7 @@
 				"VariableDmg: 5",
 				"WpnRecoil: 4",
 				"DmgFallOff: 45%",
-				"WeaponJAM: 20%"
+				"WeaponJAM: 20%",
 				"SBGR: 5",
                 "WeaponBoom: 100"
             ]

--- a/GPMechDefs/chassis/chassisdef_hellbringer_A.json
+++ b/GPMechDefs/chassis/chassisdef_hellbringer_A.json
@@ -205,7 +205,7 @@
         {
           "WeaponMount": "AntiPersonnel",
           "Omni": false
-        }
+        },
 		{
           "WeaponMount": "Missile",
           "Omni": false

--- a/GPMechDefs/chassis/chassisdef_hellbringer_H.json
+++ b/GPMechDefs/chassis/chassisdef_hellbringer_H.json
@@ -205,7 +205,7 @@
         {
           "WeaponMount": "AntiPersonnel",
           "Omni": false
-        }
+        },
 		{
           "WeaponMount": "Missile",
           "Omni": false
@@ -300,7 +300,7 @@
         {
           "WeaponMount": "AntiPersonnel",
           "Omni": false
-        }
+        },
         {
           "WeaponMount": "Missile",
           "Omni": false

--- a/GPMechDefs/mech/mechdef_bloodasp_A.json
+++ b/GPMechDefs/mech/mechdef_bloodasp_A.json
@@ -255,7 +255,7 @@
 		  "MountedLocation": "CenterTorso",
 		  "ComponentDefID": "Gear_Guardian_ECM_CLAN",
 		  "SimGameUID": null,
-		  "ComponentDefType": "Upgrade"
+		  "ComponentDefType": "Upgrade",
 		  "GUID": null,
 		  "DamageLevel": "Functional",
 		  "prefabName": null,

--- a/GPMechDefs/mech/mechdef_bloodasp_B.json
+++ b/GPMechDefs/mech/mechdef_bloodasp_B.json
@@ -234,7 +234,7 @@
 			"ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
 			"SimGameUID": null,
 			"ComponentDefType": "Weapon",
-			"HardpointSlot": 2
+			"HardpointSlot": 2,
 			"GUID": null,
 			"DamageLevel": "Functional",
 			"prefabName": null,
@@ -255,7 +255,7 @@
 		  "MountedLocation": "LeftTorso",
 		  "ComponentDefID": "Gear_TargetingTrackingSystem_Clan_ARTEMISIV",
 		  "SimGameUID": null,
-		  "ComponentDefType": "Upgrade"
+		  "ComponentDefType": "Upgrade",
 		  "GUID": null,
 		  "DamageLevel": "Functional",
 		  "prefabName": null,

--- a/GPMechDefs/mech/mechdef_cougar_CGR-B.json
+++ b/GPMechDefs/mech/mechdef_cougar_CGR-B.json
@@ -262,7 +262,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        }	
+        },
         {
             "MountedLocation": "LeftTorso",
             "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",

--- a/GPMechDefs/mech/mechdef_hellbringer_E.json
+++ b/GPMechDefs/mech/mechdef_hellbringer_E.json
@@ -7,7 +7,7 @@
       "unit_lance_tank",
       "unit_role_sniper",
 	  "unit_advanced",
-      "unit_bracket_med",,
+      "unit_bracket_med",
       "clansgeneric",
       "clanwolf",
       "clanfiremandrill",

--- a/GPMechDefs/mech/mechdef_madcatmkii-FIS.json
+++ b/GPMechDefs/mech/mechdef_madcatmkii-FIS.json
@@ -274,7 +274,7 @@
       "DamageLevel": "Functional",
       "prefabName": null,
       "hasPrefabName": false
-    }	
+    },	
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_MRM_10",

--- a/GPMechDefs/mech/mechdef_nova_C.json
+++ b/GPMechDefs/mech/mechdef_nova_C.json
@@ -297,7 +297,7 @@
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_Laser_SmallLaserPulse_CLAN",
       "SimGameUID": null,
-      "ComponentDefType": "Weapon"
+      "ComponentDefType": "Weapon",
       "HardpointSlot": -1,
       "GUID": null,
       "DamageLevel": "Functional",

--- a/GPMechDefs/mech/mechdef_nova_F.json
+++ b/GPMechDefs/mech/mechdef_nova_F.json
@@ -270,7 +270,7 @@
       "DamageLevel": "Functional",
       "prefabName": null,
       "hasPrefabName": false
-    }
+    },
 	{
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",

--- a/GPMechDefs/mech/mechdef_stormcrow_LACERATOR.json
+++ b/GPMechDefs/mech/mechdef_stormcrow_LACERATOR.json
@@ -6,7 +6,7 @@
       "unit_medium",
       "unit_lance_assasin",
       "unit_role_sniper",
-	  "unit_advanced"
+	  "unit_advanced",
       "unit_legendary",
       "unit_hero",
       "unit_bracket_high",

--- a/GPMechDefs/mech/mechdef_supernova.json
+++ b/GPMechDefs/mech/mechdef_supernova.json
@@ -245,7 +245,7 @@
       "DamageLevel": "Functional",
       "prefabName": null,
       "hasPrefabName": false
-    }		
+    },
 	{
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_JumpJet_Improved_Assault",

--- a/HoTDMechDefs/chassis/chassisdef_marauderII_MAD-4H.json
+++ b/HoTDMechDefs/chassis/chassisdef_marauderII_MAD-4H.json
@@ -103,7 +103,7 @@
         {
           "WeaponMount": "Missile",
           "Omni": false
-        }
+        },
 		{
           "WeaponMount": "Missile",
           "Omni": false
@@ -144,7 +144,7 @@
         {
           "WeaponMount": "Missile",
           "Omni": false
-        }
+        },
 		{
           "WeaponMount": "Missile",
           "Omni": false

--- a/HoTDMechDefs/chassis/chassisdef_templar_TLR1-0.json
+++ b/HoTDMechDefs/chassis/chassisdef_templar_TLR1-0.json
@@ -176,7 +176,7 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        }		
+        },
         {
           "WeaponMount": "Energy",
           "Omni": false
@@ -225,7 +225,7 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        }		
+        },
         {
           "WeaponMount": "Energy",
           "Omni": false

--- a/HoTDMechDefs/chassis/chassisdef_templar_TLR1-D.json
+++ b/HoTDMechDefs/chassis/chassisdef_templar_TLR1-D.json
@@ -175,7 +175,7 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        }		
+        },
         {
           "WeaponMount": "Energy",
           "Omni": false
@@ -224,7 +224,7 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        }		
+        },
         {
           "WeaponMount": "Energy",
           "Omni": false

--- a/HoTDMechDefs/mech/mechdef_marauder_MAD-9S.json
+++ b/HoTDMechDefs/mech/mechdef_marauder_MAD-9S.json
@@ -236,7 +236,7 @@
 			"DamageLevel": "Functional",
 			"prefabName": null,
 			"hasPrefabName": false
-		}	
+		},
     {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_lower",

--- a/PirateMechs/chassis/chassisdef_rifleman_RFL-P.json
+++ b/PirateMechs/chassis/chassisdef_rifleman_RFL-P.json
@@ -14,7 +14,7 @@
     "UIName": "Rifleman II",
     "Id": "chassisdef_rifleman_RFL-P",
     "Name": "Rifleman II",
-    "Details": "This Chassis is weird boss, it definitely was a Star League Era Design, but it seems to have been rebuilt and repaired so many times that barely anything is left of it, dont even want to speculate how a bunch of Pirates got their hands on it. <b><color=#53ff1a>Restricted Actuators- Left: Upper, Right: Upper</color></b>"
+    "Details": "This Chassis is weird boss, it definitely was a Star League Era Design, but it seems to have been rebuilt and repaired so many times that barely anything is left of it, dont even want to speculate how a bunch of Pirates got their hands on it. <b><color=#53ff1a>Restricted Actuators- Left: Upper, Right: Upper</color></b>",
     "Icon": "Rifleman1"
   },
   "MovementCapDefID": "movedef_rifleman_RFL-3N",

--- a/PirateMechs/mech/mechdef_Mackie-P.json
+++ b/PirateMechs/mech/mechdef_Mackie-P.json
@@ -307,7 +307,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        }		
+        },
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20_double",
@@ -351,7 +351,7 @@
       "DamageLevel": "Functional",
       "prefabName": null,
       "hasPrefabName": false
-    },	
+    },
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_Autocannon_RAC20_Pirate",

--- a/PirateMechs/mech/mechdef_rifleman_RFL-P.json
+++ b/PirateMechs/mech/mechdef_rifleman_RFL-P.json
@@ -7,7 +7,7 @@
             "unit_lance_support",
             "unit_role_sniper",
             "unit_advanced",
-			"unit_legendary"
+			"unit_legendary",
             "unit_bracket_medium",
             "locals",
       "jarnfolk",

--- a/RogueContracts/lance/SoloMech/lancedef_mech_d6_dynamic_solo.json
+++ b/RogueContracts/lance/SoloMech/lancedef_mech_d6_dynamic_solo.json
@@ -68,8 +68,8 @@
             },
             "pilotTagSet": {
                 "items": ["{CUR_TEAM.faction}",
-                    "pilot_npc_d8"
-					"pilot_npc_high",
+                    "pilot_npc_d8",
+					"pilot_npc_high"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/VehicleSupport/lancedef_vehicle_d10_dynamic_support.json
+++ b/RogueContracts/lance/VehicleSupport/lancedef_vehicle_d10_dynamic_support.json
@@ -106,7 +106,7 @@
             },
             "excludedUnitTagSet": {
                 "items": [
-                    "unit_noncombatant",,
+                    "unit_noncombatant",
 					"unit_assault",
                     "unit_legendary",
                     "unit_generic"

--- a/RogueFlashPointModule/Mech/mechdef_axman_AXM-1N.json
+++ b/RogueFlashPointModule/Mech/mechdef_axman_AXM-1N.json
@@ -338,7 +338,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        }		
+        },
 		{
 			"ComponentDefID": "Weapon_Autocannon_AC20_2-Kali_Yama",
 			"ComponentDefType": "Weapon",

--- a/RogueFlashPointModule/Mech/mechdef_crab_CRB-20.json
+++ b/RogueFlashPointModule/Mech/mechdef_crab_CRB-20.json
@@ -59,7 +59,7 @@
     "UIName": "Crab CRB-20",
     "Id": "mechdef_crab_CRB-20",
     "Name": "Crab",
-    "Details": "Designed in 2719 during the last days of the Star League, the Crab was built as a medium-weight raider and guerrilla fighter for the Star League Defense Force. Although lacking hand actuators or jump jets, it possessed good overland speed and its all-energy weapons payload was suitable for long-range missions without the prospect for resupply."
+    "Details": "Designed in 2719 during the last days of the Star League, the Crab was built as a medium-weight raider and guerrilla fighter for the Star League Defense Force. Although lacking hand actuators or jump jets, it possessed good overland speed and its all-energy weapons payload was suitable for long-range missions without the prospect for resupply.",
     "Icon": "uixTxrIcon_crab"
   },
   "simGameMechPartCost": 1270000,

--- a/RogueFlashPointModule/Mech/mechdef_crab_CRB-21.json
+++ b/RogueFlashPointModule/Mech/mechdef_crab_CRB-21.json
@@ -161,7 +161,7 @@
       "SimGameUID": "",
       "hasPrefabName": false,
       "prefabName": null
-    }  
+    },
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_structureslots_endosteel",

--- a/RogueFlashPointModule/Mech/mechdef_crab_CRB-GI.json
+++ b/RogueFlashPointModule/Mech/mechdef_crab_CRB-GI.json
@@ -40,7 +40,7 @@
     "UIName": "Gemji CRB-GI",
     "Id": "mechdef_crab_CRB-GI",
     "Name": "Gemji",
-    "Details": "The melee-specialized 'Gemji' CRB-GI has opened its claws, bringing Industrial-strength table flipping to a 'Mech fight. <b><color=#009933>Quirk: Melee Crab - improved Melee Accuracy and +1 Defense</color></b>"
+    "Details": "The melee-specialized 'Gemji' CRB-GI has opened its claws, bringing Industrial-strength table flipping to a 'Mech fight. <b><color=#009933>Quirk: Melee Crab - improved Melee Accuracy and +1 Defense</color></b>",
     "Icon": "uixTxrIcon_crab"
   },
   "simGameMechPartCost": 1270000,

--- a/RogueFlashPointModule/Mech/mechdef_cyclops_CP_11_Z.json
+++ b/RogueFlashPointModule/Mech/mechdef_cyclops_CP_11_Z.json
@@ -59,7 +59,7 @@
 	"ChassisID": "chassisdef_cyclops_CP-11-Z",
 	"Description": {
 		"Cost": 114600000,
-		"Details": "Cyclops 11-Zs use their imposing presence and unique communications equipment to control the battlefield. Carrying the same Battle Computer as the C10, is this variant enhanced with several LosTech including a C3 Master Computer, further increasing the lances power."
+		"Details": "Cyclops 11-Zs use their imposing presence and unique communications equipment to control the battlefield. Carrying the same Battle Computer as the C10, is this variant enhanced with several LosTech including a C3 Master Computer, further increasing the lances power.",
 		"Icon": "uixTxrIcon_cyclops",
 		"Id": "mechdef_cyclops_CP-11-Z",
 		"Manufacturer": null,

--- a/RogueFlashPointModule/Mech/mechdef_hatchetman_HCT-5D.json
+++ b/RogueFlashPointModule/Mech/mechdef_hatchetman_HCT-5D.json
@@ -303,7 +303,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        },, {
+        }, {
 			"ComponentDefID": "Ammo_AmmunitionBox_Generic_AC10",
 			"ComponentDefType": "AmmunitionBox",
 			"DamageLevel": "Functional",

--- a/RogueFlashPointModule/Mech/mechdef_hatchetman_HCT-P.json
+++ b/RogueFlashPointModule/Mech/mechdef_hatchetman_HCT-P.json
@@ -304,7 +304,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        },, {
+        }, {
 			"ComponentDefID": "Ammo_AmmunitionBox_Caseless_AC10",
 			"ComponentDefType": "AmmunitionBox",
 			"DamageLevel": "Functional",

--- a/RogueFlashPointModule/Mech/mechdef_hatchetman_HCT-S7.json
+++ b/RogueFlashPointModule/Mech/mechdef_hatchetman_HCT-S7.json
@@ -242,7 +242,7 @@
       "SimGameUID": "",
       "hasPrefabName": false,
       "prefabName": null
-    }		
+    },
 	{
 			"ComponentDefID": "Weapon_Flamer_Firefist",
 			"ComponentDefType": "Weapon",

--- a/RogueFlashPointModule/mod.json
+++ b/RogueFlashPointModule/mod.json
@@ -21,7 +21,7 @@
         {
             "Type": "MechDef",
             "Path": "FPMechs"
-        }		
+        },
         {
             "Type": "ChassisDef",
             "Path": "chassis"

--- a/RogueMechs/chassis/chassisdef_jenner_JR7-X.json
+++ b/RogueMechs/chassis/chassisdef_jenner_JR7-X.json
@@ -27,7 +27,7 @@
             "statName": "AccuracyModifier",
             "operation": "Float_Add",
             "modValue": "-2.0",
-            "modType": "System.Single"
+            "modType": "System.Single",
                 "targetCollection" : "Weapon",
                 "targetWeaponCategory" : "Missile"			
           },

--- a/RogueMechs/chassis/chassisdef_orion_ON1-KER.json
+++ b/RogueMechs/chassis/chassisdef_orion_ON1-KER.json
@@ -3,7 +3,7 @@
     "ArmActuatorSupport": {
       "LeftLimit": "Lower",
       "RightLimit": "Lower"
-    }
+    },
 	"ChassisQuirks": 
 	{
       "statusEffects": 

--- a/RogueMechs/chassis/chassisdef_raptor_RTX1-O.json
+++ b/RogueMechs/chassis/chassisdef_raptor_RTX1-O.json
@@ -410,7 +410,7 @@
   "VariantName": "RTX1-O",
   "ChassisTags": {
     "items": [
-	"OmniMech"
+	"OmniMech",
 	"mr-resize-1.1"
     ],
     "tagSetSourceFile": ""

--- a/RogueMechs/mech/mechdef_banshee_BNC-HK.json
+++ b/RogueMechs/mech/mechdef_banshee_BNC-HK.json
@@ -170,7 +170,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        },, {
+        }, {
 			"MountedLocation": "CenterTorso",
 			"ComponentDefID": "emod_engine_425",
             "SimGameUID": null,

--- a/RogueMechs/mech/mechdef_cicada_CDA-4L.json
+++ b/RogueMechs/mech/mechdef_cicada_CDA-4L.json
@@ -198,7 +198,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        },, {
+        }, {
 			"MountedLocation": "CenterTorso",
 			"ComponentDefID": "emod_engineslots_std_center",
 			"ComponentDefType": "HeatSink",

--- a/RogueMechs/mech/mechdef_spider_SDR-6V.json
+++ b/RogueMechs/mech/mechdef_spider_SDR-6V.json
@@ -150,7 +150,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        },, {
+        }, {
 			"MountedLocation": "CenterTorso",
 			"ComponentDefID": "Gear_Gyro_Ultralight",
 			"SimGameUID": null,

--- a/RogueModuleElites/chassis/chassisdef_phoenixhawk_PXH-IIC.json
+++ b/RogueModuleElites/chassis/chassisdef_phoenixhawk_PXH-IIC.json
@@ -322,7 +322,7 @@
           "WeaponMount": "AntiPersonnel",
           "Omni": false
         },
-		]
+		],
 		      "Tonnage": 0,
       "InventorySlots": 11,
       "MaxArmor": 130,

--- a/RogueModuleElites/mech/mechdef_NovaCat_NCT-Mir.json
+++ b/RogueModuleElites/mech/mechdef_NovaCat_NCT-Mir.json
@@ -119,7 +119,7 @@
             "AssignedRearArmor": 0
         }
     ],
-    "inventory": [,
+    "inventory": [
         {
             "MountedLocation": "LeftTorso",
             "ComponentDefID": "Gear_AdvancedMaterials3",

--- a/RogueModuleElites/mech/mechdef_kuro_shi.json
+++ b/RogueModuleElites/mech/mechdef_kuro_shi.json
@@ -285,7 +285,7 @@
             "DamageLevel": "Functional",
             "prefabName": null,
             "hasPrefabName": false
-        }			
+        },
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_Autocannon_AC10_LBX",

--- a/RogueModuleTech/Clan/internals/Gear_AP_CLAN.json
+++ b/RogueModuleTech/Clan/internals/Gear_AP_CLAN.json
@@ -41,7 +41,7 @@
     "Tonnage" : 1,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/Clan/internals/Gear_Cockpit_CLAN_EI.json
+++ b/RogueModuleTech/Clan/internals/Gear_Cockpit_CLAN_EI.json
@@ -48,7 +48,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/Clan/internals/Gear_Cockpit_CLAN_Society.json
+++ b/RogueModuleTech/Clan/internals/Gear_Cockpit_CLAN_Society.json
@@ -18,7 +18,7 @@
 				"TEHeatgen: -5%",
                 "BankMaxHeat: 10",
 				"BankThreshhold: 10",
-				"Initiative: +3"
+				"Initiative: +3",
 				"IsCockpit"
             ]
         },
@@ -52,7 +52,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/Clan/internals/Gear_Cockpit_CLAN_Standard.json
+++ b/RogueModuleTech/Clan/internals/Gear_Cockpit_CLAN_Standard.json
@@ -12,10 +12,10 @@
 		},
         "BonusDescriptions": {
             "Bonuses": [
-				"Breaching"
+				"Breaching",
 				"Sensors: 20%",
 				"Sight: 20%",
-				"Initiative: +2"
+				"Initiative: +2",
 				"IsCockpit"
             ]
         },
@@ -49,7 +49,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/Clan/internals/Gear_TTS_AdvancedTC_CLAN.json
+++ b/RogueModuleTech/Clan/internals/Gear_TTS_AdvancedTC_CLAN.json
@@ -51,7 +51,7 @@
     "Tonnage" : 4,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
 		{
 			"durationData" :

--- a/RogueModuleTech/Clan/internals/emod_armorslots_clanHeatDissipating.json
+++ b/RogueModuleTech/Clan/internals/emod_armorslots_clanHeatDissipating.json
@@ -15,9 +15,9 @@
 		"DynamicSlots": {
 			"ReservedSlots": 6,
 			"BackgroundColor": "GoldHalf",			
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"Weights": {
@@ -36,7 +36,7 @@
                 "ArmorFactor: +10%",
                 "Reserved: 6",
 				"ArmorTPCost: 40%",
-				"ArmorCBCost: 75%"
+				"ArmorCBCost: 75%",
 				"CASE"
             ]
         },

--- a/RogueModuleTech/Clan/internals/emod_armorslots_clanferrosfibrous.json
+++ b/RogueModuleTech/Clan/internals/emod_armorslots_clanferrosfibrous.json
@@ -15,9 +15,9 @@
 		"DynamicSlots": {
 			"ReservedSlots": 7,
 			"BackgroundColor": "GoldHalf",			
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"Weights": {

--- a/RogueModuleTech/Clan/internals/emod_armorslots_clstandard.json
+++ b/RogueModuleTech/Clan/internals/emod_armorslots_clstandard.json
@@ -11,7 +11,7 @@
 		},
         "CASE": {
             "AllLocations": true
-        }		
+        },		
 		"Category" : { 
 			"CategoryID" : "Armor" 
 		},
@@ -19,7 +19,7 @@
 		"Flags" : { "flags" : [ "ignore_damage" ] },
         "BonusDescriptions": {
             "Bonuses": [
-				"CASE"
+				"CASE",
 				"ArmorTPCost: 10%",
 				"ArmorCBCost: 15%"
             ]

--- a/RogueModuleTech/Clan/internals/emod_structureslots_clanendosteel.json
+++ b/RogueModuleTech/Clan/internals/emod_structureslots_clanendosteel.json
@@ -9,9 +9,9 @@
 		"DynamicSlots": {
 			"ReservedSlots": 7,
 			"BackgroundColor": "OrangeHalf",
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"Weights": {

--- a/RogueModuleTech/Clan/weapons/Weapon_ArrowIV_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_ArrowIV_CLAN.json
@@ -5,11 +5,11 @@
 		},
         "ComponentExplosion": {
             "ExplosionDamagePerAmmo": 300
-        }		
+        },
         "BonusDescriptions": {
             "Bonuses": [
 				"IsArtillery",
-				"VariableDmg: 75"
+				"VariableDmg: 75",
 				"WpnRecoil: 3"
             ]
         },	

--- a/RogueModuleTech/Clan/weapons/Weapon_FLAMER_PLASMA_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_FLAMER_PLASMA_CLAN.json
@@ -107,7 +107,7 @@
                 "statName" : "HeatGenerated",
                 "operation" : "Float_Multiply",
                 "modValue" : "1.2",
-                "modType" : "System.Single"
+                "modType" : "System.Single",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "Weapon",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/Clan/weapons/Weapon_LRM_iATM12_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_LRM_iATM12_CLAN.json
@@ -34,7 +34,7 @@
     "DamageVariance" : 0,
     "HeatDamage" : 0,
     "AccuracyModifier" : -2,
-    "CriticalChanceMultiplier" : 1
+    "CriticalChanceMultiplier" : 1,
     "AOECapable" : false,
     "IndirectFireCapable" : true,
     "RefireModifier" : 0,

--- a/RogueModuleTech/Clan/weapons/Weapon_LRM_iATM6_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_LRM_iATM6_CLAN.json
@@ -34,7 +34,7 @@
     "DamageVariance" : 0,
     "HeatDamage" : 0,
     "AccuracyModifier" : -2,
-    "CriticalChanceMultiplier" : 1
+    "CriticalChanceMultiplier" : 1,
     "AOECapable" : false,
     "IndirectFireCapable" : true,
     "RefireModifier" : 0,

--- a/RogueModuleTech/Clan/weapons/Weapon_LRM_iATM9_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_LRM_iATM9_CLAN.json
@@ -34,7 +34,7 @@
     "DamageVariance" : 0,
     "HeatDamage" : 0,
     "AccuracyModifier" : -2,
-    "CriticalChanceMultiplier" : 1
+    "CriticalChanceMultiplier" : 1,
     "AOECapable" : false,
     "IndirectFireCapable" : true,
     "RefireModifier" : 0,

--- a/RogueModuleTech/Clan/weapons/Weapon_Laser_HeavyMediumLaser_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_Laser_HeavyMediumLaser_CLAN.json
@@ -9,8 +9,7 @@
             "InventorySorter" : {
                 "SortKey" : "02005"
             }
-		}
-		
+		},
     "Category" : "Energy",
     "Type" : "Laser",
     "WeaponSubType" : "MediumLaser",

--- a/RogueModuleTech/Clan/weapons/Weapon_Laser_HeavySmallLaser_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_Laser_HeavySmallLaser_CLAN.json
@@ -9,8 +9,7 @@
             "InventorySorter" : {
                 "SortKey" : "02002"
             }
-		}
-		
+		},
     "Category" : "Energy",
     "Type" : "Laser",
     "WeaponSubType" : "SmallLaser",

--- a/RogueModuleTech/Clan/weapons/Weapon_Laser_ImprovedHeavyMediumLaser_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_Laser_ImprovedHeavyMediumLaser_CLAN.json
@@ -9,8 +9,7 @@
             "InventorySorter" : {
                 "SortKey" : "02005"
             }
-		}
-		
+		},
     "Category" : "Energy",
     "Type" : "Laser",
     "WeaponSubType" : "MediumLaser",

--- a/RogueModuleTech/Clan/weapons/Weapon_Laser_ImprovedHeavySmallLaser_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_Laser_ImprovedHeavySmallLaser_CLAN.json
@@ -9,8 +9,7 @@
             "InventorySorter" : {
                 "SortKey" : "02002"
             }
-		}
-		
+		},
     "Category" : "Energy",
     "Type" : "Laser",
     "WeaponSubType" : "SmallLaser",

--- a/RogueModuleTech/Pirate/upgrades/Gear_Pirate_AdvancedTC.json
+++ b/RogueModuleTech/Pirate/upgrades/Gear_Pirate_AdvancedTC.json
@@ -50,7 +50,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/Pirate/upgrades/Gear_Spiked_Fist.json
+++ b/RogueModuleTech/Pirate/upgrades/Gear_Spiked_Fist.json
@@ -7,7 +7,7 @@
             "Bonuses": [
 				"MeleeAcc: +1",
 				"Melee: +25%",
-				"Melee2: +5"
+				"Melee2: +5",
 				"MeleeStab: +30%",
 				"MeleeCrit: +100%",
 				"ActuatorWeight: 25%"

--- a/RogueModuleTech/Pirate/upgrades/emod_Aftermarket_stealth.json
+++ b/RogueModuleTech/Pirate/upgrades/emod_Aftermarket_stealth.json
@@ -33,7 +33,7 @@
 				"StealthExt: 2",
 				"StealthMove: 2",
 				"StealthDistance: 3",
-				"EvaPips: +1"			
+				"EvaPips: +1",
                 "Reserved: 6",
 				"HeatGenerated: +6%",
 				"HeatPerTurn: +6",

--- a/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC10_LBX_jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC10_LBX_jrig.json
@@ -7,7 +7,7 @@
 				"VariableDmg: 2",
 				"WpnRecoil: 5",
 				"Explodium: 25%",
-				"DakkaBoom: 80"
+				"DakkaBoom: 80",
 				"DmgFallOff: 45%",
 				"LBX: 7"
             ]

--- a/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC20_0-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC20_0-jrig.json
@@ -5,7 +5,7 @@
             "Bonuses": [
                 "WpnRecoil: 6",
 				"VariableDmg: 66",
-				"WpnCrits: +66%"
+				"WpnCrits: +66%",
 				"WpnAccuracy: +1",				
 				"PipsIgnored: 1",
 				"WeaponJAM: 18%",

--- a/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC20_AP-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC20_AP-jrig.json
@@ -5,7 +5,7 @@
             "Bonuses": [
                 "WpnRecoil: 5",
 				"VariableDmg: 25",
-				"WpnCrits: +100%"
+				"WpnCrits: +100%",
 				"WeaponJAM: 50%",
 				"IsMelee",
 				"IsAC"

--- a/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC5_IN-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_AC5_IN-jrig.json
@@ -5,7 +5,7 @@
             "Bonuses": [
                 "WpnRecoil: 2",
 				"VariableDmg: 9",
-				"WpnCrits: -50%"
+				"WpnCrits: -50%",
 				"OHDamage: X3",
 				"Explodium: 20%",
 				"IsAC"

--- a/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_RAC10_Pirate.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_RAC10_Pirate.json
@@ -28,7 +28,7 @@
     ],
     "AmmoCategory" : "AC10",
     "StartingAmmoCapacity" : 0,
-    "HeatGenerated" : 50
+    "HeatGenerated" : 50,
     "Damage" : 14,
     "OverheatedDamageMultiplier" : 0,
     "EvasiveDamageMultiplier" : 0,

--- a/RogueModuleTech/Pirate/weapons/Weapon_Flamer_Flamer_0-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Flamer_Flamer_0-jrig.json
@@ -3,7 +3,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "WpnRecoil: 1",
-				"WpnAccuracy: -1"
+				"WpnAccuracy: -1",
 				"VariableDmg: 15",
 				"PipsIgnored: 2",
 				"OHDamage: 50%"

--- a/RogueModuleTech/Pirate/weapons/Weapon_Flamer_Heavy_Pirate.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Flamer_Heavy_Pirate.json
@@ -104,7 +104,7 @@
                 "statName" : "HeatGenerated",
                 "operation" : "Float_Multiply",
                 "modValue" : "1.25",
-                "modType" : "System.Single"
+                "modType" : "System.Single",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "Weapon",
                 "targetWeaponCategory" : "NotSet",
@@ -155,7 +155,7 @@
             "statName": "HeatSinkCapacity",
             "operation": "Int_Add",
             "modValue": "-5",
-            "modType": "System.Int32"
+            "modType": "System.Int32",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "NotSet",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/Pirate/weapons/Weapon_Laser_TheStare-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Laser_TheStare-jrig.json
@@ -3,7 +3,7 @@
 "Custom": {
         "BonusDescriptions": {
             "Bonuses": [
-				"Painter"
+				"Painter",
                 "PipsIgnored: 3",
 				"VariableDmg: 20",
 				"WpnRecoil: 2",

--- a/RogueModuleTech/Pirate/weapons/Weapon_PPC_PIRATE_SNUBNOSE.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_PPC_PIRATE_SNUBNOSE.json
@@ -156,7 +156,7 @@
 				"statName" : "RefireModifier",
 				"operation" : "Int_Add",
 				"modValue" : "1",
-				"modType" : "System.Int32"
+				"modType" : "System.Int32",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "Weapon",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/Pirate/weapons/Weapon_PPC_PPC_0-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_PPC_PPC_0-jrig.json
@@ -7,7 +7,7 @@
                 "WpnCrits: +50%",
 				"VariableDmg: 10",
 				"DmgFallOff: 25%",
-				"WpnAccuracy: -2"
+				"WpnAccuracy: -2",
 				"WpnRecoil: 4"
             ]
         },

--- a/RogueModuleTech/Primitive/weapons/Weapon_Autocannon_AC10_Quicsell.json
+++ b/RogueModuleTech/Primitive/weapons/Weapon_Autocannon_AC10_Quicsell.json
@@ -3,7 +3,7 @@
 	"Custom": {
         "BonusDescriptions": {
             "Bonuses": [
-				"ACDamage: -10"
+				"ACDamage: -10",
 				"WpnRecoil: 3",
 				"WeaponJAM: 24%",
 				"IsAC"

--- a/RogueModuleTech/Primitive/weapons/Weapon_Industrial_PolePlanter.json
+++ b/RogueModuleTech/Primitive/weapons/Weapon_Industrial_PolePlanter.json
@@ -14,7 +14,7 @@
 
     "Category" : "AntiPersonnel",
     "Type" : "Autocannon",
-    "WeaponSubType" : "AC20"
+    "WeaponSubType" : "AC20",
     "MinRange" : 0,
     "MaxRange" : 40,
     "RangeSplit" : [

--- a/RogueModuleTech/VanillaWeapons/Weapon_Autocannon_AC20_1-Mydron.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_Autocannon_AC20_1-Mydron.json
@@ -3,8 +3,8 @@
 	"Custom": {
         "BonusDescriptions": {
             "Bonuses": [
-				"StabDamage: +50%"
-				"WpnRecoil: 2"
+				"StabDamage: +50%",
+				"WpnRecoil: 2",
 				"WeaponJAM: 10%",
             ]
         },	

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_B20-Extended.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_B20-Extended.json
@@ -218,7 +218,7 @@
                 "targetCollection" : "Weapon",
                 "targetWeaponSubType" : "Melee"
             }
-        }
+        },
        {
             "durationData" : {
                 "duration" : -1,

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_B40-Extended.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_B40-Extended.json
@@ -218,7 +218,7 @@
                 "targetCollection" : "Weapon",
                 "targetWeaponSubType" : "Melee"
             }
-        }
+        },
        {
             "durationData" : {
                 "duration" : -1,

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_X55-Standard.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_X55-Standard.json
@@ -11,7 +11,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "ArmAccuracy: +2",
-				"Radius: +10%"
+				"Radius: +10%",
 				"MeleeAcc: -4",
 				"ActuatorWeight: 10%"
             ]

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_X75-Standard.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_X75-Standard.json
@@ -12,7 +12,7 @@
             "Bonuses": [
                 "ArmAccuracy: +3",
 				"Recoil: -1",
-				"Radius: +30%"
+				"Radius: +30%",
 				"MeleeAcc: -2",
 				"ActuatorWeight: 10%"
             ]

--- a/RogueModuleTech/actuators/Gear_Actuator_Friedhof_Behemoth.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Friedhof_Behemoth.json
@@ -10,7 +10,7 @@
 		},
         "BonusDescriptions": {
             "Bonuses": [
-				"ActuatorWeight: 10%"
+				"ActuatorWeight: 10%",
 				"EnergyAcc: +1"
             ]
         },		

--- a/RogueModuleTech/actuators/Gear_Actuator_HandyVac_Industrial_CargoGrip.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_HandyVac_Industrial_CargoGrip.json
@@ -7,7 +7,7 @@
             "Bonuses": [
                 "MeleeStab: +20",
 				"MeleeStab: +40%",
-				"Melee: +55%"
+				"Melee: +55%",
                 "MeleeAcc: -1",
             ]
         },

--- a/RogueModuleTech/actuators/Gear_Actuator_HandyVac_Industrial_ExcavatorClaw.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_HandyVac_Industrial_ExcavatorClaw.json
@@ -6,8 +6,8 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Melee2: 20",
-				"Melee: +55%"
-				"MeleeStab: 30%"
+				"Melee: +55%",
+				"MeleeStab: 30%",
                 "MeleeAcc: -1"
             ]
         },

--- a/RogueModuleTech/actuators/Gear_Arm_Blade.json
+++ b/RogueModuleTech/actuators/Gear_Arm_Blade.json
@@ -7,7 +7,7 @@
             "Bonuses": [
 				"MeleeAcc: +1",
 				"Melee: +45%",
-				"Melee2: +5"
+				"Melee2: +5",
 				"MeleeStab: +20%",
 				"MeleeCrit: +25%",
 				"ActuatorWeight: 40%"

--- a/RogueModuleTech/actuators/Gear_Arm_Claws.json
+++ b/RogueModuleTech/actuators/Gear_Arm_Claws.json
@@ -7,7 +7,7 @@
             "Bonuses": [
 				"MeleeAcc: +2",
 				"Melee: +70%",
-				"Melee2: +10"
+				"Melee2: +10",
 				"MeleeStab: +40%",
 				"MeleeCrit: +50%",
 				"ActuatorWeight: 35%"

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_AP_GAUSS.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_AP_GAUSS.json
@@ -5,7 +5,7 @@
         "BonusDescriptions": {
             "Bonuses": [
 				"Crits: X2",
-				"GaussDamage: -10%"
+				"GaussDamage: -10%",
 				"GaussAmmo",
                 "GaussNoBoom"
             ]

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_ArtemisIV_SRM.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_ArtemisIV_SRM.json
@@ -4,7 +4,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "SRMAccuracy: +1",
-				"SRMDamage: +1"
+				"SRMDamage: +1",
 				"Crits: 50%",				
                 "SRMAmmo",
 				"ReqArtemis"

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Artemis_SRM.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Artemis_SRM.json
@@ -7,7 +7,7 @@
                 "SRMAmmo",
 				"Artemis"
             ]
-        }
+        },
             "InventorySorter" : {
                 "SortKey" : "00007"
             },		

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_ER_LRM.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_ER_LRM.json
@@ -1,6 +1,6 @@
 {
 
-	"Custom" :  {"Category" : { "CategoryID" : "LRMAmmo"}, "Tag" : "ER", "Flags" : { "flags" : [ "not_broken" ] }, "ComponentExplosion": { "ExplosionDamagePerAmmo": 3, "StabilityDamagePerAmmo": 1 }
+	"Custom" :  {"Category" : { "CategoryID" : "LRMAmmo"}, "Tag" : "ER", "Flags" : { "flags" : [ "not_broken" ] }, "ComponentExplosion": { "ExplosionDamagePerAmmo": 3, "StabilityDamagePerAmmo": 1 },
 	        "BonusDescriptions": {
             "Bonuses": [
                 "LRMDamage: -25%",

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Generic_SRM_double.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Generic_SRM_double.json
@@ -22,7 +22,7 @@
         "Manufacturer" : "Generic",
         "Model" : "SRM",
         "UIName" : "Ammo SRM [DBL]",
-        "Id" : "Ammo_AmmunitionBox_Generic_SRM_double"
+        "Id" : "Ammo_AmmunitionBox_Generic_SRM_double",
         "Name" : "SRM Ammo",
         "Details" : "Doubled Ammo Bins replace one ammo bins feeding and storing mechanism to 25% more shots into one location. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. SRM Ammo Bins each contain <b><color=#F79232>225 rounds</color></b> and may feed multiple weapons.",
         "Icon" : "uixSvgIcon_ammoBox_Missile"

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Heavy_GAUSS.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Heavy_GAUSS.json
@@ -4,7 +4,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "GaussDamage: +25%",
-				"Range: -50%"
+				"Range: -50%",
                 "GaussAccuracy: -1",
                 "GaussAmmo",
 				"GaussNoBoom"

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC10.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC10.json
@@ -71,7 +71,7 @@
                 "targetWeaponSubType" : "AC10"					
 			},		
 			"nature" : "Buff"
-		}	
+		},
 			{
 			"durationData" :
 			{

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC2.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC2.json
@@ -71,7 +71,7 @@
                 "targetWeaponSubType" : "AC2"					
 			},		
 			"nature" : "Buff"
-		}	
+		},
 			{
 			"durationData" :
 			{

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC20.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC20.json
@@ -71,7 +71,7 @@
                 "targetWeaponSubType" : "AC20"					
 			},		
 			"nature" : "Buff"
-		}	
+		},
 			{
 			"durationData" :
 			{

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC5.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Incendiary_AC5.json
@@ -71,7 +71,7 @@
                 "targetWeaponSubType" : "AC5"					
 			},		
 			"nature" : "Buff"
-		}	
+		},
 			{
 			"durationData" :
 			{

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Inferno_SRM.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Inferno_SRM.json
@@ -3,7 +3,7 @@
 	"Custom" :  {"Category" : { "CategoryID" : "SRMAmmo"}, "Tag" : "Inferno", "Flags" : { "flags" : [ "not_broken" ] }, "ComponentExplosion": { "ExplosionDamagePerAmmo": 1, "HeatDamagePerAmmo": 6, "StabilityDamagePerAmmo": 1 },
         "BonusDescriptions": {
             "Bonuses": [
-				"HeatDamage: +5"
+				"HeatDamage: +5",
                 "SRMDamage: -80%",
 				"StabDamage: -80%",
                 "SRMAmmo"

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Light_GAUSS.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Light_GAUSS.json
@@ -4,7 +4,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "GaussDamage: -40%",
-				"Range: +300%"
+				"Range: +300%",
                 "GaussAccuracy: +1",
                 "GaussAmmo",
 				"GaussNoBoom"

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Phosphor_MG.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Phosphor_MG.json
@@ -75,7 +75,7 @@
                 "targetWeaponSubType" : "MachineGun"					
 			},		
 			"nature" : "Buff"
-		}	
+		},
 			{
 			"durationData" :
 			{

--- a/RogueModuleTech/ammo/Ammo_AmmunitionBox_Tandem_SRM.json
+++ b/RogueModuleTech/ammo/Ammo_AmmunitionBox_Tandem_SRM.json
@@ -4,7 +4,7 @@
         "BonusDescriptions": {
             "Bonuses": [
 				"Crits: +200%",
-				"SRMDamage: -50%"
+				"SRMDamage: -50%",
                 "SRMAmmo"
             ]
         },

--- a/RogueModuleTech/armors/Gear_Reactive_Plating.json
+++ b/RogueModuleTech/armors/Gear_Reactive_Plating.json
@@ -6,9 +6,9 @@
 		"DynamicSlots": {
 			"ReservedSlots": 10,
 			"BackgroundColor": "GoldHalf",
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"WorkOrderCosts": {

--- a/RogueModuleTech/armors/Gear_Reflective_Coating.json
+++ b/RogueModuleTech/armors/Gear_Reflective_Coating.json
@@ -6,10 +6,10 @@
 		},
 		"DynamicSlots": {
 			"ReservedSlots": 10,
-			"BackgroundColor": "GoldHalf"
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"BackgroundColor": "GoldHalf",
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"WorkOrderCosts": {

--- a/RogueModuleTech/armors/Gear_Spall_Liner_Upgrade.json
+++ b/RogueModuleTech/armors/Gear_Spall_Liner_Upgrade.json
@@ -28,7 +28,7 @@
             "Bonuses": [			
 				"CritRes: 50%",
 				"DamageTaken: -10%",
-				"ArmorFactor: +15%"
+				"ArmorFactor: +15%",
 				"Reserved: 5",
 				"ArmorTPCost: 15%",
 				"ArmorCBCost: 25%"				

--- a/RogueModuleTech/armors/Gear_armorslots_Spiked.json
+++ b/RogueModuleTech/armors/Gear_armorslots_Spiked.json
@@ -15,9 +15,9 @@
 		"DynamicSlots": {
 			"ReservedSlots": 6,
 			"BackgroundColor": "GoldHalf",			
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},		
 		"ArmorStructureChanges": { "ArmorFactor": 1.2 },

--- a/RogueModuleTech/armors/emod_armorslots_heavyferrosfibrous.json
+++ b/RogueModuleTech/armors/emod_armorslots_heavyferrosfibrous.json
@@ -5,10 +5,10 @@
 		},
 		"DynamicSlots": {
 			"ReservedSlots": 15,
-			"BackgroundColor": "GoldHalf"
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"BackgroundColor": "GoldHalf",
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"WorkOrderCosts": {

--- a/RogueModuleTech/armors/emod_armorslots_impactresistant.json
+++ b/RogueModuleTech/armors/emod_armorslots_impactresistant.json
@@ -12,9 +12,9 @@
 		"DynamicSlots": {
 			"ReservedSlots": 6,
 			"BackgroundColor": "GoldHalf",			
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},		
 		"Category" : { 

--- a/RogueModuleTech/armors/emod_armorslots_lightferrosfibrous.json
+++ b/RogueModuleTech/armors/emod_armorslots_lightferrosfibrous.json
@@ -5,10 +5,10 @@
 		},
 		"DynamicSlots": {
 			"ReservedSlots": 5,
-			"BackgroundColor": "GoldHalf"
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"BackgroundColor": "GoldHalf",
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"Weights": {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_Ceres_Metals_Braced.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_Ceres_Metals_Braced.json
@@ -15,7 +15,7 @@
 				"Health: +1",
 				"Initiative: +1",
 				"IsECM: 1",
-				"ECMBubble: 60"
+				"ECMBubble: 60",
 				"IsCockpit"
             ]
         },
@@ -49,7 +49,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_Ceres_Metals_Hardened.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_Ceres_Metals_Hardened.json
@@ -9,7 +9,7 @@
 				"TechCost": "1",
 				"CBillCost": "[[Chassis.Tonnage]]"
 			}
-		}
+		},
         "BonusDescriptions": {
             "Bonuses": [
 				"Health: +3",
@@ -49,7 +49,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_Ceres_Metals_Reinforced.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_Ceres_Metals_Reinforced.json
@@ -49,7 +49,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_CommandConsole.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_CommandConsole.json
@@ -50,7 +50,7 @@
     "Tonnage" : 6,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_DNI.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_DNI.json
@@ -49,7 +49,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_Majesty_M_M_120KL.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_Majesty_M_M_120KL.json
@@ -48,7 +48,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_Majesty_M_M_180KL.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_Majesty_M_M_180KL.json
@@ -48,7 +48,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_Majesty_M_M_60KL.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_Majesty_M_M_60KL.json
@@ -48,7 +48,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_SLDF_Custom.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_SLDF_Custom.json
@@ -52,7 +52,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_StarCorps_Advanced.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_StarCorps_Advanced.json
@@ -48,7 +48,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_StarCorps_Enhanced.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_StarCorps_Enhanced.json
@@ -48,7 +48,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_StarCorps_Improved.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_StarCorps_Improved.json
@@ -48,7 +48,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_Cockpit_Torsomount.json
+++ b/RogueModuleTech/cockpits/Gear_Cockpit_Torsomount.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
 				"TorsoMount",
-				"Initiative: +1"
+				"Initiative: +1",
 				"Health: +10",
 				"IsCockpit"
             ]
@@ -44,7 +44,7 @@
     "Tonnage" : 4,
     "AllowedLocations" : "CenterTorso",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/cockpits/Gear_TTS_AdvancedTC.json
+++ b/RogueModuleTech/cockpits/Gear_TTS_AdvancedTC.json
@@ -15,7 +15,7 @@
 				"Breaching",			
                 "Accuracy: +1",
 				"Recoil: -1",
-				"Initiative: +1"
+				"Initiative: +1",
 				"CalledShot: 20%",
 				"IsCockpit"
             ]
@@ -50,7 +50,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/gyro/Gear_Gyro_Friedhof_Kite.json
+++ b/RogueModuleTech/gyro/Gear_Gyro_Friedhof_Kite.json
@@ -13,7 +13,7 @@
 		},
         "BonusDescriptions": {
             "Bonuses": [
-				"EvaPips: +1"
+				"EvaPips: +1",
                 "Defense: +1",
 				"GyroStab: 40"
             ]

--- a/RogueModuleTech/gyro/Gear_Gyro_Friedhof_Sparrow.json
+++ b/RogueModuleTech/gyro/Gear_Gyro_Friedhof_Sparrow.json
@@ -13,7 +13,7 @@
 		},
         "BonusDescriptions": {
             "Bonuses": [
-				"EvaMax: +1"
+				"EvaMax: +1",
 				"EvaPips: +1",
                 "Defense: +1",
 				"GyroStab: 40"

--- a/RogueModuleTech/jumpjets/Gear_JumpJet_Directional_Assault.json
+++ b/RogueModuleTech/jumpjets/Gear_JumpJet_Directional_Assault.json
@@ -6,7 +6,7 @@
             "Bonuses": [
 				"DFA: +5%",
 				"DFASelfDamage: -5%",
-				"DFAAcc: +1"				
+				"DFAAcc: +1",
 				"JumpDistance: -5%",
             ]
         },

--- a/RogueModuleTech/jumpjets/Gear_JumpJet_Directional_Heavy.json
+++ b/RogueModuleTech/jumpjets/Gear_JumpJet_Directional_Heavy.json
@@ -6,7 +6,7 @@
             "Bonuses": [
 				"DFA: +5%",
 				"DFASelfDamage: -5%",
-				"DFAAcc: +1"				
+				"DFAAcc: +1",
 				"JumpDistance: -5%",
             ]
         },

--- a/RogueModuleTech/jumpjets/Gear_JumpJet_Directional_Standard.json
+++ b/RogueModuleTech/jumpjets/Gear_JumpJet_Directional_Standard.json
@@ -5,7 +5,7 @@
             "Bonuses": [
 				"DFA: +5%",
 				"DFASelfDamage: -5%",
-				"DFAAcc: +1"				
+				"DFAAcc: +1",
 				"JumpDistance: -5%",
             ]
         },

--- a/RogueModuleTech/quirks/heatsink/emod_engineslots_xl_proto.json
+++ b/RogueModuleTech/quirks/heatsink/emod_engineslots_xl_proto.json
@@ -11,7 +11,7 @@
 		},
 		"Category" : { 
 			"CategoryID" : "EngineShield" 
-		}
+		},
 		"Flags" : { "flags" : [ "engine_part", "not_broken", "no_salvage", "autorepair" ] },
         "BonusDescriptions": {
             "Bonuses": [
@@ -136,7 +136,7 @@
 				"statName" : "HeatSinkCapacity",
                 "operation" : "Int_Add",
                 "modValue" : "-10",
-                "modType" : "System.Int32"
+                "modType" : "System.Int32",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "NotSet",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/quirks/jumpjet/Gear_PartialWing_Phoenix.json
+++ b/RogueModuleTech/quirks/jumpjet/Gear_PartialWing_Phoenix.json
@@ -1,7 +1,7 @@
 {
 
 	"Custom" :  {"Category" : { "CategoryID" : "PartialWing"}, 
-	"Flags" : { "flags" : [ "not_broken", "no_salvage", "autorepair" ] }
+	"Flags" : { "flags" : [ "not_broken", "no_salvage", "autorepair" ] },
         "BonusDescriptions": {
             "Bonuses": [
                 "HeatPerTurn: - 9",

--- a/RogueModuleTech/quirks/upgrade/Gear_Carebear_VibroClaws.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Carebear_VibroClaws.json
@@ -7,7 +7,7 @@
             "Bonuses": [
 				"MeleeAcc: +2",
 				"Melee: +75%",
-				"Melee2: +20"
+				"Melee2: +20",
 				"MeleeStab: +50%",
 				"MeleeCrit: +60%",
 				"HeatPerTurn: 9"

--- a/RogueModuleTech/quirks/upgrade/Gear_Cockpit_AR12.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Cockpit_AR12.json
@@ -54,7 +54,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
 		{
 			"durationData" :

--- a/RogueModuleTech/quirks/upgrade/Gear_Cockpit_AR14.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Cockpit_AR14.json
@@ -56,7 +56,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
 		{
 			"durationData" :

--- a/RogueModuleTech/quirks/upgrade/Gear_Cockpit_Ceres_REPORTME.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Cockpit_Ceres_REPORTME.json
@@ -9,7 +9,7 @@
 				"TechCost": "1",
 				"CBillCost": "[[Chassis.Tonnage]]"
 			}
-		}
+		},
         "BonusDescriptions": {
             "Bonuses": [
 				"Health: +300",
@@ -47,7 +47,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/quirks/upgrade/Gear_Cockpit_SLDF_Pirate.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Cockpit_SLDF_Pirate.json
@@ -56,7 +56,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
 		{
 			"durationData" :
@@ -137,7 +137,7 @@
             "vfxData" : null,
             "instantModData" : null,
             "poorlyMaintainedEffectData" : null
-        }	
+        },
         {
             "durationData" : {
                 "duration" : -1,

--- a/RogueModuleTech/quirks/upgrade/Gear_Pirate_ECM.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Pirate_ECM.json
@@ -1,6 +1,6 @@
 {
 
-	"Custom" :  {"Category" : { "CategoryID" : "ECM"}
+	"Custom" :  {"Category" : { "CategoryID" : "ECM"},
         "BonusDescriptions": {
             "Bonuses": [
                 "Tacticon: +1",

--- a/RogueModuleTech/quirks/upgrade/Gear_TTS_Echidnae.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_TTS_Echidnae.json
@@ -53,7 +53,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {
@@ -200,7 +200,7 @@
             "vfxData" : null,
             "instantModData" : null,
             "poorlyMaintainedEffectData" : null
-        }		
+        },
         {
             "durationData" : {
                 "duration" : -1,

--- a/RogueModuleTech/quirks/upgrade/Gear_TTS_Howler.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_TTS_Howler.json
@@ -15,7 +15,7 @@
             "Bonuses": [			
                 "SRMAccuracy: +2",
 				"SRMRange: +15%",
-				"SRMCrit: +35%"
+				"SRMCrit: +35%",
 				"Sensors: +25%",
 				"Sight: +25%",
 				"Initiative: +2",
@@ -58,7 +58,7 @@
     "Tonnage" : 4,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/quirks/upgrade/Gear_TTS_K4tapult.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_TTS_K4tapult.json
@@ -51,7 +51,7 @@
     "Tonnage" : 4,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/quirks/upgrade/Gear_TTS_Zeus_C.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_TTS_Zeus_C.json
@@ -51,7 +51,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
 		{
 			"durationData" :

--- a/RogueModuleTech/quirks/upgrade/Gear_TTS_Zeus_X.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_TTS_Zeus_X.json
@@ -52,7 +52,7 @@
     "Tonnage" : 3,
     "AllowedLocations" : "Head",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
 		{
 			"durationData" :

--- a/RogueModuleTech/quirks/upgrade/emod_armor_phoenix_LAM.json
+++ b/RogueModuleTech/quirks/upgrade/emod_armor_phoenix_LAM.json
@@ -5,10 +5,10 @@
 		},
 		"DynamicSlots": {
 			"ReservedSlots": 6,
-			"BackgroundColor": "GoldHalf"
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"BackgroundColor": "GoldHalf",
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"WorkOrderCosts": {

--- a/RogueModuleTech/quirks/upgrade/emod_structure_phoenix_LAM.json
+++ b/RogueModuleTech/quirks/upgrade/emod_structure_phoenix_LAM.json
@@ -20,7 +20,7 @@
 		"Category" : { 
 			"CategoryID" : "Structure" 
 		},
-		"Flags" : { "flags" : [ "not_broken", "no_salvage", "autorepair" ] }
+		"Flags" : { "flags" : [ "not_broken", "no_salvage", "autorepair" ] },
 		"RequiredCategories" : { "Categories" : ["PartialWing"] },
         "BonusDescriptions": {
             "Bonuses": [

--- a/RogueModuleTech/quirks/weapon/Weapon_Flamer_Dragonbreath.json
+++ b/RogueModuleTech/quirks/weapon/Weapon_Flamer_Dragonbreath.json
@@ -176,7 +176,7 @@
                 "targetWeaponSubType" : "NotSet"
         },
 			"nature": "Debuff"
-		} 	
+	},
         {
             "durationData" : {
                 "duration" : -1,

--- a/RogueModuleTech/quirks/weapon/Weapon_Gauss_Prototype_HEAVY.json
+++ b/RogueModuleTech/quirks/weapon/Weapon_Gauss_Prototype_HEAVY.json
@@ -107,7 +107,7 @@
                 "statName" : "UnsteadyThreshold",
 				"operation": "Float_Multiply",
 				"modValue": "0.9",
-				"modType": "System.Single"
+				"modType": "System.Single",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "NotSet",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/structure/Gear_structureslots_Composite.json
+++ b/RogueModuleTech/structure/Gear_structureslots_Composite.json
@@ -12,7 +12,7 @@
 		"Weights": {
 			"StructureFactor": 0.5
 		},	
-		"ArmorStructureChanges": { "StructureFactor": 0.5 }	
+		"ArmorStructureChanges": { "StructureFactor": 0.5 },
 		"Category" : { 
 			"CategoryID" : "Structure" 
 		},		

--- a/RogueModuleTech/structure/Gear_structureslots_Reinforced.json
+++ b/RogueModuleTech/structure/Gear_structureslots_Reinforced.json
@@ -16,7 +16,7 @@
 		"Category" : { 
 			"CategoryID" : "Structure" 
 		},		
-		"Flags" : { "flags" : [ "ignore_damage", "autorepair", "not_broken" ] }
+		"Flags" : { "flags" : [ "ignore_damage", "autorepair", "not_broken" ] },
         "BonusDescriptions": {
             "Bonuses": [
                 "StructureFactor: +25%",

--- a/RogueModuleTech/structure/emod_structureslots_endocomposite.json
+++ b/RogueModuleTech/structure/emod_structureslots_endocomposite.json
@@ -6,9 +6,9 @@
 		"DynamicSlots": {
 			"ReservedSlots": 7,
 			"ReservedSlotColor": "OrangeHalf",
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"WorkOrderCosts": {

--- a/RogueModuleTech/targetTrackingSystem/Gear_TargetingTrackingSystem_Hartford_F2400.json
+++ b/RogueModuleTech/targetTrackingSystem/Gear_TargetingTrackingSystem_Hartford_F2400.json
@@ -3,7 +3,7 @@
 	"Custom" :  {"Category" : { "CategoryID" : "MissTTST2"},
         "BonusDescriptions": {
             "Bonuses": [
-                "DFMissileAcc: +1"
+                "DFMissileAcc: +1",
 				"MissileCrit: 25%"
             ]
         },

--- a/RogueModuleTech/targetTrackingSystem/Gear_TargetingTrackingSystem_Kallon_A-C-1500.json
+++ b/RogueModuleTech/targetTrackingSystem/Gear_TargetingTrackingSystem_Kallon_A-C-1500.json
@@ -3,7 +3,7 @@
 	"Custom" :  {"Category" : { "CategoryID" : "BallTTST2"},
         "BonusDescriptions": {
             "Bonuses": [
-                "BallisticAcc: +1"
+                "BallisticAcc: +1",
 				"BallisticCrit: 25%"
             ]
         },

--- a/RogueModuleTech/targetTrackingSystem/Gear_TargetingTrackingSystem_RCA_InstaTrac-IX.json
+++ b/RogueModuleTech/targetTrackingSystem/Gear_TargetingTrackingSystem_RCA_InstaTrac-IX.json
@@ -3,7 +3,7 @@
 	"Custom" :  {"Category" : { "CategoryID" : "ENGTTST2"},
         "BonusDescriptions": {
             "Bonuses": [
-                "EnergyAcc: +1"
+                "EnergyAcc: +1",
 				"EnergyCrit: 25%"
             ]
         },

--- a/RogueModuleTech/upgrade/Gear_BAP.json
+++ b/RogueModuleTech/upgrade/Gear_BAP.json
@@ -41,7 +41,7 @@
     "Tonnage" : 1.5,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/upgrade/Gear_Bloodhound_AP.json
+++ b/RogueModuleTech/upgrade/Gear_Bloodhound_AP.json
@@ -41,7 +41,7 @@
     "Tonnage" : 2,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/upgrade/Gear_BlueShield.json
+++ b/RogueModuleTech/upgrade/Gear_BlueShield.json
@@ -129,7 +129,7 @@
             "statName" : "HeatSinkCapacity",
                         "operation" : "Int_Add",
                         "modValue" : "-9",
-                        "modType" : "System.Int32"
+                        "modType" : "System.Int32",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "NotSet",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/upgrade/Gear_C3.json
+++ b/RogueModuleTech/upgrade/Gear_C3.json
@@ -40,7 +40,7 @@
     "Tonnage" : 1,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/upgrade/Gear_C3i.json
+++ b/RogueModuleTech/upgrade/Gear_C3i.json
@@ -40,7 +40,7 @@
     "Tonnage" : 2.5,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
-    "CriticalComponent" : false
+    "CriticalComponent" : false,
     "statusEffects" : [
         {
             "durationData" : {

--- a/RogueModuleTech/upgrade/Gear_ECM.json
+++ b/RogueModuleTech/upgrade/Gear_ECM.json
@@ -1,6 +1,6 @@
 {
 
-	"Custom" :  {"Category" : { "CategoryID" : "ECM"}
+	"Custom" :  {"Category" : { "CategoryID" : "ECM"},
         "BonusDescriptions": {
             "Bonuses": [
                 "EvaPips: +1",

--- a/RogueModuleTech/upgrade/Gear_LAMS.json
+++ b/RogueModuleTech/upgrade/Gear_LAMS.json
@@ -180,7 +180,7 @@
                 "statName" : "HeatSinkCapacity",
                 "operation" : "Int_Subtract",
                 "modValue" : "6",
-                "modType" : "System.Int32"
+                "modType" : "System.Int32",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "NotSet",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/upgrade/emod_armorslots_LAM.json
+++ b/RogueModuleTech/upgrade/emod_armorslots_LAM.json
@@ -5,10 +5,10 @@
 		},
 		"DynamicSlots": {
 			"ReservedSlots": 6,
-			"BackgroundColor": "GoldHalf"
-			"ShowIcon": false
-			"NameText": "Dynamic Slot"
-			"BonusAText": "Dynamic Slot"
+			"BackgroundColor": "GoldHalf",
+			"ShowIcon": false,
+			"NameText": "Dynamic Slot",
+			"BonusAText": "Dynamic Slot",
 			"BonusAText": " "			
 		},
 		"Weights": {

--- a/RogueModuleTech/weapon/Weapon_ArrowIV.json
+++ b/RogueModuleTech/weapon/Weapon_ArrowIV.json
@@ -5,11 +5,11 @@
 		},
         "ComponentExplosion": {
             "ExplosionDamagePerAmmo": 300
-        }		
+        },
         "BonusDescriptions": {
             "Bonuses": [
 				"IsArtillery",
-				"VariableDmg: 75"
+				"VariableDmg: 75",
 				"WpnRecoil: 3"
             ]
         },	

--- a/RogueModuleTech/weapon/Weapon_ArrowIV_Incendiary.json
+++ b/RogueModuleTech/weapon/Weapon_ArrowIV_Incendiary.json
@@ -6,7 +6,7 @@
         "ComponentExplosion": {
             "ExplosionDamagePerAmmo": 100,
 			"HeatDamagePerAmmo": 100
-        }		
+        },
         "BonusDescriptions": {
             "Bonuses": [
 				"IsArtillery",

--- a/RogueModuleTech/weapon/Weapon_Autocannon_LONGTOM.json
+++ b/RogueModuleTech/weapon/Weapon_Autocannon_LONGTOM.json
@@ -6,7 +6,7 @@
 				"IsArtillery",
 				"WpnCrits: X2",
 				"WpnAccuracy: -1",
-				"VariableDmg: 75"
+				"VariableDmg: 75",
 				"WpnRecoil: 4"
             ]
         },	

--- a/RogueModuleTech/weapon/Weapon_Autocannon_SNIPER.json
+++ b/RogueModuleTech/weapon/Weapon_Autocannon_SNIPER.json
@@ -6,7 +6,7 @@
 				"IsArtillery",
 				"WpnCrits: X2",
 				"WpnAccuracy: -2",
-				"VariableDmg: 75"
+				"VariableDmg: 75",
 				"WpnRecoil: 5"
             ]
         },	

--- a/RogueModuleTech/weapon/Weapon_Autocannon_THUMPER.json
+++ b/RogueModuleTech/weapon/Weapon_Autocannon_THUMPER.json
@@ -6,7 +6,7 @@
 				"IsArtillery",
 				"WpnCrits: X2",
 				"WpnAccuracy: -1",
-				"VariableDmg: 50"
+				"VariableDmg: 50",
 				"WpnRecoil: 3"
             ]
         },	

--- a/RogueModuleTech/weapon/Weapon_FLAMER_PLASMA.json
+++ b/RogueModuleTech/weapon/Weapon_FLAMER_PLASMA.json
@@ -107,7 +107,7 @@
                 "statName" : "HeatGenerated",
                 "operation" : "Float_Multiply",
                 "modValue" : "1.15",
-                "modType" : "System.Single"
+                "modType" : "System.Single",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "Weapon",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/weapon/Weapon_Flamer_Firefist.json
+++ b/RogueModuleTech/weapon/Weapon_Flamer_Firefist.json
@@ -5,7 +5,7 @@
 				"IsMelee",
 				"VariableDmg: 5",
 				"PipsIgnored: 1",
-				"WpnAccuracy: +1"
+				"WpnAccuracy: +1",
 				"MeleeHeat: 15",
 				"OHDamage: X2"
             ]

--- a/RogueModuleTech/weapon/Weapon_Flamer_Flamer_3-Prometheus.json
+++ b/RogueModuleTech/weapon/Weapon_Flamer_Flamer_3-Prometheus.json
@@ -4,7 +4,7 @@
 	        "BonusDescriptions": {
             "Bonuses": [
                 "OHDamage: X3",
-				"Inferno: +5"
+				"Inferno: +5",
 				"PipsIgnored: 2"
             ]
         },
@@ -102,7 +102,7 @@
             "statName": "HeatSinkCapacity",
             "operation": "Int_Add",
             "modValue": "-5",
-            "modType": "System.Int32"
+            "modType": "System.Int32",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "NotSet",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/weapon/Weapon_Flamer_Heavy_Vehicle.json
+++ b/RogueModuleTech/weapon/Weapon_Flamer_Heavy_Vehicle.json
@@ -5,7 +5,7 @@
             "Bonuses": [
                 "OHDamage: X3",
 				"PipsIgnored: 2",
-				"Range: 33%"
+				"Range: 33%",
 				"InternalAmmo: 10"
             ]
         },

--- a/RogueModuleTech/weapon/Weapon_PA_PLASMA.json
+++ b/RogueModuleTech/weapon/Weapon_PA_PLASMA.json
@@ -107,7 +107,7 @@
                 "statName" : "HeatGenerated",
                 "operation" : "Float_Multiply",
                 "modValue" : "1.1",
-                "modType" : "System.Single"
+                "modType" : "System.Single",
                 "additionalRules" : "NotSet",
                 "targetCollection" : "Weapon",
                 "targetWeaponCategory" : "NotSet",

--- a/RogueModuleTech/weapon/Weapon_POD_B.json
+++ b/RogueModuleTech/weapon/Weapon_POD_B.json
@@ -3,7 +3,7 @@
 "Custom": { "ComponentExplosion": { "ExplosionDamagePerAmmo": 4, "StabilityDamagePerAmmo": 1 },
         "BonusDescriptions": {
             "Bonuses": [
-				"1shot"
+				"1shot",
                 "InternalAmmo: 4"
             ]
         },

--- a/RogueModuleTech/weapon/Weapon_PPC_PPC_LIGHT.json
+++ b/RogueModuleTech/weapon/Weapon_PPC_PPC_LIGHT.json
@@ -4,7 +4,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "WpnRecoil: 0",
-                "PipsIgnored: 1"			
+                "PipsIgnored: 1",
                 "PPCDEBUFF: 1"
             ]
         },	

--- a/RogueTech Core/StreamingAssets/data/behaviorVariables/global_def.json
+++ b/RogueTech Core/StreamingAssets/data/behaviorVariables/global_def.json
@@ -97,7 +97,7 @@
             "type" : "Float",
             "floatVal" : 100,
          }
-      }
+      },
       {
          "k" : "Float_PreferLowerMovementFactorWeight",
          "v" : {

--- a/RogueTech Core/StreamingAssets/data/behaviorVariables/personality_aggressive.json
+++ b/RogueTech Core/StreamingAssets/data/behaviorVariables/personality_aggressive.json
@@ -98,7 +98,7 @@
             "type" : "Float",
             "floatVal" : 100,
          }
-      }
+      },
       {
          "k" : "Float_PreferLowerMovementFactorWeight",
          "v" : {

--- a/RogueTech Core/StreamingAssets/data/behaviorVariables/personality_disciplined.json
+++ b/RogueTech Core/StreamingAssets/data/behaviorVariables/personality_disciplined.json
@@ -97,7 +97,7 @@
             "type" : "Float",
             "floatVal" : 90,
          }
-      }
+      },
       {
          "k" : "Float_PreferLowerMovementFactorWeight",
          "v" : {

--- a/RogueTech Core/StreamingAssets/data/behaviorVariables/personality_qapersonality.json
+++ b/RogueTech Core/StreamingAssets/data/behaviorVariables/personality_qapersonality.json
@@ -98,7 +98,7 @@
             "type" : "Float",
             "floatVal" : 100,
          }
-      }
+      },
       {
          "k" : "Float_PreferLowerMovementFactorWeight",
          "v" : {

--- a/RogueTech Core/StreamingAssets/data/behaviorVariables/role_lastmanstanding.json
+++ b/RogueTech Core/StreamingAssets/data/behaviorVariables/role_lastmanstanding.json
@@ -27,7 +27,7 @@
 		"type" : "Float",
 		"floatVal" : 0.1
             }
-	}
+	},
 	{
 	    /* The number of hostiles considered when evaluating
 	       influence maps. */

--- a/RogueTech Core/StreamingAssets/data/simGameConstants/SimGameConstants.json
+++ b/RogueTech Core/StreamingAssets/data/simGameConstants/SimGameConstants.json
@@ -296,8 +296,8 @@
 		"HonoredMaxContractDifficulty": 50,
 
 		"MissionsForFirstBreadcrumb": 0,
-		"MaxContractsPerSystem": 12
-		"MaxBreadcrumbsPerSystem": 4
+		"MaxContractsPerSystem": 12,
+		"MaxBreadcrumbsPerSystem": 4,
 
 		"ContractRenewalPerWeek": 5,
 		"ContractSuccessReduction": 1.0,

--- a/RogueTechBrutal/AIPilotsHigh/pilot_d10_vanguard_high.json
+++ b/RogueTechBrutal/AIPilotsHigh/pilot_d10_vanguard_high.json
@@ -37,7 +37,7 @@
 "TraitAID7",
 "TraitAID8",
 "TraitAID9",
-"TraitAID10",,
+"TraitAID10",
     "AbilityDefT5A",
     "AbilityDefT8A",
     "AbilityDefGu5",

--- a/RogueTechBrutal/AItraits/TraitClanner.json
+++ b/RogueTechBrutal/AItraits/TraitClanner.json
@@ -64,7 +64,7 @@
                 "modType" : "System.Single",
 			},
 			"nature" : "Buff"
-		}		
+		},
         {
 			"durationData" :
 			{

--- a/RogueTechBrutal/ClanAIPilotsHigh/clanner_d10_vanguard_high.json
+++ b/RogueTechBrutal/ClanAIPilotsHigh/clanner_d10_vanguard_high.json
@@ -37,7 +37,7 @@
 "TraitAID7",
 "TraitAID8",
 "TraitAID9",
-"TraitAID10",,
+"TraitAID10",
     "AbilityDefT5A",
     "AbilityDefT8A",
     "AbilityDefGu5",

--- a/RogueTechBrutal/StreamingAssets/data/constants/CombatGameConstants.json
+++ b/RogueTechBrutal/StreamingAssets/data/constants/CombatGameConstants.json
@@ -1589,7 +1589,7 @@
         "cacheCount": 1
       },
       "artillery_explosion": {
-        "name": "vfxPrfPrtl_propaneTankExplosion"
+        "name": "vfxPrfPrtl_propaneTankExplosion",
 		"cacheCount": 1
       },
       "artillery_projectile_single": {
@@ -1601,11 +1601,11 @@
         "cacheCount": 1
       },
       "artillery_projectile_barrage": {
-        "name": "vfxPrfPrtl_artilleryProjectile_barrage"
+        "name": "vfxPrfPrtl_artilleryProjectile_barrage",
 		"cacheCount": 1
       },
       "artillery_impact_barrage": {
-        "name": "vfxPrfPrtl_artilleryImpact_barrage"
+        "name": "vfxPrfPrtl_artilleryImpact_barrage",
 		"cacheCount": 1
       },
       "artillery_orbital_ppc": {

--- a/RogueTechNormal/AItraits/TraitClanner.json
+++ b/RogueTechNormal/AItraits/TraitClanner.json
@@ -64,7 +64,7 @@
                 "modType" : "System.Single",
 			},
 			"nature" : "Buff"
-		}		
+		},
         {
 			"durationData" :
 			{

--- a/RogueTechNormal/StreamingAssets/data/constants/CombatGameConstants.json
+++ b/RogueTechNormal/StreamingAssets/data/constants/CombatGameConstants.json
@@ -366,7 +366,7 @@
 		"StabilityDumpDFA": -0.5,
 		"SearchForValidCritSlot": true,
 		"MinCritChance": 0.5,
-		"AllowTotalNegativeModifier": true
+		"AllowTotalNegativeModifier": true,
         "CoolantVentEffect":
 		{
 			"durationData" :
@@ -1490,7 +1490,7 @@
         "cacheCount": 1
       },
       "artillery_explosion": {
-        "name": "vfxPrfPrtl_propaneTankExplosion"
+        "name": "vfxPrfPrtl_propaneTankExplosion",
 		"cacheCount": 1
       },
       "artillery_projectile_single": {
@@ -1502,11 +1502,11 @@
         "cacheCount": 1
       },
       "artillery_projectile_barrage": {
-        "name": "vfxPrfPrtl_artilleryProjectile_barrage"
+        "name": "vfxPrfPrtl_artilleryProjectile_barrage",
 		"cacheCount": 1
       },
       "artillery_impact_barrage": {
-        "name": "vfxPrfPrtl_artilleryImpact_barrage"
+        "name": "vfxPrfPrtl_artilleryImpact_barrage",
 		"cacheCount": 1
       },
       "artillery_orbital_ppc": {

--- a/RogueVanillaMechs/chassis/chassisdef_highlander_HGN-733.json
+++ b/RogueVanillaMechs/chassis/chassisdef_highlander_HGN-733.json
@@ -4,8 +4,7 @@
     "ArmActuatorSupport": {
       "RightLimit": "Lower"
     },
-	}
-	
+	},
   "Description": {
     "Cost": 11900000,
     "Rarity": 4,

--- a/RogueVanillaMechs/chassis/chassisdef_highlander_HGN-733P.json
+++ b/RogueVanillaMechs/chassis/chassisdef_highlander_HGN-733P.json
@@ -4,7 +4,7 @@
     "ArmActuatorSupport": {
       "RightLimit": "Lower"
     },
-	}
+	},
   "Description": {
     "Cost": 11910000,
     "Rarity": 5,

--- a/Superheavys/mech/mechdef_tiamat_FNR-SH.json
+++ b/Superheavys/mech/mechdef_tiamat_FNR-SH.json
@@ -11,7 +11,7 @@
       "kurita",
       "davion",
       "liao",
-      "rasalhague"
+      "rasalhague",
       "tortuga",
       "axumite",
       "auriganpirates",

--- a/Totem Mechs/chassis/chassisdef_firestarter_O-PRIME.json
+++ b/Totem Mechs/chassis/chassisdef_firestarter_O-PRIME.json
@@ -442,7 +442,7 @@
   "VariantName": "FS9-O",
   "ChassisTags": {
     "items": [
-"mr-resize-1.1-1.1-1.1"
+"mr-resize-1.1-1.1-1.1",
 "OmniMech"
 
     ],

--- a/UrbieNuke/weapon/Weapon_AIV_DAVYCROCKET.json
+++ b/UrbieNuke/weapon/Weapon_AIV_DAVYCROCKET.json
@@ -10,7 +10,7 @@
         },
         "ComponentExplosion": {
             "ExplosionDamage": 20000
-        }		
+        },
         "BonusDescriptions": {
             "Bonuses": [
 				"IsNOOK",


### PR DESCRIPTION
Most of the changes - adding commas where needed and replacing double commas with single commas.
For finding files with errors I've used json5 ( https://json5.org/ ) so that comments in json files was not marked as errors.
Everything was done from linux (most likely on windows you can use cygwin instead).
I've wrote very simple zsh script that takes list of files and outputs for every file with error it's name and first error found in it (provided by json5 linter).
If anyone interested - I can share this script and/or create bash script as more universally accepted alternative, and possibly instructions on how to install cygwin + json5 and run this script from windows.
