### PR TITLE
Added Default tags to Society gear

### DIFF
--- a/RogueModuleTech/basic/ChassisDefaults/Gear_FCS_Society.json
+++ b/RogueModuleTech/basic/ChassisDefaults/Gear_FCS_Society.json
@@ -15,6 +15,7 @@
         },
 		"Flags": {
             "flags": [
+		"default",
                 "not_broken",
                 "no_salvage",
                 "autorepair"

--- a/RogueModuleTech/basic/ChassisDefaults/Gear_Sensors_Society.json
+++ b/RogueModuleTech/basic/ChassisDefaults/Gear_Sensors_Society.json
@@ -13,6 +13,7 @@
         },
 		"Flags": {
             "flags": [
+		"default",
                 "not_broken",
                 "no_salvage",
                 "autorepair"


### PR DESCRIPTION
Fixes some of the cool society mechs from being rendered unusable and overwritten with ghost systems.