### PR TITLE
Update vehicledef_METALSTORM_SUPERHEAVY_TANK.json

### DIFF
--- a/Superheavys/vehicle/vehicledef_METALSTORM_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_METALSTORM_SUPERHEAVY_TANK.json
@@ -208,7 +208,7 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Gear_AMS",
+                  "ComponentDefID": "Gear_advanced_AMS",
                   "ComponentDefType": "Upgrade",
                   "MountedLocation": "Turret",
                   "HardpointSlot": -1,
@@ -216,6 +216,27 @@
             },
             {
                   "ComponentDefID": "Gear_Guardian_ECM",
+                  "ComponentDefType": "Upgrade",
+                  "MountedLocation": "Front",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Gear_BlueShield",
+                  "ComponentDefType": "Upgrade",
+                  "MountedLocation": "Front",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Gear_Boosted_BAP",
+                  "ComponentDefType": "Upgrade",
+                  "MountedLocation": "Front",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Gear_C3i",
                   "ComponentDefType": "Upgrade",
                   "MountedLocation": "Front",
                   "HardpointSlot": -1,
@@ -243,7 +264,7 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS_half",
+                  "ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS_double",
                   "ComponentDefType": "AmmunitionBox",
                   "MountedLocation": "Rear",
                   "HardpointSlot": -1,
@@ -300,6 +321,34 @@
             },
             {
                   "ComponentDefID": "Ammo_AmmunitionBox_ArtemisIV_LRM",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Rear",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_double",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Rear",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Tracer_LMG",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Rear",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_AP_LMG",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Rear",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_HE_LMG",
                   "ComponentDefType": "AmmunitionBox",
                   "MountedLocation": "Rear",
                   "HardpointSlot": -1,
@@ -308,27 +357,6 @@
             {
                   "MountedLocation": "Rear",
                   "ComponentDefID": "emod_engine_300",
-                  "ComponentDefType": "HeatSink",
-                  "HardpointSlot": -1,
-                  "DamageLevel": "Functional"
-            },
-            {
-                  "MountedLocation": "Rear",
-                  "ComponentDefID": "emod_engineslots_xl_center",
-                  "ComponentDefType": "HeatSink",
-                  "HardpointSlot": -1,
-                  "DamageLevel": "Functional"
-            },
-            {
-                  "MountedLocation": "Left",
-                  "ComponentDefID": "emod_engineslots_size3",
-                  "ComponentDefType": "HeatSink",
-                  "HardpointSlot": -1,
-                  "DamageLevel": "Functional"
-            },
-            {
-                  "MountedLocation": "Right",
-                  "ComponentDefID": "emod_engineslots_size3",
                   "ComponentDefType": "HeatSink",
                   "HardpointSlot": -1,
                   "DamageLevel": "Functional"


### PR DESCRIPTION
This was missing all MG ammo. And upon inspection seemed to be about 10 tons underweight. So it got more gizmos.  But that's pretty weird so I'll need to double-check this again, but I'm too sleepy to get out the tabletop books and re-do all the math.