### PR TITLE
Quick Fix for Mixed Support lances

### DIFF
--- a/RogueContracts/lance/MixedSupport/lancedef_mixed_d3_dynamic_support.json
+++ b/RogueContracts/lance/MixedSupport/lancedef_mixed_d3_dynamic_support.json
@@ -38,7 +38,8 @@
                     "unit_noncombatant",
                     "unit_bracket_high",
                     "unit_lance_assassin",
-                    "unit_assault"
+                    "unit_assault",
+                    "unit_heavy"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -112,9 +113,6 @@
                     "unit_legendary",
                     "unit_bracket_med",
                     "unit_bracket_high",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank",
                     "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
@@ -156,7 +154,9 @@
                     "unit_superheavy",
                     "unit_superheavytank",
                     "unit_lance_assassin",
-                    "unit_assault"
+                    "unit_assault",
+                    "unit_heavy",
+                    "unit_medium"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueContracts/lance/MixedSupport/lancedef_mixed_d4_dynamic_support.json
+++ b/RogueContracts/lance/MixedSupport/lancedef_mixed_d4_dynamic_support.json
@@ -37,7 +37,8 @@
                 "items": [
                     "unit_noncombatant",
                     "unit_lance_assassin",
-                    "unit_assault"
+                    "unit_assault",
+                    "unit_heavy"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -109,9 +110,6 @@
                     "unit_legendary",
                     "unit_bracket_high",
                     "unit_advanced",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank",
                     "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
@@ -149,11 +147,9 @@
                     "unit_legendary",
                     "unit_bracket_med",
                     "unit_bracket_high",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank",
                     "unit_lance_assassin",
-                    "unit_assault"
+                    "unit_assault",
+                    "unit_heavy"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueContracts/lance/MixedSupport/lancedef_mixed_d5_dynamic_support.json
+++ b/RogueContracts/lance/MixedSupport/lancedef_mixed_d5_dynamic_support.json
@@ -38,7 +38,9 @@
                 "items": [
                     "unit_noncombatant",
                     "unit_bracket_low",
-                    "unit_lance_assassin"
+                    "unit_lance_assassin",
+                    "unit_assault",
+                    "unit_heavy"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -106,10 +108,7 @@
                 "items": [
                     "unit_noncombatant",
                     "unit_legendary",
-                    "unit_bracket_high",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank"
+                    "unit_bracket_high"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -145,9 +144,6 @@
                     "unit_legendary",
                     "unit_bracket_high",
                     "unit_advanced",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank",
                     "unit_lance_assassin"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"

--- a/RogueContracts/lance/MixedSupport/lancedef_mixed_d5_dynamic_support.json
+++ b/RogueContracts/lance/MixedSupport/lancedef_mixed_d5_dynamic_support.json
@@ -1,6 +1,6 @@
 {
     "Description": {
-        "Id": "lancedef_mech_d5_dynamic_support",
+        "Id": "lancedef_mixed_d5_dynamic_support",
         "Name": "Dynamic Dif 5 Support",
         "Details": "",
         "Icon": "",

--- a/RogueContracts/lance/MixedSupport/lancedef_mixed_d6_dynamic_support.json
+++ b/RogueContracts/lance/MixedSupport/lancedef_mixed_d6_dynamic_support.json
@@ -38,7 +38,9 @@
                     "unit_noncombatant",
                     "unit_generic",
                     "unit_bracket_low",
-                    "unit_lance_assassin"
+                    "unit_lance_assassin",
+                    "unit_assault",
+                    "unit_heavy"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -141,10 +143,8 @@
                     "unit_noncombatant",
                     "unit_legendary",
                     "unit_bracket_high",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank",
-                    "unit_lance_assassin"
+                    "unit_lance_assassin",
+                    "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueContracts/lance/MixedSupport/lancedef_mixed_d7_dynamic_support.json
+++ b/RogueContracts/lance/MixedSupport/lancedef_mixed_d7_dynamic_support.json
@@ -39,7 +39,9 @@
                     "unit_noncombatant",
                     "unit_generic",
                     "unit_bracket_low",
-                    "unit_lance_assassin"
+                    "unit_lance_assassin",
+                    "unit_assault",
+                    "unit_heavy"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -109,10 +111,7 @@
                 "items": [
                     "unit_noncombatant",
                     "unit_legendary",
-                    "unit_bracket_low",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank"
+                    "unit_bracket_low"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -146,10 +145,8 @@
                 "items": [
                     "unit_noncombatant",
                     "unit_legendary",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank",
-                    "unit_lance_assassin"
+                    "unit_lance_assassin",
+                    "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueContracts/lance/MixedSupport/lancedef_mixed_d8_dynamic_support.json
+++ b/RogueContracts/lance/MixedSupport/lancedef_mixed_d8_dynamic_support.json
@@ -39,7 +39,8 @@
                     "unit_noncombatant",
                     "unit_generic",
                     "unit_bracket_low",
-                    "unit_lance_assassin"
+                    "unit_lance_assassin",
+                    "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -111,10 +112,7 @@
                     "unit_noncombatant",
                     "unit_legendary",
                     "unit_generic",
-                    "unit_bracket_low",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank"
+                    "unit_bracket_low"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -149,10 +147,8 @@
                     "unit_noncombatant",
                     "unit_legendary",
                     "unit_bracket_low",
-                    "unit_turret",
-                    "unit_superheavy",
-                    "unit_superheavytank",
-                    "unit_lance_assassin"
+                    "unit_lance_assassin",
+                    "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },


### PR DESCRIPTION
One bad dupe ID, and several lances missing tonnage restrictions.