### PR TITLE
A Proposal for CASED ammo bins

### DIFF
--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC10.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC10.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"AC10Ammo: 8"
+				"AC10Ammo: 6"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_AC10",
-    "Capacity": 8,
+    "Capacity": 6,
     "Description": {
         "Cost": 60000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC2.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC2.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"AC2Ammo: 25"
+				"AC2Ammo: 20"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_AC2",
-    "Capacity": 25,
+    "Capacity": 20,
     "Description": {
         "Cost": 20000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC20.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC20.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"AC20Ammo: 5"
+				"AC20Ammo: 4"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_AC20",
-    "Capacity": 5,
+    "Capacity": 4,
     "Description": {
         "Cost": 80000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC5.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Protected_AC5.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"AC5Ammo: 15"
+				"AC5Ammo: 12"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_AC5",
-    "Capacity": 15,
+    "Capacity": 12,
     "Description": {
         "Cost": 40000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/LRM/Ammo_AmmunitionBox_Protected_LRM.json
+++ b/CustomAmmoCategories/LRM/Ammo_AmmunitionBox_Protected_LRM.json
@@ -19,7 +19,7 @@
         }
     },
     "AmmoID": "Ammunition_LRM",
-    "Capacity": 120,
+    "Capacity": 80,
     "Description": {
         "Cost": 40000,
         "Rarity": 5,
@@ -39,7 +39,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/MG/Ammo_AmmunitionBox_Protected_HMG.json
+++ b/CustomAmmoCategories/MG/Ammo_AmmunitionBox_Protected_HMG.json
@@ -5,7 +5,7 @@
 		        "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"HMGAmmo: 100"
+				"HMGAmmo: 80"
             ]
         },	
             "InventorySorter" : {
@@ -14,7 +14,7 @@
 	},
 
     "AmmoID" : "Ammunition_HMG",
-    "Capacity" : 100,
+    "Capacity" : 80,
     "Description" : {
         "Cost" : 20000,
         "Rarity" : 5,
@@ -34,7 +34,7 @@
     "PrefabIdentifier" : "",
     "BattleValue" : 0,
     "InventorySize" : 1,
-    "Tonnage" : 1.25,
+    "Tonnage" : 1,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
     "CriticalComponent" : false,

--- a/CustomAmmoCategories/MG/Ammo_AmmunitionBox_Protected_LMG.json
+++ b/CustomAmmoCategories/MG/Ammo_AmmunitionBox_Protected_LMG.json
@@ -5,7 +5,7 @@
 		        "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"LMGAmmo: 200"
+				"LMGAmmo: 160"
             ]
         },	
             "InventorySorter" : {
@@ -14,7 +14,7 @@
 	},
 
     "AmmoID" : "Ammunition_LMG",
-    "Capacity" : 200,
+    "Capacity" : 160,
     "Description" : {
         "Cost" : 20000,
         "Rarity" : 5,
@@ -34,7 +34,7 @@
     "PrefabIdentifier" : "",
     "BattleValue" : 0,
     "InventorySize" : 1,
-    "Tonnage" : 1.25,
+    "Tonnage" : 1,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
     "CriticalComponent" : false,

--- a/CustomAmmoCategories/MG/Ammo_AmmunitionBox_Protected_MG.json
+++ b/CustomAmmoCategories/MG/Ammo_AmmunitionBox_Protected_MG.json
@@ -5,7 +5,7 @@
 		        "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"MGAmmo: 200"
+				"MGAmmo: 160"
             ]
         },	
             "InventorySorter" : {
@@ -14,7 +14,7 @@
 	},
 
     "AmmoID" : "Ammunition_MG",
-    "Capacity" : 200,
+    "Capacity" : 160,
     "Description" : {
         "Cost" : 20000,
         "Rarity" : 5,
@@ -34,7 +34,7 @@
     "PrefabIdentifier" : "",
     "BattleValue" : 0,
     "InventorySize" : 1,
-    "Tonnage" : 1.25,
+    "Tonnage" : 1,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
     "CriticalComponent" : false,

--- a/CustomAmmoCategories/MRM/Ammo_AmmunitionBox_Protected_MRM.json
+++ b/CustomAmmoCategories/MRM/Ammo_AmmunitionBox_Protected_MRM.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
 				"Protected: 75%",
-                "MRMAmmo: 200"
+                "MRMAmmo: 160"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID" : "Ammunition_MRM",
-    "Capacity" : 200,
+    "Capacity" : 160,
     "Description" : {
         "Cost" : 25000,
         "Rarity" : 0,
@@ -40,7 +40,7 @@
     "PrefabIdentifier" : "",
     "BattleValue" : 0,
     "InventorySize" : 1,
-    "Tonnage" : 1.25,
+    "Tonnage" : 1,
     "AllowedLocations" : "All",
     "DisallowedLocations" : "All",
     "CriticalComponent" : false,

--- a/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC10.json
+++ b/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC10.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"RAC10Ammo: 8"
+				"RAC10Ammo: 6"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_RAC10",
-    "Capacity": 8,
+    "Capacity": 6,
     "Description": {
         "Cost": 60000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC2.json
+++ b/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC2.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"RAC2Ammo: 25"
+				"RAC2Ammo: 20"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_RAC2",
-    "Capacity": 25,
+    "Capacity": 20,
     "Description": {
         "Cost": 20000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC20.json
+++ b/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC20.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"RAC20Ammo: 5"
+				"RAC20Ammo: 4"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_RAC20",
-    "Capacity": 5,
+    "Capacity": 4,
     "Description": {
         "Cost": 80000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC5.json
+++ b/CustomAmmoCategories/RotaryAC/Ammo_AmmunitionBox_Rotary_Protected_AC5.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"RAC5Ammo: 15"
+				"RAC5Ammo: 12"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_RAC5",
-    "Capacity": 15,
+    "Capacity": 12,
     "Description": {
         "Cost": 40000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/SRM/Ammo_AmmunitionBox_Protected_SRM.json
+++ b/CustomAmmoCategories/SRM/Ammo_AmmunitionBox_Protected_SRM.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"SRMAmmo: 100"
+				"SRMAmmo: 80"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_SRM",
-    "Capacity": 100,
+    "Capacity": 80,
     "Description": {
         "Cost": 20000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC10.json
+++ b/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC10.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"UAC10Ammo: 8"
+				"UAC10Ammo: 6"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_UAC10",
-    "Capacity": 8,
+    "Capacity": 6,
     "Description": {
         "Cost": 60000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC2.json
+++ b/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC2.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"UAC2Ammo: 25"
+				"UAC2Ammo: 20"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_UAC2",
-    "Capacity": 25,
+    "Capacity": 20,
     "Description": {
         "Cost": 20000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC20.json
+++ b/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC20.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"UAC20Ammo: 2"
+				"UAC20Ammo: 4"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_AC20",
-    "Capacity": 5,
+    "Capacity": 4,
     "Description": {
         "Cost": 80000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,

--- a/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC5.json
+++ b/CustomAmmoCategories/UltraAC/Ammo_AmmunitionBox_Ultra_Protected_AC5.json
@@ -12,7 +12,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Protected: 75%",
-				"UAC5Ammo: 15"
+				"UAC5Ammo: 12"
             ]
         },
         "InventorySorter": {
@@ -20,7 +20,7 @@
         }
     },
     "AmmoID": "Ammunition_UAC5",
-    "Capacity": 15,
+    "Capacity": 12,
     "Description": {
         "Cost": 40000,
         "Rarity": 5,
@@ -40,7 +40,7 @@
     "PrefabIdentifier": "",
     "BattleValue": 0,
     "InventorySize": 1,
-    "Tonnage": 1.25,
+    "Tonnage": 1,
     "AllowedLocations": "All",
     "DisallowedLocations": "All",
     "CriticalComponent": false,


### PR DESCRIPTION
My impression is that these are seldom used, and I think the main reason is that the extra quarter ton makes them trickier to fit onto designs. Both for us and for players. Proposal: Reduce weight 20% to bring it to 1 ton even, and reduce capacity 20% to match.