### PR TITLE
X65 StructureFactor corrected to 1.1

### DIFF
--- a/MWOHeroes/mech/mechdef_enforcer_ENF-GH.json
+++ b/MWOHeroes/mech/mechdef_enforcer_ENF-GH.json
@@ -105,7 +105,7 @@
 	],
 	"inventory": [{
 			"MountedLocation": "LeftArm",
-			"ComponentDefID": "Gear_Actuator_Coventry_X65-Standard",
+			"ComponentDefID": "emod_arm_lower",
 			"SimGameUID": "",
 			"ComponentDefType": "Upgrade",
 			"HardpointSlot": 0,

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_X65-Standard.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_X65-Standard.json
@@ -17,7 +17,7 @@
             ]
         },
         "Weights": {
-            "StructureFactor": 1.075
+            "StructureFactor": 1.1
         },
         "InventorySorter": {
             "SortKey": "00020"


### PR DESCRIPTION
- to match ActuatorWeight 10%
- balance mechdef_enforcer_ENF-GH.json: swap one X65 for Lower Arm

These 'Mechs also use X65, but after rounding they are unaffected by the change:

- RogueMechs/mech/mechdef_orion_ON1-KER.json
- Flashpoint-The-Raid/mech/mechdef_firestarter_FS9-H_fp_theRaid.json