### PR TITLE
Make Gladiators Great again

### DIFF
--- a/RogueFlashPointModule/contract/c_fp_limitedlight_1_destroyBase.json
+++ b/RogueFlashPointModule/contract/c_fp_limitedlight_1_destroyBase.json
@@ -7,7 +7,7 @@
 "weight" : 1,
 "scope" : "UNKNOWN",
 "finalDifficulty" : 0,
-"shortDescription" : "A local mercinary is trying to make it big. He thinks by calling you out he can gain fame and fortune.",
+"shortDescription" : "A local mercenary is trying to make it big. He thinks by calling you out he can gain fame and fortune.",
 "longDescription" : "Well, this should be fun.",
 "salvagePotential" : 8,
 "requirementList" : [],

--- a/RogueFlashPointModule/contract/c_fp_limitedlightd10_1_destroyBase.json
+++ b/RogueFlashPointModule/contract/c_fp_limitedlightd10_1_destroyBase.json
@@ -3,11 +3,11 @@
 "contractName" : "Limited Gladiator",
 "contractDisplayStyle" : "BaseFlashpoint",
 "difficulty" : 8,
-"difficultyUIModifier" : 0,
+"difficultyUIModifier" : 2,
 "weight" : 1,
 "scope" : "UNKNOWN",
 "finalDifficulty" : 0,
-"shortDescription" : "A local mercinary is trying to make it big. He thinks by calling you out he can gain fame and fortune.",
+"shortDescription" : "A local mercenary is trying to make it big. He thinks by calling you out he can gain fame and fortune.",
 "longDescription" : "Well, this should be fun.",
 "salvagePotential" : 16,
 "requirementList" : [],
@@ -16,19 +16,19 @@
 "contractType" : "SimpleBattle",
 "encounterPlayStyle" : "SinglePlayer",
 "maxNumberOfPlayerUnits" : 1,
-"lanceMinTonnage" : -1,
-"lanceMaxTonnage" : -1,
+"lanceMinTonnage" : 20,
+"lanceMaxTonnage" : 100,
 "mechMinTonnages" : [
-    -1,
-    -1,
-    -1,
-    -1
+    20,
+    20,
+    20,
+    20
 ],
 "mechMaxTonnages" : [
     100,
-    -1,
-    -1,
-    -1
+    100,
+    100,
+    100
 ],
 "mapMood" : null,
 "startingFogOfWarVisibility" : "Surveyed",
@@ -421,6 +421,7 @@
                       "lance_type_gladiator",
 			      "lance_type_solo"
 
+
                 ],
                 "tagSetSourceFile" : "tags/LanceTags"
             },
@@ -476,7 +477,7 @@
                     "customUnitName" : "",
                     "customHeraldryDefId" : null,
                     "unitType" : "Mech",
-                    "unitDefId" : "mechDef_None",
+                    "unitDefId" : "mechDef_InheritLance",
                     "unitTagSet" : {
                         "items" : [],
                         "tagSetSourceFile" : "tags/UnitTags"

--- a/RogueFlashPointModule/contract/c_fp_limitedlightd6_1_destroyBase.json
+++ b/RogueFlashPointModule/contract/c_fp_limitedlightd6_1_destroyBase.json
@@ -7,7 +7,7 @@
 "weight" : 1,
 "scope" : "UNKNOWN",
 "finalDifficulty" : 0,
-"shortDescription" : "A local mercinary is trying to make it big. He thinks by calling you out he can gain fame and fortune.",
+"shortDescription" : "A local mercenary is trying to make it big. He thinks by calling you out he can gain fame and fortune.",
 "longDescription" : "Well, this should be fun.",
 "salvagePotential" : 16,
 "requirementList" : [],

--- a/RogueFlashPointModule/milestoneSets/ms_fp_limitedgladiator5az.json
+++ b/RogueFlashPointModule/milestoneSets/ms_fp_limitedgladiator5az.json
@@ -162,7 +162,7 @@
                             "additionalValues" : [
                                 "",
                                 "",
-                                "c_fp_limitedlightd6_1_destroyBase",
+                                "c_fp_limitedlightd10_1_destroyBase",
                                 "{PLANETOWNER}",
                                 "{RANDOM}",
                                 "8",
@@ -418,7 +418,7 @@
                             "additionalValues" : [
                                 "",
                                 "",
-                                "c_fp_limitedlightd6_1_destroyBase",
+                                "c_fp_limitedlightd10_1_destroyBase",
                                 "{PLANETOWNER}",
                                 "{RANDOM}",
                                 "8",

--- a/RogueFlashPointModule/milestoneSets/ms_fp_limitedgladiator5bz.json
+++ b/RogueFlashPointModule/milestoneSets/ms_fp_limitedgladiator5bz.json
@@ -162,7 +162,7 @@
                             "additionalValues" : [
                                 "",
                                 "",
-                                "c_fp_limitedlightd6_1_destroyBase",
+                                "c_fp_limitedlightd10_1_destroyBase",
                                 "{PLANETOWNER}",
                                 "{RANDOM}",
                                 "8",
@@ -418,7 +418,7 @@
                             "additionalValues" : [
                                 "",
                                 "",
-                                "c_fp_limitedlightd6_1_destroyBase",
+                                "c_fp_limitedlightd10_1_destroyBase",
                                 "{PLANETOWNER}",
                                 "{RANDOM}",
                                 "8",


### PR DESCRIPTION
Replaced Mercinary misspelling with Mercenary. Fixed contract type c_fp_limitedlightd10_1_destroyBase to spawn one more mech than c_fp_limitedlightd6_1_destroyBase. Making a full lance.