### PR TITLE
Minor Fixes

### DIFF
--- a/RogueTanks/vehicle/light/vehicledef_SALADIN_LBX.json
+++ b/RogueTanks/vehicle/light/vehicledef_SALADIN_LBX.json
@@ -88,7 +88,7 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Ammo_AmmunitionBox_LBX_SLUG_AC20",
+                  "ComponentDefID": "Ammo_AmmunitionBox_LBX_CLUSTER_AC20",
                   "ComponentDefType": "AmmunitionBox",
                   "MountedLocation": "Right",
                   "HardpointSlot": -1,

--- a/RogueTanks/vehicle/medium/vehicledef_GORGON.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GORGON.json
@@ -135,7 +135,7 @@
 			"DamageLevel": "Functional"
 		},
 		{
-			"ComponentDefID": "Ammo_AmmunitionBox_Thermobolt_TB5",
+			"ComponentDefID": "Ammo_AmmunitionBox_Thermobolt_TB10",
 			"ComponentDefType": "AmmunitionBox",
 			"MountedLocation": "Front",
 			"HardpointSlot": -1,

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_LBX.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_LBX.json
@@ -96,7 +96,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "ComponentDefID": "Ammo_AmmunitionBox_LBX_SLUG_AC20",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_CLUSTER_AC20",
       "ComponentDefType": "AmmunitionBox",
       "MountedLocation": "Turret",
       "HardpointSlot": -1,

--- a/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1.json
+++ b/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1.json
@@ -98,28 +98,7 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Weapon_MachineGun_MachineGun_1-LIGHT",
-                  "ComponentDefType": "Weapon",
-                  "MountedLocation": "Turret",
-                  "HardpointSlot": 0,
-                  "DamageLevel": "Functional"
-            },
-            {
-                  "ComponentDefID": "Weapon_MachineGun_MachineGun_1-LIGHT",
-                  "ComponentDefType": "Weapon",
-                  "MountedLocation": "Turret",
-                  "HardpointSlot": 1,
-                  "DamageLevel": "Functional"
-            },
-            {
-                  "ComponentDefID": "Weapon_MachineGun_MachineGun_1-LIGHT",
-                  "ComponentDefType": "Weapon",
-                  "MountedLocation": "Turret",
-                  "HardpointSlot": 2,
-                  "DamageLevel": "Functional"
-            },
-            {
-                  "ComponentDefID": "Weapon_MachineGun_MachineGun_1-LIGHT",
+                  "ComponentDefID": "Weapon_MachineGun_MachineGun_ARRAY-LIGHT",
                   "ComponentDefType": "Weapon",
                   "MountedLocation": "Turret",
                   "HardpointSlot": 3,

--- a/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1_MG.json
+++ b/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1_MG.json
@@ -132,14 +132,35 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Weapon_MachineGun_MachineGun_ARRAY-STOCK",
+                  "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
                   "ComponentDefType": "Weapon",
                   "MountedLocation": "Turret",
                   "HardpointSlot": 4,
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Ammo_AmmunitionBox_Phosphor_LMG",
+                  "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 5,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 6,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 7,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Phosphor_MG",
                   "ComponentDefType": "AmmunitionBox",
                   "MountedLocation": "Rear",
                   "HardpointSlot": -1,

--- a/RogueTanks/vehicleChassis/vehiclechassisdef_RANGER_VV1.json
+++ b/RogueTanks/vehicleChassis/vehiclechassisdef_RANGER_VV1.json
@@ -115,18 +115,6 @@
 				{
 					"WeaponMount": "Ballistic",
 					"Omni": false
-				},
-				{
-					"WeaponMount": "Ballistic",
-					"Omni": false
-				},
-				{
-					"WeaponMount": "Ballistic",
-					"Omni": false
-				},
-				{
-					"WeaponMount": "Ballistic",
-					"Omni": false
 				}
 			],
 			"Tonnage": 0,

--- a/RogueTanks/vehicleChassis/vehiclechassisdef_RANGER_VV1_MG.json
+++ b/RogueTanks/vehicleChassis/vehiclechassisdef_RANGER_VV1_MG.json
@@ -135,6 +135,18 @@
 				{
 					"WeaponMount": "Ballistic",
 					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,


### PR DESCRIPTION
Small fixes and adjustments of ammo and weapon loadouts. Gorgon had wrong ammo. LBX Saladin won't live long enough to use cluster if it has slug. Hetzer LB slug ammo reduced for same reason. One ranger was supposed to have two MG arrays the other none, one had wrong ammo.