### PR TITLE
Add missing Gear_Cockpit_StarCorps_Dalban.json

### DIFF
--- a/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_StarCorps_Dalban.json
+++ b/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_StarCorps_Dalban.json
@@ -11,7 +11,7 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-                "Resolve: +3",
+                "Resolve: +4",
                 "Initiative: +1",
                 "IsCockpit"
             ]
@@ -24,18 +24,18 @@
     "RelativeModifier": 0,
     "AbsoluteModifier": 0,
     "Description": {
-        "Cost": 470000,
-        "Rarity": 5,
+        "Cost": 940000,
+        "Rarity": 99,
         "Purchasable": true,
         "Manufacturer": "StarCorps",
-        "Model": "Advanced",
-        "UIName": "Comms Suite + +",
-        "Id": "Gear_Cockpit_StarCorps_Advanced",
-        "Name": "StarCorps Advanced Comms Suite",
+        "Model": "Dalban",
+        "UIName": "Comms Suite + + +",
+        "Id": "Gear_Cockpit_StarCorps_Dalban",
+        "Name": "StarCorps Dalban Comms Suite",
         "Details": "All 'Mechs come equipped with a stock cockpit configuration, which can be upgraded for improved performance. Comms Suite upgrades allow for better lance cohesion during combat, increasing the Resolve generated.",
         "Icon": "uixSvgIcon_equipment_Comms"
     },
-    "BonusValueA": "+ 3 Resolve Gain",
+    "BonusValueA": "+ 4 Resolve Gain",
     "BonusValueB": "+ 1 Initiative",
     "ComponentType": "Upgrade",
     "ComponentSubType": "NotSet",
@@ -122,7 +122,7 @@
             },
             "effectType": "StatisticEffect",
             "Description": {
-                "Id": "StatusEffect-Morale_Gain-T3",
+                "Id": "StatusEffect-Morale_Gain-T4",
                 "Name": "RESOLVE GENERATION INCREASED",
                 "Details": "Provides a [AMT] bonus to actions that generate Resolve.",
                 "Icon": "uixSvgIcon_equipment_Cockpit"
@@ -133,7 +133,7 @@
                 "effectsPersistAfterDestruction": false,
                 "statName": "MoraleBonusGain",
                 "operation": "Int_Add",
-                "modValue": "3",
+                "modValue": "4",
                 "modType": "System.Int32",
                 "additionalRules": "NotSet",
                 "targetCollection": "NotSet",

--- a/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_StarCorps_Enhanced.json
+++ b/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_StarCorps_Enhanced.json
@@ -5,8 +5,8 @@
         }],
         "WorkOrderCosts": {
             "Install": {
-                "TechCost": "1",
-                "CBillCost": "[[Chassis.Tonnage]]"
+                "TechCost": "[[Chassis.Tonnage]]/5",
+                "CBillCost": "[[Chassis.Tonnage]]*50"
             }
         },
         "BonusDescriptions": {
@@ -31,12 +31,12 @@
         "Model": "Enhanced",
         "UIName": "Comms Suite +",
         "Id": "Gear_Cockpit_StarCorps_Enhanced",
-        "Name": "StarCorps Enhanced Comms System",
-        "Details": "All 'Mechs come equipped with a stock cockpit configuration, which can be upgraded for improved performance. Comms System upgrades allow for better lance cohesion during combat, increasing the Morale generated.",
+        "Name": "StarCorps Enhanced Comms Suite",
+        "Details": "All 'Mechs come equipped with a stock cockpit configuration, which can be upgraded for improved performance. Comms Suite upgrades allow for better lance cohesion during combat, increasing the Resolve generated.",
         "Icon": "uixSvgIcon_equipment_Comms"
     },
-    "BonusValueA": "+ 2 Morale Gain",
-    "BonusValueB": "",
+    "BonusValueA": "+ 2 Resolve Gain",
+    "BonusValueB": "+ 1 Initiative",
     "ComponentType": "Upgrade",
     "ComponentSubType": "NotSet",
     "PrefabIdentifier": "",
@@ -46,7 +46,7 @@
     "AllowedLocations": "Head",
     "DisallowedLocations": "All",
     "CriticalComponent": false,
-    "statusEffects": [	
+    "statusEffects": [
         {
             "durationData": {
                 "duration": -1,
@@ -123,8 +123,8 @@
             "effectType": "StatisticEffect",
             "Description": {
                 "Id": "StatusEffect-Morale_Gain-T2",
-                "Name": "MORALE GENERATION INCREASED",
-                "Details": "Provides a +2 bonus to actions that generate Resolve.",
+                "Name": "RESOLVE GENERATION INCREASED",
+                "Details": "Provides a [AMT] bonus to actions that generate Resolve.",
                 "Icon": "uixSvgIcon_equipment_Cockpit"
             },
             "nature": "Buff",

--- a/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_StarCorps_Improved.json
+++ b/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_StarCorps_Improved.json
@@ -31,12 +31,12 @@
         "Model": "Improved",
         "UIName": "Comms Suite",
         "Id": "Gear_Cockpit_StarCorps_Improved",
-        "Name": "StarCorps Improved Comms System",
-        "Details": "All 'Mechs come equipped with a stock cockpit configuration, which can be upgraded for improved performance. Comms System upgrades allow for better lance cohesion during combat, increasing the Morale generated.",
+        "Name": "StarCorps Improved Comms Suite",
+        "Details": "All 'Mechs come equipped with a stock cockpit configuration, which can be upgraded for improved performance. Comms Suite upgrades allow for better lance cohesion during combat, increasing the Resolve generated.",
         "Icon": "uixSvgIcon_equipment_Comms"
     },
-    "BonusValueA": "+ 1 Morale Gain",
-    "BonusValueB": "",
+    "BonusValueA": "+ 1 Resolve Gain",
+    "BonusValueB": "+ 1 Initiative",
     "ComponentType": "Upgrade",
     "ComponentSubType": "NotSet",
     "PrefabIdentifier": "",
@@ -123,8 +123,8 @@
             "effectType": "StatisticEffect",
             "Description": {
                 "Id": "StatusEffect-Morale_Gain-T1",
-                "Name": "MORALE GENERATION INCREASED",
-                "Details": "Provides a +1 bonus to actions that generate Morale.",
+                "Name": "RESOLVE GENERATION INCREASED",
+                "Details": "Provides a [AMT] bonus to actions that generate Resolve.",
                 "Icon": "uixSvgIcon_equipment_Cockpit"
             },
             "nature": "Buff",


### PR DESCRIPTION
- Adds custom def for rare vanilla +++ item in the Gear_Cockpit_StarCorps series.
- Standardises TechCost and CBillCost for all StarCorps cockpits
- Change "Morale" references to "Resolve"

NOTE: If a 'Mech has one of these installed already, it will have 2 cockpits after this update (and have an extra ton). If it is removed, a (second) default cockpit replaces it, and so on. The 'Mech can be fixed by storing/readying the 'Mech.