### PR TITLE
Ebon Jag Description Fix

### DIFF
--- a/GPMechDefs/mech/mechdef_ebonjaguar_B.json
+++ b/GPMechDefs/mech/mechdef_ebonjaguar_B.json
@@ -41,7 +41,7 @@
     "UIName": "Ebon Jaguar",
     "Id": "mechdef_ebonjaguar_B",
     "Name": "Ebon Jaguar",
-    "Details": "The Mad Dog’s most distinctive feature is its side torso and arm pods, which are practically full modules by themselves, suggesting that the mech was conceived as a long-range support unit. The torso modules, angled high, are ideal for missiles while the arms serve as extended turrets suited for direct-fire weaponry.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
+    "Details": "Once fielded in great numbers by the Smoke Jaguars, the Ebon Jaguar has proliferated to many of Kerensky's Clans, though some, like the Wolves, Jade Falcons and Coyotes, continue to field Hellbringers instead.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
     "Icon": "uixTxrIcon_ebonjaguar"
   },
   "simGameMechPartCost": 1210000,

--- a/GPMechDefs/mech/mechdef_ebonjaguar_C.json
+++ b/GPMechDefs/mech/mechdef_ebonjaguar_C.json
@@ -40,7 +40,7 @@
     "UIName": "Ebon Jaguar",
     "Id": "mechdef_ebonjaguar_C",
     "Name": "Ebon Jaguar",
-    "Details": "The Mad Dog’s most distinctive feature is its side torso and arm pods, which are practically full modules by themselves, suggesting that the mech was conceived as a long-range support unit. The torso modules, angled high, are ideal for missiles while the arms serve as extended turrets suited for direct-fire weaponry.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
+    "Details": "Once fielded in great numbers by the Smoke Jaguars, the Ebon Jaguar has proliferated to many of Kerensky's Clans, though some, like the Wolves, Jade Falcons and Coyotes, continue to field Hellbringers instead.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
     "Icon": "uixTxrIcon_ebonjaguar"
   },
   "simGameMechPartCost": 1210000,

--- a/GPMechDefs/mech/mechdef_ebonjaguar_D.json
+++ b/GPMechDefs/mech/mechdef_ebonjaguar_D.json
@@ -40,7 +40,7 @@
     "UIName": "Ebon Jaguar",
     "Id": "mechdef_ebonjaguar_D",
     "Name": "Ebon Jaguar",
-    "Details": "The Mad Dog’s most distinctive feature is its side torso and arm pods, which are practically full modules by themselves, suggesting that the mech was conceived as a long-range support unit. The torso modules, angled high, are ideal for missiles while the arms serve as extended turrets suited for direct-fire weaponry.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
+    "Details": "Once fielded in great numbers by the Smoke Jaguars, the Ebon Jaguar has proliferated to many of Kerensky's Clans, though some, like the Wolves, Jade Falcons and Coyotes, continue to field Hellbringers instead.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
     "Icon": "uixTxrIcon_ebonjaguar"
   },
   "simGameMechPartCost": 1210000,

--- a/GPMechDefs/mech/mechdef_ebonjaguar_H.json
+++ b/GPMechDefs/mech/mechdef_ebonjaguar_H.json
@@ -40,7 +40,7 @@
     "UIName": "Ebon Jaguar",
     "Id": "mechdef_ebonjaguar_H",
     "Name": "Ebon Jaguar",
-    "Details": "The Mad Dog’s most distinctive feature is its side torso and arm pods, which are practically full modules by themselves, suggesting that the mech was conceived as a long-range support unit. The torso modules, angled high, are ideal for missiles while the arms serve as extended turrets suited for direct-fire weaponry.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
+    "Details": "Once fielded in great numbers by the Smoke Jaguars, the Ebon Jaguar has proliferated to many of Kerensky's Clans, though some, like the Wolves, Jade Falcons and Coyotes, continue to field Hellbringers instead.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
     "Icon": "uixTxrIcon_ebonjaguar"
   },
   "simGameMechPartCost": 1210000,

--- a/GPMechDefs/mech/mechdef_ebonjaguar_PRIME.json
+++ b/GPMechDefs/mech/mechdef_ebonjaguar_PRIME.json
@@ -40,7 +40,7 @@
     "UIName": "Ebon Jaguar",
     "Id": "mechdef_ebonjaguar_PRIME",
     "Name": "Ebon Jaguar",
-    "Details": "The Mad Dog’s most distinctive feature is its side torso and arm pods, which are practically full modules by themselves, suggesting that the mech was conceived as a long-range support unit. The torso modules, angled high, are ideal for missiles while the arms serve as extended turrets suited for direct-fire weaponry.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
+    "Details": "Once fielded in great numbers by the Smoke Jaguars, the Ebon Jaguar has proliferated to many of Kerensky's Clans, though some, like the Wolves, Jade Falcons and Coyotes, continue to field Hellbringers instead.   <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
     "Icon": "uixTxrIcon_ebonjaguar"
   },
   "simGameMechPartCost": 1210000,

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_ENHANCED.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_ENHANCED.json
@@ -155,7 +155,7 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Ammo_AmmunitionBox_FTL_LRM",
+                  "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
                   "ComponentDefType": "AmmunitionBox",
                   "MountedLocation": "Front",
                   "HardpointSlot": -1,

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_EXTENDED.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_LRM_EXTENDED.json
@@ -169,7 +169,7 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+                  "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
                   "ComponentDefType": "AmmunitionBox",
                   "MountedLocation": "Rear",
                   "HardpointSlot": -1,

--- a/RogueTanks/vehicle/carrier/vehicledef_CARRIER_MORTAR.json
+++ b/RogueTanks/vehicle/carrier/vehicledef_CARRIER_MORTAR.json
@@ -156,7 +156,7 @@
                   "DamageLevel": "Functional"
             },
             {
-                  "ComponentDefID": "Ammo_AmmunitionBox_Generic_Mortar",
+                  "ComponentDefID": "Ammo_AmmunitionBox_Fascam_Mortar",
                   "ComponentDefType": "AmmunitionBox",
                   "MountedLocation": "Front",
                   "HardpointSlot": -1,


### PR DESCRIPTION
Descriptions in mechdef had info about Mad Dogs. I have replaced it with text copied from the Ebon Jag chassisdef.