### PR TITLE
Fixes in mod.json manifests, required for running roguetech on linux

### DIFF
--- a/All 3025 Mercs/mod.json
+++ b/All 3025 Mercs/mod.json
@@ -9,7 +9,7 @@
   "ConflictsWith": ["RogueTech Enhanced", "RogueTech Enhanced Clans"],
 
   "Manifest": [
-    { "Type": "Texture2D", "Path": "emblems\\", "AddToAddendum": "PlayerEmblems" },
-    { "Type": "Sprite", "Path": "emblems\\", "AddToAddendum": "PlayerEmblems" }
+    { "Type": "Texture2D", "Path": "emblems", "AddToAddendum": "PlayerEmblems" },
+    { "Type": "Sprite", "Path": "emblems", "AddToAddendum": "PlayerEmblems" }
   ]
 }

--- a/Capellan Emblems/mod.json
+++ b/Capellan Emblems/mod.json
@@ -9,7 +9,7 @@
 	"ConflictsWith": [ "RogueTech Enhanced", "RogueTech Enhanced Clans"],
 	
     "Manifest": [
-       { "Type": "Texture2D",  "Path": "emblems\\", "AddToAddendum": "PlayerEmblems" },
-       { "Type": "Sprite", "Path": "emblems\\", "AddToAddendum": "PlayerEmblems" }
+       { "Type": "Texture2D",  "Path": "emblems", "AddToAddendum": "PlayerEmblems" },
+       { "Type": "Sprite", "Path": "emblems", "AddToAddendum": "PlayerEmblems" }
     ]
 }

--- a/RogueFlashPointModule/mod.json
+++ b/RogueFlashPointModule/mod.json
@@ -16,7 +16,7 @@
     "Manifest": [
         {
             "Type": "MechDef",
-            "Path": "mech"
+            "Path": "Mech"
         },
         {
             "Type": "MechDef",
@@ -24,7 +24,7 @@
         }		
         {
             "Type": "ChassisDef",
-            "Path": "chassis"
+            "Path": "Chassis"
         },
         {
             "Type": "Sprite",

--- a/RogueTanksCore/mod.json
+++ b/RogueTanksCore/mod.json
@@ -17,7 +17,7 @@
     "Manifest": [
         {
             "Type": "VehicleChassisDef",
-            "Path": "vehiclechassis"
+            "Path": "vehicleChassis"
         },
         {
             "Type": "VehicleDef",

--- a/RogueTechBrutal/mod.json
+++ b/RogueTechBrutal/mod.json
@@ -15,7 +15,7 @@
 		{ "Type": "PilotDef", "Path": "ClanAIPilotsBuff" },
 		{ "Type": "PilotDef", "Path": "ClanAIPilotsMed" },
 		{ "Type": "PilotDef", "Path": "ClanAIPilotsHigh" },
-		{ "Type": "AbilityDef", "Path": "AITraits" }		
+		{ "Type": "AbilityDef", "Path": "AItraits" }		
     ],
 	
 	

--- a/RogueTechNormal/mod.json
+++ b/RogueTechNormal/mod.json
@@ -15,7 +15,7 @@
         { "Type": "PilotDef", "Path": "ClanAIPilotsBuff" },
 		{ "Type": "PilotDef", "Path": "ClanAIPilotsMed" },
 		{ "Type": "PilotDef", "Path": "ClanAIPilotsHigh" },		
-		{ "Type": "AbilityDef", "Path": "AITraits" }
+		{ "Type": "AbilityDef", "Path": "AItraits" }
     ],
 	
 	

--- a/The Star League Rides Again/mod.json
+++ b/The Star League Rides Again/mod.json
@@ -12,12 +12,12 @@
 	"Manifest": [
 		{
 			"Type": "ChassisDef",
-			"Path": "chassis\\",
+			"Path": "chassis",
 			"AddToDB": true
 		},
 		{
 			"Type": "MechDef",
-			"Path": "mech\\",
+			"Path": "mech",
 			"AddToDB": true
 		}
 	]


### PR DESCRIPTION
This PR fixes next two problems, and allows users to run this mod on linux, without manually changing anything.

1. When you run RogueTech on linux, ModTek will try to search for wrong files/directories, if path in manifest in mod.json differs in capital letters from path on filesystem ("Dir\subdir" in manifest and "dir\SubDir" in filesystem). Reason for this - most filesystems used on linux are case sensitive.

2. On linux (and likely OSX) ModTek will not find directory inside specific mod, if path to this directory in mod.json ends with double slash ("\\\\"). For following manifest, it will search inside "SubFolder" for directory with name "SubSubFolder\\" (single slash, "\\" - allowed character in file/directory name on linux), while mod author meant it to be just "SubSubFolder".
```
    "Manifest": [
        { "Type": "WeaponDef", "Path": "SubFolder\\SubSubFolder\\" },
    ],
```

Related issue in ModTek repo:
https://github.com/BattletechModders/ModTek/issues/97

UPD:
Some additional info - linux users will have to create symlink `mods -> Mods` for this mod to work:
`cd path/to/BATTLETECH && ln -s Mods mods`