### PR TITLE
fix for wrong lv-vismode-zoom tags on NAOP's cockpits

### DIFF
--- a/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Artillerist.json
+++ b/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Artillerist.json
@@ -404,6 +404,7 @@
         "items" : [
 			"lv-probe-boost_m1",
 			"lv-vismode-zoom_m0_c-2_s30",
+		        "lv-vismode-heat_m1_d20",
             "component_type_stock",
 			"lv-shares-sensors",
 			"ClanFCS",

--- a/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Artillerist.json
+++ b/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Artillerist.json
@@ -403,8 +403,7 @@
     "ComponentTags" : {
         "items" : [
 			"lv-probe-boost_m1",
-			"lv-vismode-zoom_m2_s30",
-			"lv-vismode-heat_m1_d20",
+			"lv-vismode-zoom_m0_c-2_s30",
             "component_type_stock",
 			"lv-shares-sensors",
 			"ClanFCS",

--- a/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_CQB_S.json
+++ b/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_CQB_S.json
@@ -239,7 +239,7 @@
     "ComponentTags" : {
         "items" : [
 			"lv-probe-boost_m1",
-			"lv-vismode-zoom_m9_s1",
+			"lv-vismode-zoom_m0_c-5_s2",
             "component_type_stock",
 			"ClanCockpit",
 			"ClanFCS"

--- a/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Marksman.json
+++ b/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Marksman.json
@@ -308,7 +308,7 @@
         "items" : [
 			"lv-probe-boost_m1",
 			"lv-vismode-heat_m1_d40",
-			"lv-vismode-zoom_m2_s9",
+			"lv-vismode-zoom_m0_c-2_s9",
             "component_type_stock",
 			"lv-shares-sensors",
 			"ClanCockpit",

--- a/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Supersoldier.json
+++ b/NAOP_CustomMechsNParts/cockpits/Gear_Cockpit_Toho_Supersoldier.json
@@ -448,7 +448,7 @@
         "items" : [
             "component_type_stock",
 			"lv-probe-boost_m2",
-			"lv-vismode-zoom_m3_s10",
+			"lv-vismode-zoom_m0_c-3_s10",
 			"lv-vismode-heat_m2_d30",
 			"ClanCockpit",
 			"ClanFCS",

--- a/NAOP_CustomMechsNParts/cockpits/Gear_FCS_Seeker.json
+++ b/NAOP_CustomMechsNParts/cockpits/Gear_FCS_Seeker.json
@@ -98,7 +98,7 @@
 		"items": [
 			"component_type_variant",
 			"ClanFCS",
-			"lv-vismode-zoom_m5_s2",
+			"lv-vismode-zoom_m0_c-5_s2",
 			"lv-vismode-heat_m1_d40"
 		],
 		"tagSetSourceFile": ""


### PR DESCRIPTION
Gear_Cockpit_Toho_CQB_S lv-vismode-zoom was different from BonusDescriptions, i made the new one according to BonusDescriptions.