### PR TITLE
Vehicles Scale Update

### DIFF
--- a/Nagas/vehicle/vehicledef_DEMOLISHER-II_CX.json
+++ b/Nagas/vehicle/vehicledef_DEMOLISHER-II_CX.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER-II",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/Nagas/vehicle/vehicledef_HUITZILOPOCHTLI_AAA_CLAN.json
+++ b/Nagas/vehicle/vehicledef_HUITZILOPOCHTLI_AAA_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HUITZILOPOCHTLI_AAA_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.44",
+                  "mr-resize-1.55",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/Nagas/vehicle/vehicledef_HUITZILOPOCHTLI_CLAN.json
+++ b/Nagas/vehicle/vehicledef_HUITZILOPOCHTLI_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HUITZILOPOCHTLI_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.44",
+                  "mr-resize-1.55",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/Nagas/vehicle/vehicledef_REDOCTOBER.json
+++ b/Nagas/vehicle/vehicledef_REDOCTOBER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_REDOCTOBER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.5",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_APC_INDRA_BA_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_APC_INDRA_BA_CLAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_INDRA_BA_CLAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.17",
+			"mr-resize-1.25",
 			"unit_vehicle",
 			"unit_light",
 			"unit_medium",

--- a/RogueTanks/CLANK/vehicle/vehicledef_APC_INDRA_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_APC_INDRA_CLAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_INDRA_CLAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.17",
+			"mr-resize-1.25",
 			"unit_vehicle",
 			"unit_light",
 			"unit_medium",

--- a/RogueTanks/CLANK/vehicle/vehicledef_APC_KU_TURHAN2_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_APC_KU_TURHAN2_CLAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_KU_TURHAN2_CLAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheels",

--- a/RogueTanks/CLANK/vehicle/vehicledef_ARES_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_ARES_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_ARES_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_medium",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_ARES_PLASMA_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_ARES_PLASMA_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_ARES_PLASMA_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_medium",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_AXEL2XL_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_AXEL2XL_CLAN_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_AXEL2XL_CLAN_RTcv",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_AXEL2_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_AXEL2_CLAN_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_AXEL2_CLAN_RTcv",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_assault",

--- a/RogueTanks/CLANK/vehicle/vehicledef_BELLONA2_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_BELLONA2_CLAN_RT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_BELLONA2_CLAN_RT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.48",
+            "mr-resize-1.59",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_BELLONA_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_BELLONA_CLAN_RT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_BELLONA_CLAN_RT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.48",
+            "mr-resize-1.59",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_CARRIER_LRM_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_CARRIER_LRM_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_LRM_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_DEMOLISHER_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_DEMOLISHER_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_DEMOLISHER_UAC_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_DEMOLISHER_UAC_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER_UAC_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_DEMON_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_DEMON_CLAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_DEMON_CLAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheeled",

--- a/RogueTanks/CLANK/vehicle/vehicledef_EPONA-A_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_EPONA-A_CLAN_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_EPONA-A_CLAN_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.48",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_EPONA-B_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_EPONA-B_CLAN_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_EPONA-B_CLAN_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.48",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_EPONA-C_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_EPONA-C_CLAN_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_EPONA-C_CLAN_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.48",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_EPONA-D_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_EPONA-D_CLAN_RT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_EPONA-D_CLAN_RT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.48",
+            "mr-resize-1.68",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_EPONA-E_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_EPONA-E_CLAN_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_EPONA-E_CLAN_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.48",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_EPONA_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_EPONA_CLAN_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_EPONA_CLAN_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.48",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE700_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE700_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JOUST_BE700_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.14-1.14-0.90",
+            "mr-resize-1.24-1.24-1.0",
             "unit_vehicle",
             "unit_medium",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE700_EXPORT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE700_EXPORT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JOUST_BE700_EXPORT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.14-1.14-0.90",
+            "mr-resize-1.24-1.24-1.0",
             "unit_vehicle",
             "unit_medium",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE701_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE701_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JOUST_BE701_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.14-1.14-0.90",
+            "mr-resize-1.24-1.24-1.0",
             "unit_vehicle",
             "unit_medium",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE701_EXPORT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_JOUST_BE701_EXPORT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JOUST_BE701_EXPORT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.14-1.14-0.90",
+            "mr-resize-1.24-1.24-1.0",
             "unit_vehicle",
             "unit_medium",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_KU_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_KU_CLAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_KU_CLAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MARS_ATM_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MARS_ATM_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MARS_ATM_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MARS_CASSIUS_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MARS_CASSIUS_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MARS_CASSIUS_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MARS_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MARS_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MARS_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MARS_HAG_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MARS_HAG_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MARS_HAG_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MARS_STREAKLRM_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MARS_STREAKLRM_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MARS_STREAKLRM_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MARS_XL_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MARS_XL_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MARS_XL_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MORRIGU_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MORRIGU_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MORRIGU_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MORRIGU_HAG_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MORRIGU_HAG_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MORRIGU_HAG_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_MORRIGU_LASER_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_MORRIGU_LASER_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MORRIGU_LASER_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracked",

--- a/RogueTanks/CLANK/vehicle/vehicledef_ORO_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_ORO_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_ORO_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.14-1.14-0.90",
+            "mr-resize-1.24-1.24-1.0",
             "unit_vehicle",
             "unit_heavy",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_ORO_HAG_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_ORO_HAG_CLAN.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_ORO_HAG_CLAN",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.14-1.14-0.90",
+            "mr-resize-1.24-1.24-1.0",
             "unit_vehicle",
             "unit_heavy",
             "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_PIKE_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_PIKE_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PIKE_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.21",
+                  "mr-resize-1.3",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_PUMA-2_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_PUMA-2_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PUMA-2_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-2.49",
+                  "mr-resize-2.67",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_PUMA_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_PUMA_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PUMA_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-2.49",
+                  "mr-resize-2.67",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SCORPION_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SCORPION_CLAN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCORPION_CLAN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_tracks",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SHAMASH_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SHAMASH_CLAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SHAMASH_CLAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.78",
+			"mr-resize-0.88",
 			"unit_vehicle",
 			"unit_light",
 			"unit_noconvoy",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SHAMASH_CLAN_ECM.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SHAMASH_CLAN_ECM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SHAMASH_CLAN_ECM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.78",
+			"mr-resize-0.88",
 			"unit_vehicle",
 			"unit_light",
 			"unit_noconvoy",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SM1A_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SM1A_CLAN_RT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_SM1A_CLAN_RT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.48",
+            "mr-resize-1.68",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SM1_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SM1_CLAN_RT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_SM1_CLAN_RT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.48",
+            "mr-resize-1.68",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SM3_CLAN_RT.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SM3_CLAN_RT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_SM3_CLAN_RT",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.48",
+            "mr-resize-1.68",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/CLANK/vehicle/vehicledef_ZORYA_AMMO_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_ZORYA_AMMO_CLAN.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_ZORYA_AMMO_CLAN",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_light",
       "unit_wheels",

--- a/RogueTanks/CLANK/vehicle/vehicledef_ZORYA_ATM_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_ZORYA_ATM_CLAN.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_ZORYA_ATM_CLAN",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_light",
       "unit_wheels",

--- a/RogueTanks/CLANK/vehicle/vehicledef_ZORYA_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_ZORYA_CLAN.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_ZORYA_CLAN",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_light",
       "unit_wheels",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_ALACORN_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_ALACORN_PIRATE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ALACORN_PIRATE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_AXELB_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_AXELB_PIRATE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_AXELB_PIRATE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_BOOMBOX_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_BOOMBOX_PIRATE.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_BOOMBOX_PIRATE",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_DEMON_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_DEMON_PIRATE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_DEMON_PIRATE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheeled",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_HUNTER-B_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_HUNTER-B_PIRATE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HUNTER-B_PIRATE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_medium",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_IGNIS_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_IGNIS_PIRATE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_IGNIS_PIRATE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_MANTICORE_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_MANTICORE_PIRATE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_MANTICORE_PIRATE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_MANTICORE_PIRATE_2.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_MANTICORE_PIRATE_2.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_MANTICORE_PIRATE_2",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_MARSDENIIA_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_MARSDENIIA_PIRATE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MARSDENIIA_PIRATE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_PLUNDERER_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_PLUNDERER_PIRATE.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_PLUNDERER_PIRATE",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_assault",
             "unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_SALADIN_Pirate.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_SALADIN_Pirate.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SALADIN_PIRATE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.31",
+			"mr-resize-1.40",
 			"unit_vehicle",
 			"unit_light",
 			"unit_release",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_SCHREK_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_SCHREK_PIRATE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SCHREK_PIRATE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_STRIKER_DIRECT_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_STRIKER_DIRECT_PIRATE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_STRIKER_DIRECT_PIRATE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_wheels",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_VEDETTE_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_VEDETTE_PIRATE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_VEDETTE_PIRATE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_tracks",

--- a/RogueTanks/PirateTanks/vehicle/vehicledef_ZEPHYR_PIRATE.json
+++ b/RogueTanks/PirateTanks/vehicle/vehicledef_ZEPHYR_PIRATE.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_ZEPHYR_PIRATE",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.40",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_medium",
             "unit_release",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_BATTLEBUS_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_BATTLEBUS_PRIMITIVE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BATTLEBUS_PRIMITIVE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.17",
+                  "mr-resize-1.27",
                   "unit_vehicle",
                   "unit_light",
                   "unit_medium",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_BULLETANT_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_BULLETANT_PRIMITIVE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BULLETANT_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.28",
+			"mr-resize-1.38",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CANDIRU_Primitive.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CANDIRU_Primitive.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_CANDIRU_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.07",
+			"mr-resize-1.17",
 			"unit_vehicle",
 			"unit_light",
 			"unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_HEAVY_RL.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_HEAVY_RL.json
@@ -14,7 +14,7 @@
             "items": [
                   "mr-resize-1.62",
                   "unit_vehicle",
-                  "unit_assault",
+                  "unit_heavy",
                   "unit_tracks",
                   "unit_release",
                   "unit_carrier",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_RIFLE_MIXED_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_RIFLE_MIXED_PRIMITIVE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_RIFLE_MIXED_PRIMITIVE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_RIFLE_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_RIFLE_PRIMITIVE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_RIFLE_PRIMITIVE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_RL_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CARRIER_RL_PRIMITIVE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_CARRIER_RL_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CHARIOT_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_CHARIOT_PRIMITIVE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_CHARIOT_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.57",
+			"mr-resize-1.67",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_DEMOLISHER_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_DEMOLISHER_PRIMITIVE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER_PRIMITIVE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_DEMOLISHER_PRIMITIVE_2.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_DEMOLISHER_PRIMITIVE_2.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER_PRIMITIVE_2",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_ACID.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_ACID.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_FIRETRUCK_ACID",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_FIRE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_FIRE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_FIRETRUCK_FIRE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_wheels",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_IVAN.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_IVAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_FIRETRUCK_IVAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_OIL.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_OIL.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_FIRETRUCK_OIL",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_PAINT.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_FIRETRUCK_PAINT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_FIRETRUCK_PAINT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_IZULA_Primitive.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_IZULA_Primitive.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_IZULA_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.21",
+			"mr-resize-1.31",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_tracks",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_JEdgar_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_JEdgar_PRIMITIVE.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JEdgar_PRIMITIVE",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.11",
+            "mr-resize-1.40",
             "unit_vehicle",
             "unit_light",
             "unit_release",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_LIGHT_INFERNO_RL_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_LIGHT_INFERNO_RL_PRIMITIVE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_LIGHT_RL_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.5",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_LIGHT_RL_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_LIGHT_RL_PRIMITIVE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_LIGHT_RL_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.5",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/PrimitiveTanks/vehicle/vehicledef_SCHREK_PRIMITIVE.json
+++ b/RogueTanks/PrimitiveTanks/vehicle/vehicledef_SCHREK_PRIMITIVE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SCHREK_PRIMITIVE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/Readme.txt
+++ b/RogueTanks/Readme.txt
@@ -34,6 +34,10 @@ unit_hunter,
 
 Changelog:
 
+6.5.6
+
+Scale update. Fixed/Updated all vehicle scaling.
+
 6.5.5
 
 Added Mortar Techies,

--- a/RogueTanks/artillery/vehicle/vehicledef_LONGTOM.json
+++ b/RogueTanks/artillery/vehicle/vehicledef_LONGTOM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_LONGTOM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/artillery/vehicle/vehicledef_THUMPER.json
+++ b/RogueTanks/artillery/vehicle/vehicledef_THUMPER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_THUMPER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.11",
+                  "mr-resize-1.19",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/mod.json
+++ b/RogueTanks/mod.json
@@ -1,7 +1,7 @@
 {
     "Name": "RogueTanks",
     "Enabled": true,
-    "Version": "6.5.5",
+    "Version": "6.5.6",
     "Description": "The Tanks of Roguetech",
     "Author": "Cargo Vroom and LadyAlekto with special thanks to Justin Kase and Colobos",
     "Website": "",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_HeavyWheeled",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.89",
+			"mr-resize-0.95",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled_LRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled_LRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_HeavyWheeled_LRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.89",
+			"mr-resize-0.95",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled_MG.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled_MG.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_HeavyWheeled_MG",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.89",
+			"mr-resize-0.95",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled_SRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_HeavyWheeled_SRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_HeavyWheeled_SRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.89",
+			"mr-resize-0.95",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Sleipnir",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.47",
+			"mr-resize-1.57",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir_AC2.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir_AC2.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Sleipnir_AC2",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.47",
+			"mr-resize-1.57",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir_LRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir_LRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Sleipnir_LRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.47",
+			"mr-resize-1.57",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir_SRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Sleipnir_SRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Sleipnir_SRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.47",
+			"mr-resize-1.57",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_TURHAN.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_TURHAN.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_TURHAN",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_TURHAN_AMS.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_TURHAN_AMS.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_TURHAN_AMS",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Vargr.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Vargr.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_APC_Vargr",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.47",
+            "mr-resize-1.57",
             "unit_vehicle",
             "unit_heavy",
             "unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Vargr_LL.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Vargr_LL.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Vargr_LL",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.47",
+			"mr-resize-1.57",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Vargr_LRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Vargr_LRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Vargr_LRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.47",
+			"mr-resize-1.57",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Vargr_SRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Vargr_SRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Vargr_SRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.47",
+			"mr-resize-1.57",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Wheeled",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.63",
+			"mr-resize-0.67",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled_LRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled_LRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Wheeled_LRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.63",
+			"mr-resize-0.67",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled_MG.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled_MG.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Wheeled_MG",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.63",
+			"mr-resize-0.67",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled_SRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_APC_Wheeled_SRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_Wheeled_SRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.63",
+			"mr-resize-0.67",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MASHTruck-ICE.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MASHTruck-ICE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MASHTruck-ICE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.34",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MASHTruck-L.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MASHTruck-L.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MASHTruck-L",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.34",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MASHTruck-UA.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MASHTruck-UA.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MASHTruck-UA",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.34",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MASHTruck.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MASHTruck.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MASHTruck",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.34",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MOBILEHQ",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ_ARMORED.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ_ARMORED.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MOBILEHQ_ARMORED",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ_LL.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ_LL.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MOBILEHQ_LL",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ_LRM.json
+++ b/RogueTanks/vehicle/apc/vehicledef_MOBILEHQ_LRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MOBILEHQ_LRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_SWIFTWIND.json
+++ b/RogueTanks/vehicle/apc/vehicledef_SWIFTWIND.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SWIFTWIND",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.67",
+			"mr-resize-0.80",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/apc/vehicledef_SWIFTWIND_ARMORED.json
+++ b/RogueTanks/vehicle/apc/vehicledef_SWIFTWIND_ARMORED.json
@@ -13,7 +13,7 @@
 	"ChassisID": "vehiclechassisdef_SWIFTWIND_ARMORED",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-0.67",
+			"mr-resize-0.80",
 			"unit_vehicle",
 			"unit_light",
 			"unit_wheels",

--- a/RogueTanks/vehicle/assault/vehicledef_AJAX_B.json
+++ b/RogueTanks/vehicle/assault/vehicledef_AJAX_B.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_AJAX_B",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.59",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_AJAX_C.json
+++ b/RogueTanks/vehicle/assault/vehicledef_AJAX_C.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_AJAX_C",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.59",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_AJAX_RT.json
+++ b/RogueTanks/vehicle/assault/vehicledef_AJAX_RT.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_AJAX_RT",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.59",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ALACORN.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ALACORN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ALACORN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.53",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ALACORN_6B.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ALACORN_6B.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ALACORN_6B",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.53",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ALACORN_VII.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ALACORN_VII.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ALACORN_VII",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.53",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_BEHEMOTH.json
+++ b/RogueTanks/vehicle/assault/vehicledef_BEHEMOTH.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BEHEMOTH",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.57",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_BEHEMOTHA.json
+++ b/RogueTanks/vehicle/assault/vehicledef_BEHEMOTHA.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BEHEMOTHA",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.57",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_BEHEMOTHF.json
+++ b/RogueTanks/vehicle/assault/vehicledef_BEHEMOTHF.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BEHEMOTHF",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.57",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_BEHEMOTH_KURITA.json
+++ b/RogueTanks/vehicle/assault/vehicledef_BEHEMOTH_KURITA.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BEHEMOTH_KURITA",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.57",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_CHALLENGER_X.json
+++ b/RogueTanks/vehicle/assault/vehicledef_CHALLENGER_X.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CHALLENGER_X",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.59",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_CHALLENGER_XI.json
+++ b/RogueTanks/vehicle/assault/vehicledef_CHALLENGER_XI.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CHALLENGER_XI",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.59",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_CHALLENGER_XII.json
+++ b/RogueTanks/vehicle/assault/vehicledef_CHALLENGER_XII.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CHALLENGER_XII",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.59",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER-II.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER-II.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER-II",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER-II_TBM.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER-II_TBM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER-II",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER-R.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER-R.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER-R",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHERD.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHERD.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHERD",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER_BOMBAST.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER_BOMBAST.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER_BOMBAST",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER_BOMBAST_CELL.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER_BOMBAST_CELL.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER_BOMBAST_CELL",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER_GAUSS.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEMOLISHER_GAUSS.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEMOLISHER_GAUSS",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_DEVASTATOR.json
+++ b/RogueTanks/vehicle/assault/vehicledef_DEVASTATOR.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_DEVASTATOR",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ONTOS_FUSION.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ONTOS_FUSION.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ONTOS_FUSION",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.76",
+                  "mr-resize-1.89",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ONTOS_LIGHTGAUSS.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ONTOS_LIGHTGAUSS.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ONTOS_LIGHTGAUSS",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.76",
+                  "mr-resize-1.89",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ONTOS_LRM.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ONTOS_LRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ONTOS_LRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.76",
+                  "mr-resize-1.89",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ONTOS_MK1.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ONTOS_MK1.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ONTOS_MK1",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.76",
+                  "mr-resize-1.89",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ONTOS_MML.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ONTOS_MML.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ONTOS_MML",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.76",
+                  "mr-resize-1.89",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_ONTOS_RT.json
+++ b/RogueTanks/vehicle/assault/vehicledef_ONTOS_RT.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ONTOS_RT",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.76",
+                  "mr-resize-1.89",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_PUMA.json
+++ b/RogueTanks/vehicle/assault/vehicledef_PUMA.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_PUMA",
   "VehicleTags": {
     "items": [
-      "mr-resize-2.49",
+      "mr-resize-2.67",
       "unit_vehicle",
       "unit_assault",
       "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_PUMA_RT.json
+++ b/RogueTanks/vehicle/assault/vehicledef_PUMA_RT.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PUMA_RT",
       "VehicleTags": {
             "items": [
-                  "mr-resize-2.49",
+                  "mr-resize-2.67",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_RHINO_FLAMER.json
+++ b/RogueTanks/vehicle/assault/vehicledef_RHINO_FLAMER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_RHINO_FLAMER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.62",
+                  "mr-resize-1.73",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_RHINO_ROYAL.json
+++ b/RogueTanks/vehicle/assault/vehicledef_RHINO_ROYAL.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_RHINO_ROYAL",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.62",
+                  "mr-resize-1.73",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_SCHREK.json
+++ b/RogueTanks/vehicle/assault/vehicledef_SCHREK.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SCHREK",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_SCHREK_AC.json
+++ b/RogueTanks/vehicle/assault/vehicledef_SCHREK_AC.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SCHREK_AC",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/vehicle/assault/vehicledef_SCHREK_MG.json
+++ b/RogueTanks/vehicle/assault/vehicledef_SCHREK_MG.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCHREK_MG",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_AC2.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_AC2.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_AC2",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_AC2_LBX.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_AC2_LBX.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_AC2_LBX",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HEAVYLRM.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HEAVYLRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_HEAVYLRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.62",
+                  "mr-resize-1.73",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HEAVY_TBM10.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HEAVY_TBM10.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_HEAVY_TBM10",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.62",
+                  "mr-resize-1.73",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HEAVY_TBM15.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HEAVY_TBM15.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_HEAVY_TBM15",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.62",
+                  "mr-resize-1.73",
                   "unit_vehicle",
                   "unit_assault",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HYBRID_10-5.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HYBRID_10-5.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_HYBRID_10-5",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HYBRID_20-20.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HYBRID_20-20.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_HYBRID_20-20",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HYBRID_5-15.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_HYBRID_5-15.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_HYBRID_5-15",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LASER.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LASER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_LASER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_medium",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_LRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_3055.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_3055.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_LRM_3055",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_ENHANCED.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_ENHANCED.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_LRM_ENHANCED",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_EXTENDED.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_EXTENDED.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_LRM_EXTENDED",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_MORTAR.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_MORTAR.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_MORTAR",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_MRM.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_MRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_MRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_SRM.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_SRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_SRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_SRM_3054.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_SRM_3054.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_CARRIER_SRM_3054",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.40",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_heavy",
       "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_SRM_C3.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_SRM_C3.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_CARRIER_SRM_C3",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.40",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_heavy",
       "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_TBM5.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_TBM5.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_TBM5",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_TBOLT.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_TBOLT.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CARRIER_TBOLT",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/carrier/vehicledef_LIGHTLRM.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_LIGHTLRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_LIGHTLRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/carrier/vehicledef_LIGHTMRM.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_LIGHTMRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_LIGHTMRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/carrier/vehicledef_LIGHTSRM.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_LIGHTSRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_LIGHTSRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/carrier/vehicledef_LIGHTTHUNDERBOLT_10_RT.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_LIGHTTHUNDERBOLT_10_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_LIGHTTHUNDERBOLT_10_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/carrier/vehicledef_LIGHTTHUNDERBOLT_RT.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_LIGHTTHUNDERBOLT_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_LIGHTTHUNDERBOLT_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.25",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_wheels",

--- a/RogueTanks/vehicle/heavy/vehicledef_AXEL_MK1.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_AXEL_MK1.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_AXEL_MK1",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_AXEL_MK2.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_AXEL_MK2.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_AXEL_MK2",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BALROG.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BALROG.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BALROG",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BARDICHE.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BARDICHE.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BARDICHE",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheeled",

--- a/RogueTanks/vehicle/heavy/vehicledef_BOLLA_COMMINUS.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BOLLA_COMMINUS.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BOLLA_COMMINUS",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BOLLA_DOMINUS.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BOLLA_DOMINUS.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BOLLA_DOMINUS",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BOLLA_INFERNUS.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BOLLA_INFERNUS.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BOLLA_INFERNUS",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BOLLA_INVICTUS.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BOLLA_INVICTUS.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BOLLA_INVICTUS",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BRUTUS.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BRUTUS.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BRUTUS",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BRUTUS_PPC.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BRUTUS_PPC.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BRUTUSBcv",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BRUTUS_PPC2.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BRUTUS_PPC2.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BRUTUS_PPC2",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BULLDOG.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BULLDOG.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BULLDOG",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BULLDOG_AC.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BULLDOG_AC.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BULLDOG_AC",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_BULLDOG_LRM.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_BULLDOG_LRM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_BULLDOG_LRM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_DEMON.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_DEMON.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_DEMON",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheeled",

--- a/RogueTanks/vehicle/heavy/vehicledef_DEMON_HORNED.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_DEMON_HORNED.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_DEMON_HORNED",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheeled",

--- a/RogueTanks/vehicle/heavy/vehicledef_DEMON_ROYAL.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_DEMON_ROYAL.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_DEMON_ROYAL",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_wheeled",

--- a/RogueTanks/vehicle/heavy/vehicledef_MANTICORE.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_MANTICORE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_MANTICORE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_MANTICOREB_RT.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_MANTICOREB_RT.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_MANTICOREB_RT",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_heavy",
       "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_MANTICOREC_RT.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_MANTICOREC_RT.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_MANTICORE-C_RTcv",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_heavy",
             "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_MANTICORE_ELITE.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_MANTICORE_ELITE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_MANTICORE_ELITE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_MARSDENII.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_MARSDENII.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_MARSDENII",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_MARSDENIIA.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_MARSDENIIA.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MARSDENIIA",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_MARSDENIIA_LBX.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_MARSDENIIA_LBX.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MARSDENIIA_LBX",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.4",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PATTON.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PATTON.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PATTON",
       "VehicleTags": {
             "items": [
-                  "mr-resize-2.26",
+                  "mr-resize-2.21",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PATTON_RT.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PATTON_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_PATTON_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PIKE.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PIKE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PIKE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.21",
+                  "mr-resize-1.3",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PIKE_RT.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PIKE_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_PIKE_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.21",
+			"mr-resize-1.3",
 			"unit_vehicle",
 			"unit_assault",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PO.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PO.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PO",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.98",
+                  "mr-resize-2.12",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PO_II.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PO_II.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PO_II",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.98",
+                  "mr-resize-2.12",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PO_II_GAUSS.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PO_II_GAUSS.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PO_II_GAUSS",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.98",
+                  "mr-resize-2.12",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PO_II_STEALTH.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PO_II_STEALTH.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PO_II_STEALTH",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.98",
+                  "mr-resize-2.12",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PO_LBX.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PO_LBX.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PO_LBX",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.98",
+                  "mr-resize-2.12",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_PO_RT.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_PO_RT.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_PO_RT",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.98",
+                  "mr-resize-2.12",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_ROMMEL.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_ROMMEL.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_ROMMEL",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_ROMMEL_RT.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_ROMMEL_RT.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_ROMMEL_RT",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-2.21",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_ROTTWEILER.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_ROTTWEILER.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_ROTTWEILER",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-2.26",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_heavy",
 			"unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_SHEPARD.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_SHEPARD.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SHEPARD",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_VONLUCKNER_K65N.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_VONLUCKNER_K65N.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_VONLUCKNER_K65N",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.57",
+            "mr-resize-1.68",
             "unit_vehicle",
             "unit_heavy",
             "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_VONLUCKNER_K70.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_VONLUCKNER_K70.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VONLUCKNER_K70",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_VONLUCKNER_K75N.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_VONLUCKNER_K75N.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VONLUCKNER_K75N",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.57",
+                  "mr-resize-1.68",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_WINSTON_LAC.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_WINSTON_LAC.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_WINSTON_LAC",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.51",
+                  "mr-resize-1.62",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_WINSTON_RT.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_WINSTON_RT.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_WINSTON_RT",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.51",
+                  "mr-resize-1.62",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_ZHUKOV.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_ZHUKOV.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ZHUKOV",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/heavy/vehicledef_ZHUKOV_LIAO.json
+++ b/RogueTanks/vehicle/heavy/vehicledef_ZHUKOV_LIAO.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_ZHUKOV_LIAO",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_heavy",
                   "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_CENTAURUS.json
+++ b/RogueTanks/vehicle/light/vehicledef_CENTAURUS.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_CENTAURUS",
       "VehicleTags": {
             "items": [
-                  "mr-resize-0.77",
+                  "mr-resize-0.82",
                   "unit_vehicle",
                   "unit_light",
                   "unit_wheels",

--- a/RogueTanks/vehicle/light/vehicledef_GALLEON.json
+++ b/RogueTanks/vehicle/light/vehicledef_GALLEON.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_GALLEON",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.40",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL102.json
+++ b/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL102.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_GALLEON_GAL102",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.40",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_light",
             "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL103.json
+++ b/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL103.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_GALLEON_GAL103",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.40",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_light",
             "unit_medium",

--- a/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL104.json
+++ b/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL104.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_GALLEON_GAL104",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.40",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL200.json
+++ b/RogueTanks/vehicle/light/vehicledef_GALLEON_GAL200.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_GALLEON_GAL200",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.40",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_HARASSER.json
+++ b/RogueTanks/vehicle/light/vehicledef_HARASSER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HARASSER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.18",
+                  "mr-resize-1.27",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_HARASSER_FLAMER.json
+++ b/RogueTanks/vehicle/light/vehicledef_HARASSER_FLAMER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HARASSER_FLAMER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.18",
+                  "mr-resize-1.27",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_HARASSER_NARC.json
+++ b/RogueTanks/vehicle/light/vehicledef_HARASSER_NARC.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HARASSER_NARC",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.18",
+                  "mr-resize-1.27",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_HUNTER.json
+++ b/RogueTanks/vehicle/light/vehicledef_HUNTER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HUNTER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_medium",

--- a/RogueTanks/vehicle/light/vehicledef_HUNTER_3054.json
+++ b/RogueTanks/vehicle/light/vehicledef_HUNTER_3054.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_HUNTER_3054",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.40",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_medium",
       "unit_light",

--- a/RogueTanks/vehicle/light/vehicledef_HUNTER_LA.json
+++ b/RogueTanks/vehicle/light/vehicledef_HUNTER_LA.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HUNTER_LA",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_medium",

--- a/RogueTanks/vehicle/light/vehicledef_HUNTER_LRM10.json
+++ b/RogueTanks/vehicle/light/vehicledef_HUNTER_LRM10.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HUNTER_LRM10",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracked",

--- a/RogueTanks/vehicle/light/vehicledef_HUNTER_LRM15.json
+++ b/RogueTanks/vehicle/light/vehicledef_HUNTER_LRM15.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_HUNTER_LRM15",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.40",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracked",

--- a/RogueTanks/vehicle/light/vehicledef_IGNIS.json
+++ b/RogueTanks/vehicle/light/vehicledef_IGNIS.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_IGNIS",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_IGNISSRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_IGNISSRM.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_IGNISSRM",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_light",
       "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_JEdgar.json
+++ b/RogueTanks/vehicle/light/vehicledef_JEdgar.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JEdgar",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.40",
             "unit_vehicle",
             "unit_light",
             "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_JEdgar_Flamer.json
+++ b/RogueTanks/vehicle/light/vehicledef_JEdgar_Flamer.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_JEdgar_Flamer",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.11",
+			"mr-resize-1.40",
 			"unit_vehicle",
 			"unit_light",
 			"unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_JEdgar_KURITA.json
+++ b/RogueTanks/vehicle/light/vehicledef_JEdgar_KURITA.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JEdgar_KURITA",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.40",
             "unit_vehicle",
             "unit_light",
             "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_JEdgar_MG.json
+++ b/RogueTanks/vehicle/light/vehicledef_JEdgar_MG.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JEdgar_MG",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.40",
             "unit_vehicle",
             "unit_light",
             "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_JEdgar_TAG.json
+++ b/RogueTanks/vehicle/light/vehicledef_JEdgar_TAG.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_JEdgar_TAG",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.40",
             "unit_vehicle",
             "unit_light",
             "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_KINGSCORPION.json
+++ b/RogueTanks/vehicle/light/vehicledef_KINGSCORPION.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_KINGSCORPION",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.66",
+                  "mr-resize-1.77",
                   "unit_vehicle",
                   "unit_light",
                   "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_PEGASUS",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.31",
+                        "mr-resize-1.40",
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS_3058.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS_3058.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_PEGASUS_3058",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.31",
+                        "mr-resize-1.40",
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS_C3.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS_C3.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_PEGASUS_C3",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.31",
+                        "mr-resize-1.40",
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS_MG.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS_MG.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_PEGASUS_MG",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.31",
+         "mr-resize-1.40",
          "unit_vehicle",
          "unit_light",
          "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS_MRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS_MRM.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_PEGASUS_MRM",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.31",
+                        "mr-resize-1.40",
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS_SEALED.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS_SEALED.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_PEGASUS_SEALED",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.31",
+                        "mr-resize-1.40",
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS_SENSOR.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS_SENSOR.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_PEGASUS_SENSOR",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.31",
+                        "mr-resize-1.40",
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_PEGASUS_SRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_PEGASUS_SRM.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_PEGASUS_SRM",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.31",
+                        "mr-resize-1.40",
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SALADIN.json
+++ b/RogueTanks/vehicle/light/vehicledef_SALADIN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SALADIN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.66",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SALADIN_ARMOR.json
+++ b/RogueTanks/vehicle/light/vehicledef_SALADIN_ARMOR.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SALADIN_ARMOR",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.66",
+			"mr-resize-1.40",
 			"unit_vehicle",
 			"unit_light",
 			"unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SALADIN_LBX.json
+++ b/RogueTanks/vehicle/light/vehicledef_SALADIN_LBX.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SALADIN_LBX",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.66",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SALADIN_UAC.json
+++ b/RogueTanks/vehicle/light/vehicledef_SALADIN_UAC.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_SALADIN_UAC",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.66",
+			"mr-resize-1.40",
 			"unit_vehicle",
 			"unit_low",
 			"unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SARACEN.json
+++ b/RogueTanks/vehicle/light/vehicledef_SARACEN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SARACEN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.31",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SARACEN_MRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_SARACEN_MRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SARACEN_MRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.31",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SCIMITAR.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCIMITAR.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCIMITAR",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.31",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SCIMITAR_C3.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCIMITAR_C3.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCIMITAR_C3",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.31",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SCIMITAR_LRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCIMITAR_LRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCIMITAR_LRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.31",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SCIMITAR_TAG.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCIMITAR_TAG.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCIMITAR_TAG",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.31",
+                  "mr-resize-1.40",
                   "unit_vehicle",
                   "unit_light",
                   "unit_release",

--- a/RogueTanks/vehicle/light/vehicledef_SCORPION.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCORPION.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCORPION",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_SCORPION_LAC.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCORPION_LAC.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCORPION_LAC",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_SCORPION_LRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCORPION_LRM.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_SCORPION_LRM",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_light",
             "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_SCORPION_ML.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCORPION_ML.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_SCORPION_ML",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_SCORPION_MRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCORPION_MRM.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_SCORPION_MRM",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_light",
             "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_SCORPION_SRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_SCORPION_SRM.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_SCORPION_SRM",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.4",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_light",
             "unit_tracks",

--- a/RogueTanks/vehicle/light/vehicledef_STRIKER.json
+++ b/RogueTanks/vehicle/light/vehicledef_STRIKER.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_STRIKER",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_light",
       "unit_wheels",

--- a/RogueTanks/vehicle/light/vehicledef_STRIKER_3053.json
+++ b/RogueTanks/vehicle/light/vehicledef_STRIKER_3053.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_STRIKER_3053",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_wheels",

--- a/RogueTanks/vehicle/light/vehicledef_STRIKER_LRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_STRIKER_LRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_STRIKER_LRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_wheels",

--- a/RogueTanks/vehicle/light/vehicledef_STRIKER_SRM.json
+++ b/RogueTanks/vehicle/light/vehicledef_STRIKER_SRM.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_STRIKER_SRM",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_light",
                   "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_APC_MAXIM.json
+++ b/RogueTanks/vehicle/medium/vehicledef_APC_MAXIM.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_APC_MAXIM",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.57",
+			"mr-resize-1.68",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_CONDOR.json
+++ b/RogueTanks/vehicle/medium/vehicledef_CONDOR.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_CONDOR",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.40",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_hover",

--- a/RogueTanks/vehicle/medium/vehicledef_CONDOR_DAVION.json
+++ b/RogueTanks/vehicle/medium/vehicledef_CONDOR_DAVION.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_CONDOR_DAVION",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.40",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_hover",

--- a/RogueTanks/vehicle/medium/vehicledef_CONDOR_FLAMER.json
+++ b/RogueTanks/vehicle/medium/vehicledef_CONDOR_FLAMER.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_CONDOR_FLAMER",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.40",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_hover",

--- a/RogueTanks/vehicle/medium/vehicledef_CONDOR_LASER.json
+++ b/RogueTanks/vehicle/medium/vehicledef_CONDOR_LASER.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_CONDOR_LASER",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.40",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_hover",

--- a/RogueTanks/vehicle/medium/vehicledef_CONDOR_LIAO.json
+++ b/RogueTanks/vehicle/medium/vehicledef_CONDOR_LIAO.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_CONDOR_LIAO",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.40",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_DRILLSON.json
+++ b/RogueTanks/vehicle/medium/vehicledef_DRILLSON.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_DRILLSON",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.57",
+      "mr-resize-1.68",
       "unit_vehicle",
       "unit_medium",
       "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_DRILLSON_ERLL.json
+++ b/RogueTanks/vehicle/medium/vehicledef_DRILLSON_ERLL.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_DRILLSON_ERLL",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.57",
+         "mr-resize-1.68",
          "unit_vehicle",
          "unit_medium",
          "unit_heavy",

--- a/RogueTanks/vehicle/medium/vehicledef_DRILLSON_ICE.json
+++ b/RogueTanks/vehicle/medium/vehicledef_DRILLSON_ICE.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_DRILLSON_ICE",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.57",
+         "mr-resize-1.68",
          "unit_vehicle",
          "unit_medium",
          "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_DRILLSON_SRM.json
+++ b/RogueTanks/vehicle/medium/vehicledef_DRILLSON_SRM.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_DRILLSON_SRM",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.57",
+         "mr-resize-1.68",
          "unit_vehicle",
          "unit_medium",
          "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_DRILLSON_STREAK.json
+++ b/RogueTanks/vehicle/medium/vehicledef_DRILLSON_STREAK.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_DRILLSON_STREAK",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.57",
+      "mr-resize-1.68",
       "unit_vehicle",
       "unit_medium",
       "unit_heavy",

--- a/RogueTanks/vehicle/medium/vehicledef_FULCRUM_1.json
+++ b/RogueTanks/vehicle/medium/vehicledef_FULCRUM_1.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_FULCRUM_1",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.57",
+      "mr-resize-1.68",
       "unit_vehicle",
       "unit_medium",
       "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_FULCRUM_2.json
+++ b/RogueTanks/vehicle/medium/vehicledef_FULCRUM_2.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_FULCRUM_2",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.57",
+      "mr-resize-1.68",
       "unit_vehicle",
       "unit_medium",
       "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_FULCRUM_3.json
+++ b/RogueTanks/vehicle/medium/vehicledef_FULCRUM_3.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_FULCRUM_3",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.57",
+      "mr-resize-1.68",
       "unit_vehicle",
       "unit_medium",
       "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_GLADIUS.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GLADIUS.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_GLADIUS",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.40",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_light",
 			"unit_medium",

--- a/RogueTanks/vehicle/medium/vehicledef_GLADIUS_MKII.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GLADIUS_MKII.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_GLADIUS_MKII",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.40",
+			"mr-resize-1.50",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_GOBLIN.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GOBLIN.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_GOBLIN",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_GOBLIN_ISV.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GOBLIN_ISV.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_GOBLIN_ISV",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_GOBLIN_LRM.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GOBLIN_LRM.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_GOBLIN_LRM",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.4",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_light",
          "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_GOBLIN_MG.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GOBLIN_MG.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_GOBLIN_MG",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_GOBLIN_SRM.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GOBLIN_SRM.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_GOBLIN_SRM",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.4",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_GORGON.json
+++ b/RogueTanks/vehicle/medium/vehicledef_GORGON.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_GORGON",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.28",
+			"mr-resize-1.37",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_HETZER",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_medium",
       "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_AC10.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_AC10.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_HETZER_AC10",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.4",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_AP.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_AP.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_HETZER_AP",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_medium",
       "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_LASER.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_LASER.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_HETZER_LASER",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.4",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_LBX.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_LBX.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_HETZER",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_medium",
       "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_LRM.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_LRM.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_HETZER_LRM",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.4",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_SCOUT.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_SCOUT.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_HETZER_SCOUT",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_medium",
       "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_SRM.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_SRM.json
@@ -12,7 +12,7 @@
    "ChassisID": "vehiclechassisdef_HETZER_SRM",
    "VehicleTags": {
       "items": [
-         "mr-resize-1.4",
+         "mr-resize-1.50",
          "unit_vehicle",
          "unit_medium",
          "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_HETZER_UAC.json
+++ b/RogueTanks/vehicle/medium/vehicledef_HETZER_UAC.json
@@ -12,7 +12,7 @@
   "ChassisID": "vehiclechassisdef_HETZER_UAC",
   "VehicleTags": {
     "items": [
-      "mr-resize-1.4",
+      "mr-resize-1.50",
       "unit_vehicle",
       "unit_medium",
       "unit_wheels",

--- a/RogueTanks/vehicle/medium/vehicledef_MYRMIDON.json
+++ b/RogueTanks/vehicle/medium/vehicledef_MYRMIDON.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MYRMIDON",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.14",
+			"mr-resize-1.22",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_MYRMIDON_INF.json
+++ b/RogueTanks/vehicle/medium/vehicledef_MYRMIDON_INF.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_MYRMIDON_INF",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.14",
+			"mr-resize-1.22",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1.json
+++ b/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_RANGER_VV1",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracked",

--- a/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1_MG.json
+++ b/RogueTanks/vehicle/medium/vehicledef_RANGER_VV1_MG.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_RANGER_VV1_MG",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracked",

--- a/RogueTanks/vehicle/medium/vehicledef_REGULATOR.json
+++ b/RogueTanks/vehicle/medium/vehicledef_REGULATOR.json
@@ -12,7 +12,7 @@
 	"ChassisID": "vehiclechassisdef_REGULATOR",
 	"VehicleTags": {
 		"items": [
-			"mr-resize-1.49",
+			"mr-resize-1.59",
 			"unit_vehicle",
 			"unit_medium",
 			"unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_REGULATOR_RAC5.json
+++ b/RogueTanks/vehicle/medium/vehicledef_REGULATOR_RAC5.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_REGULATOR_RAC5",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.49",
+                  "mr-resize-1.59",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_SABAKU.json
+++ b/RogueTanks/vehicle/medium/vehicledef_SABAKU.json
@@ -12,7 +12,7 @@
     "ChassisID": "vehiclechassisdef_SABAKU",
     "VehicleTags": {
         "items": [
-            "mr-resize-1.40",
+            "mr-resize-1.50",
             "unit_vehicle",
             "unit_medium",
             "unit_heavy",

--- a/RogueTanks/vehicle/medium/vehicledef_TIGER.json
+++ b/RogueTanks/vehicle/medium/vehicledef_TIGER.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_TIGER",
       "VehicleTags": {
             "items": [
-                  "mr-resize-2.08",
+                  "mr-resize-2.03",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_VEDETTE.json
+++ b/RogueTanks/vehicle/medium/vehicledef_VEDETTE.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VEDETTE",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_VEDETTE_AC2.json
+++ b/RogueTanks/vehicle/medium/vehicledef_VEDETTE_AC2.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VEDETTE_AC2",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_VEDETTE_LBX.json
+++ b/RogueTanks/vehicle/medium/vehicledef_VEDETTE_LBX.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VEDETTE_LBX",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_VEDETTE_LIAO.json
+++ b/RogueTanks/vehicle/medium/vehicledef_VEDETTE_LIAO.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VEDETTE_LIAO",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_VEDETTE_NETC.json
+++ b/RogueTanks/vehicle/medium/vehicledef_VEDETTE_NETC.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VEDETTE_NETC",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_VEDETTE_UAC.json
+++ b/RogueTanks/vehicle/medium/vehicledef_VEDETTE_UAC.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_VEDETTE_UAC",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.4",
+                  "mr-resize-1.50",
                   "unit_vehicle",
                   "unit_medium",
                   "unit_tracks",

--- a/RogueTanks/vehicle/medium/vehicledef_ZEPHYR.json
+++ b/RogueTanks/vehicle/medium/vehicledef_ZEPHYR.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_ZEPHYR",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.4",
+                        "mr-resize-1.50",
                         "unit_vehicle",
                         "unit_medium",
                         "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_ZEPHYR_C3I.json
+++ b/RogueTanks/vehicle/medium/vehicledef_ZEPHYR_C3I.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_ZEPHYR_C3I",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.4",
+                        "mr-resize-1.50",
                         "unit_vehicle",
                         "unit_medium",
                         "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_ZEPHYR_ROYAL.json
+++ b/RogueTanks/vehicle/medium/vehicledef_ZEPHYR_ROYAL.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_ZEPHYR_ROYAL",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.4",
+                        "mr-resize-1.50",
                         "unit_vehicle",
                         "unit_medium",
                         "unit_release",

--- a/RogueTanks/vehicle/medium/vehicledef_ZEPHYR_SRM2.json
+++ b/RogueTanks/vehicle/medium/vehicledef_ZEPHYR_SRM2.json
@@ -12,7 +12,7 @@
         "ChassisID": "vehiclechassisdef_ZEPHYR_SRM2",
         "VehicleTags": {
                 "items": [
-                        "mr-resize-1.4",
+                        "mr-resize-1.50",
                         "unit_vehicle",
                         "unit_medium",
                         "unit_release",

--- a/Superheavys/vehicle/vehicledef_BIGPIRATE_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_BIGPIRATE_SUPERHEAVY_TANK.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_BIGPIRATE_SUPERHEAVY_TANK",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.92",
+                  "mr-resize-2.05",
                   "unit_superheavytank",
                   "unit_noconvoy",
                   "marian",

--- a/Superheavys/vehicle/vehicledef_GULLTOPPR_ARTY_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_GULLTOPPR_ARTY_SUPERHEAVY_TANK.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_GULLTOPPR_ARTY_SUPERHEAVY_TANK",
       "VehicleTags": {
             "items": [
-                  "mr-resize-2.73",
+                  "mr-resize-2.96",
                   "unit_superheavytank",
                   "unit_noconvoy",
                   "comstar",

--- a/Superheavys/vehicle/vehicledef_GULLTOPPR_LRM_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_GULLTOPPR_LRM_SUPERHEAVY_TANK.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_GULLTOPPR_LRM_SUPERHEAVY_TANK",
       "VehicleTags": {
             "items": [
-                  "mr-resize-2.73",
+                  "mr-resize-2.96",
                   "unit_superheavytank",
                   "unit_noconvoy",
                   "comstar",

--- a/Superheavys/vehicle/vehicledef_LBX20Carrier_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_LBX20Carrier_SUPERHEAVY_TANK.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_LBX20CARRIER_SUPERHEAVY_TANK",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.92",
+                  "mr-resize-2.05",
                   "unit_superheavytank",
                   "unit_noconvoy",
                   "comstar",

--- a/Superheavys/vehicle/vehicledef_METALSTORM_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_METALSTORM_SUPERHEAVY_TANK.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_METALSTORM_SUPERHEAVY_TANK",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.92",
+                  "mr-resize-2.05",
                   "unit_superheavytank",
                   "unit_noconvoy",
                   "comstar",

--- a/Superheavys/vehicle/vehicledef_OBJECT404_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_OBJECT404_SUPERHEAVY_TANK.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_OBJECT404_SUPERHEAVY_TANK",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.92",
+                  "mr-resize-2.05",
                   "unit_superheavytank",
                   "unit_noconvoy",
                   "comstar",

--- a/Superheavys/vehicle/vehicledef_OBLITERATOR_CLAN_SUPERHEAVY_TANK.json
+++ b/Superheavys/vehicle/vehicledef_OBLITERATOR_CLAN_SUPERHEAVY_TANK.json
@@ -12,7 +12,7 @@
       "ChassisID": "vehiclechassisdef_OBLITERATOR_CLAN_SUPERHEAVY_TANK",
       "VehicleTags": {
             "items": [
-                  "mr-resize-1.98",
+                  "mr-resize-1.91",
                   "unit_superheavytank",
                   "unit_noconvoy",
                   "clansgeneric",


### PR DESCRIPTION
Vehicle scale base calibration 1.4 to 1.5 as in MechResizer default, incidentally correcting several errors.