### PR TITLE
Update vehicledef_MARS_XL_CLAN.json

### DIFF
--- a/RogueTanks/CLANK/vehicle/vehicledef_MARS_XL_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MARS_XL_CLAN.json
@@ -108,14 +108,14 @@
             "DamageLevel": "Functional"
         },
         {
-            "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
+            "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
             "ComponentDefType": "Weapon",
             "MountedLocation": "Left",
             "HardpointSlot": 0,
             "DamageLevel": "Functional"
         },
         {
-            "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
+            "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
             "ComponentDefType": "Weapon",
             "MountedLocation": "Right",
             "HardpointSlot": 0,
@@ -143,6 +143,13 @@
             "DamageLevel": "Functional"
         },
         {
+            "ComponentDefID": "Gear_LAMS_CLAN",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
             "ComponentDefID": "Gear_FCS_Clan_ARTEMISIV",
             "ComponentDefType": "Upgrade",
             "MountedLocation": "Front",
@@ -151,6 +158,13 @@
         },
         {
             "ComponentDefID": "Gear_ArtemisIV_LRM_Ammo_Standin",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_ArtemisIV_SRM_Ammo_Standin",
             "ComponentDefType": "Upgrade",
             "MountedLocation": "Rear",
             "HardpointSlot": -1,


### PR DESCRIPTION
Canon vehicle has Artemis IV LRM and Streak SRM, this isn't an allowed build in RT, so switched to Artemis SRM, and gave an AMS for the one ton that freed up.