### PR TITLE
Partisan

### DIFF
--- a/RogueTanks/Readme.txt
+++ b/RogueTanks/Readme.txt
@@ -35,6 +35,10 @@ unit_hunter,
 
 Changelog:
 
+6.9.4 - 4/20/2019
+
+Added four Partisan variants using Colo's model
+
 6.9.0 - 4/15 -> 4/17/2019
 
 Oro to Colo's Oro model,

--- a/RogueTanks/mod.json
+++ b/RogueTanks/mod.json
@@ -1,7 +1,7 @@
 {
     "Name": "RogueTanks",
     "Enabled": true,
-    "Version": "6.9.0",
+    "Version": "6.9.4",
     "Description": "The Tanks of Roguetech",
     "Author": "Cargo Vroom and LadyAlekto with special thanks to Justin Kase and Colobos",
     "Website": "",

--- a/RogueTanks/vehicle/assault/vehicledef_PARTISAN.json
+++ b/RogueTanks/vehicle/assault/vehicledef_PARTISAN.json
@@ -1,0 +1,177 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "vehicledef_PARTISAN",
+      "Name": "Partisan Heavy Tank",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 4,
+      "Purchasable": false
+   },
+   "ChassisID": "vehiclechassisdef_PARTISAN",
+   "VehicleTags": {
+      "items": [
+         "unit_vehicle",
+         "unit_assault",
+         "unit_tracks",
+         "unit_release",
+         "unit_lance_support",
+         "unit_generic",
+         "unit_bracket_med",
+         "betrayers",
+         "comstar",
+         "davion",
+         "ives",
+         "kurita",
+         "liao",
+         "marik",
+         "rasalhague",
+         "steiner",
+         "aurigandirectorate",
+         "auriganpirates",
+         "auriganrestoration",
+         "axumite",
+         "castile",
+         "chainelane",
+         "circinus",
+         "delphi",
+         "elysia",
+         "hanse",
+         "illyrian",
+         "jarnfolk",
+         "locals",
+         "LocalsBrockwayRefugees",
+         "lothian",
+         "marian",
+         "magistracyofcanopus",
+         "magistracycentrella",
+         "oberon",
+         "outworld",
+         "SelfEmployed",
+         "taurianconcordat",
+         "tortuga",
+         "valkyrate",
+         "auriganmercenaries",
+         "mercenaryreviewboard",
+         "MajestyMetals",
+         "Marauders",
+         "MasonsMarauders",
+         "RazorbackMercs",
+         "HostileMercenaries",
+         "KellHounds",
+         "SteelBeast",
+         "FlakJackals"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "Locations": [
+      {
+         "Location": "Front",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Left",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Right",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Rear",
+         "CurrentArmor": 80,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 80,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Turret",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      }
+   ],
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_1-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_1-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_1-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_1-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Front",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Front",
+         "HardpointSlot": 1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_Half",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "MountedLocation": "Rear",
+         "ComponentDefID": "emod_engineslots_ICE_center",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      }
+   ]
+}

--- a/RogueTanks/vehicle/assault/vehicledef_PARTISAN_AC2.json
+++ b/RogueTanks/vehicle/assault/vehicledef_PARTISAN_AC2.json
@@ -1,0 +1,181 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "vehicledef_PARTISAN_AC2",
+      "Name": "Partisan (AC2)",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 4,
+      "Purchasable": false
+   },
+   "ChassisID": "vehiclechassisdef_PARTISAN_AC2",
+   "VehicleTags": {
+      "items": [
+         "unit_vehicle",
+         "unit_assault",
+         "unit_tracks",
+         "unit_release",
+         "unit_lance_support",
+         "unit_generic",
+         "unit_bracket_med",
+         "betrayers",
+         "comstar",
+         "davion",
+         "ives",
+         "kurita",
+         "liao",
+         "marik",
+         "rasalhague",
+         "steiner",
+         "auriganmercenaries",
+         "mercenaryreviewboard",
+         "MajestyMetals",
+         "Marauders",
+         "MasonsMarauders",
+         "RazorbackMercs",
+         "HostileMercenaries",
+         "KellHounds",
+         "SteelBeast",
+         "FlakJackals",
+         "locals",
+         "LocalsBrockwayRefugees",
+         "SelfEmployed",
+         "marian",
+         "taurianconcordat",
+         "magistracyofcanopus",
+         "magistracycentrella"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "Locations": [
+      {
+         "Location": "Front",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Left",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Right",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Rear",
+         "CurrentArmor": 80,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 80,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Turret",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      }
+   ],
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC2_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC2_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC2_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC2_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 4,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Front",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Front",
+         "HardpointSlot": 1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Incendiary_AC2",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Precision_AC2",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Protected_AC2",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Protected_AC2",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Protected_AC2",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "MountedLocation": "Rear",
+         "ComponentDefID": "emod_engineslots_ICE_center",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      }
+   ]
+}

--- a/RogueTanks/vehicle/assault/vehicledef_PARTISAN_C3.json
+++ b/RogueTanks/vehicle/assault/vehicledef_PARTISAN_C3.json
@@ -1,0 +1,129 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "vehicledef_PARTISAN_C3",
+      "Name": "Partisan (C3)",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 4,
+      "Purchasable": false
+   },
+   "ChassisID": "vehiclechassisdef_PARTISAN_C3",
+   "VehicleTags": {
+      "items": [
+         "unit_vehicle",
+         "unit_assault",
+         "unit_tracks",
+         "unit_release",
+         "unit_lance_support",
+         "unit_advanced",
+         "unit_bracket_med",
+         "davion",
+         "steiner"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "Locations": [
+      {
+         "Location": "Front",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Left",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Right",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Rear",
+         "CurrentArmor": 80,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 80,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Turret",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      }
+   ],
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_Autocannon_AC5_2-Imperator",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Precision_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Rear",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Precision_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Rear",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_C3",
+         "ComponentDefType": "Upgrade",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "emod_case",
+         "ComponentDefType": "Upgrade",
+         "MountedLocation": "Rear",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "MountedLocation": "Rear",
+         "ComponentDefID": "emod_engineslots_ICE_center",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      }
+   ]
+}

--- a/RogueTanks/vehicle/assault/vehicledef_PARTISAN_LRM.json
+++ b/RogueTanks/vehicle/assault/vehicledef_PARTISAN_LRM.json
@@ -1,0 +1,188 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "vehicledef_PARTISAN_LRM",
+      "Name": "Partisan (LRM)",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 4,
+      "Purchasable": false
+   },
+   "ChassisID": "vehiclechassisdef_PARTISAN_LRM",
+   "VehicleTags": {
+      "items": [
+         "unit_vehicle",
+         "unit_assault",
+         "unit_tracks",
+         "unit_release",
+         "unit_lance_support",
+         "unit_generic",
+         "unit_bracket_med",
+         "betrayers",
+         "comstar",
+         "davion",
+         "ives",
+         "kurita",
+         "liao",
+         "marik",
+         "rasalhague",
+         "steiner",
+         "auriganmercenaries",
+         "mercenaryreviewboard",
+         "MajestyMetals",
+         "Marauders",
+         "MasonsMarauders",
+         "RazorbackMercs",
+         "HostileMercenaries",
+         "KellHounds",
+         "SteelBeast",
+         "FlakJackals",
+         "locals",
+         "LocalsBrockwayRefugees",
+         "SelfEmployed",
+         "marian",
+         "taurianconcordat",
+         "magistracyofcanopus",
+         "magistracycentrella"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "Locations": [
+      {
+         "Location": "Front",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Left",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Right",
+         "CurrentArmor": 90,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 90,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Rear",
+         "CurrentArmor": 80,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 80,
+         "DamageLevel": "Functional"
+      },
+      {
+         "Location": "Turret",
+         "CurrentArmor": 110,
+         "CurrentInternalStructure": 40,
+         "AssignedArmor": 110,
+         "DamageLevel": "Functional"
+      }
+   ],
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_LRM_LRM15_1-Delta",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_LRM_LRM15_1-Delta",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_LRM_LRM15_1-Delta",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_LRM_LRM15_1-Delta",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Turret",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Front",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+         "ComponentDefType": "Weapon",
+         "MountedLocation": "Front",
+         "HardpointSlot": 1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Deadfire_LRM",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Swarm_LRM",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Swarm_LRM",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+         "ComponentDefType": "AmmunitionBox",
+         "MountedLocation": "Front",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "MountedLocation": "Rear",
+         "ComponentDefID": "emod_engineslots_ICE_center",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      }
+   ]
+}

--- a/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN.json
+++ b/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN.json
@@ -1,0 +1,134 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_PARTISAN",
+		"Name": "Partisan Heavy Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 4,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_assault_tracked",
+	"HardpointDataDefID": "hardpointdatadef_partisan",
+	"PrefabIdentifier": "chrprfvhcl_partisanbase",
+	"PrefabBase": "partisan",
+	"Tonnage": 80,
+	"weightClass": "ASSAULT",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		}
+	]
+}

--- a/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN_AC2.json
+++ b/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN_AC2.json
@@ -1,0 +1,138 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_PARTISAN_AC2",
+		"Name": "Partisan Heavy Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 4,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_assault_tracked",
+	"HardpointDataDefID": "hardpointdatadef_partisan",
+	"PrefabIdentifier": "chrprfvhcl_partisanbase",
+	"PrefabBase": "partisan",
+	"Tonnage": 80,
+	"weightClass": "ASSAULT",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		}
+	]
+}

--- a/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN_C3.json
+++ b/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN_C3.json
@@ -1,0 +1,134 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_PARTISAN_C3",
+		"Name": "Partisan Heavy Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 4,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_assault_tracked",
+	"HardpointDataDefID": "hardpointdatadef_partisan",
+	"PrefabIdentifier": "chrprfvhcl_partisanbase",
+	"PrefabBase": "partisan",
+	"Tonnage": 80,
+	"weightClass": "ASSAULT",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		}
+	]
+}

--- a/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN_LRM.json
+++ b/RogueTanks/vehicleChassis/vehiclechassisdef_PARTISAN_LRM.json
@@ -1,0 +1,134 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_PARTISAN_LRM",
+		"Name": "Partisan Heavy Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 4,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_assault_tracked",
+	"HardpointDataDefID": "hardpointdatadef_partisan",
+	"PrefabIdentifier": "chrprfvhcl_partisanbase",
+	"PrefabBase": "partisan",
+	"Tonnage": 80,
+	"weightClass": "ASSAULT",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 4
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 40
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 110,
+			"InternalStructure": 40
+		}
+	]
+}


### PR DESCRIPTION
Partisan fire support tanks. The ones with AC have AOE brand because they are pre-lbx AA flak units.