### PR TITLE
AC2 Incendiary Fix - MAYBE

### DIFF
--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Incendiary_AC2.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Incendiary_AC2.json
@@ -13,7 +13,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "HeatDamage: +10",
-                "ACDamage: -15",
+                "ACDamage: -10",
 				"Inferno: 5",
                 "AC2Ammo: 13"
             ]

--- a/CustomAmmoCategories/ammunition/Ammunition_AC2_Incendiary.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_AC2_Incendiary.json
@@ -11,7 +11,7 @@
    },
    "Type" : "Normal",
    "Category" : "AC2",
-   "DamagePerShot": -15.0,
+   "DamagePerShot": -10.0,
    "HeatDamagePerShot": 10.0,
    "AIBattleValue":90,
    "HeatGenerated" : 0,


### PR DESCRIPTION
Every other AC Incendiary ammo's damage goes down equal to the heat it gains. I looked at the ratios and couldn't figure any reason the 2 ammo should be different.