### PR TITLE
First iteration of new weapon Trait descriptions

### DIFF
--- a/MechEngineer/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/MechEngineer/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -46,7 +46,7 @@
 			"Bonus": "SawedOffArtillery",
 			"Short": "SawedOff Artillery",
 			"Long": "Sawed Off Artillery",
-			"Full": "Short-barrelled artillery piece trading range and accuracy for weight and size"
+			"Full": "Short-barrelled Artillery: reduced weight; reduced size; reduced range; reduced accuracy"
 		},
 		{
 			"Bonus": "DefianceAC",

--- a/MechEngineer/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/MechEngineer/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -4,235 +4,235 @@
 			"Bonus": "MineClearanceBoom",
 			"Short": "Mine Clear",
 			"Long": "Mine Clearance Radius",
-			"Full": "High Explosive blast removes mines within a {0} hex radius of impact."
+			"Full": "High Explosive removes mines within a {0} hex radius of impact"
 		},
 		{
 			"Bonus": "Thunder",
 			"Short": "Thunder Munition",
 			"Long": "Thunder Munition",
-			"Full": "Thunder or FASCAM munitions will create a minefield wherever a missile hit the ground"
+			"Full": "Thunder/FASCAM munitions will lay mines wherever a missile hits the ground"
 		},
 		{
 			"Bonus": "ThunderMines",
 			"Short": "{0} Mines",
 			"Long": "{0} Mines",
-			"Full": "{0} Mines per Projectile"
+			"Full": "{0} Mines per projectile"
 		},
 		{
 			"Bonus": "ThunderRadius",
 			"Short": "{0} Radius",
 			"Long": "{0} Radius",
-			"Full": "{0} Mine Trigger Radius"
+			"Full": "{0} Mine trigger radius"
 		},
 		{
 			"Bonus": "ThunderChance",
 			"Short": "{0} Chance",
 			"Long": "{0} Chance",
-			"Full": "{0} Mine Trigger Chance"
+			"Full": "{0} Mine trigger chance"
 		},
 		{
 			"Bonus": "ThunderDamage",
 			"Short": "{0} Damage",
 			"Long": "{0} Damage",
-			"Full": "{0} Mine Damage"
+			"Full": "{0} Mine damage"
 		},
 		{
 			"Bonus": "ThunderHeatDamage",
 			"Short": "{0} Heat Dmg.",
 			"Long": "{0} Heat Damage",
-			"Full": "{0} Mine Heat Damage"
+			"Full": "{0} Mine heat damage"
 		},
 		{
 			"Bonus": "SawedOffArtillery",
 			"Short": "SawedOff Artillery",
 			"Long": "Sawed Off Artillery",
-			"Full": "Short Barrelled Artillery Piece trading Range and Accuracy for Weight and Size"
+			"Full": "Short-barrelled artillery piece trading range and accuracy for weight and size"
 		},
 		{
 			"Bonus": "DefianceAC",
 			"Short": "Defiance",
 			"Long": "Defiance",
-			"Full": "Defiance AutoCannons trade Heat Management for Improved Range"
+			"Full": "Defiance AC: increased range; increased heat"
 		},
 		{
 			"Bonus": "FederatedAC",
 			"Short": "Federated",
 			"Long": "Federated",
-			"Full": "Federated AutoCannons are less likely to Jam but have slightly reduced Damage"
+			"Full": "Federated AC: reduced jam rate; slightly reduced damage"
 		},
 		{
 			"Bonus": "FederatedAC2",
 			"Short": "Federated",
 			"Long": "Federated",
-			"Full": "Federated AutoCannons/2 are more likely to Crit but have slightly reduced Damage"
+			"Full": "Federated AC/2: increased crit chance; slightly reduced damage"
 		},
 		{
 			"Bonus": "KaliYamaAC",
 			"Short": "KaliYama",
 			"Long": "Kali Yama",
-			"Full": "Kali Yama AutoCannons have increased Damage but increased Recoil and Heat Generation"
+			"Full": "Kali Yama AC: increased damage; increased recoil; increased heat"
 		},
 		{
 			"Bonus": "ImperatorAC",
 			"Short": "Imperator",
 			"Long": "Imperator",
-			"Full": "Imperator AutoCannons fire High Explosive Shells dealing a small Area of Effect Damage"
+			"Full": "Imperator AC: minor area-of-effect damage"
 		},
 		{
 			"Bonus": "NorseGauss",
 			"Short": "NorseStorm",
 			"Long": "NorseStorm",
-			"Full": "Norse Storm Gauss Rifles fire High Explosive Shells dealing a small Area of Effect Damage"
+			"Full": "Norse Storm Gauss Rifle: minor area-of-effect damage"
 		},
 		{
 			"Bonus": "DefianceGauss",
 			"Short": "Defiance",
 			"Long": "Defiance",
-			"Full": "Defiance Gauss Rifle trade Heat Management for Improved Range"
+			"Full": "Defiance Gauss Rifle: increased range; increased heat"
 		},
 		{
 			"Bonus": "BlackwellGauss",
 			"Short": "Blackwell",
 			"Long": "Blackwell",
-			"Full": "Blackwell Gauss Rifles have superior Accuracy but may Jam"
+			"Full": "Blackwell Gauss Rifle: increased accuracy; increased jam rate"
 		},
 		{
 			"Bonus": "MydronAC",
 			"Short": "Mydron",
 			"Long": "Mydron",
-			"Full": "Mydron AutoCannons fire Hyper Velocity Shells with increased Accuracy at cost of Recoil and Heat"
+			"Full": "Mydron AC: increased accuracy; increased recoil; increased heat"
 		},
 		{
 			"Bonus": "DeltaLRM",
 			"Short": "Delta",
 			"Long": "Delta",
-			"Full": "Delta LRM are less likely to be intercepted by AMS but have a bit of 'Recoil'"
+			"Full": "Delta LRM: resistance to AMS; has recoil"
 		},
 		{
 			"Bonus": "LongFireLRM",
 			"Short": "LongFire",
 			"Long": "LongFire",
-			"Full": "Longfire LRM trade Heat efficiency for Superior Range"
+			"Full": "Longfire LRM: increased range; increased heat"
 		},
 		{
 			"Bonus": "TelosLRM",
 			"Short": "Telos",
 			"Long": "Telos",
-			"Full": "Telos LRM are more Accurate but more likely to be intercepted by AMS"
+			"Full": "Telos LRM: increased accuracy; more vulnerable to AMS"
 		},
 		{
 			"Bonus": "ZeusLRM",
 			"Short": "Zeus",
 			"Long": "Zeus",
-			"Full": "Zeus LRM have improved Damage but have a chance to Jam"
+			"Full": "Zeus LRM: increased damage; increased jam rate"
 		},
 		{
 			"Bonus": "HollySRM",
 			"Short": "Holly",
 			"Long": "Holly",
-			"Full": "Holly SRM are more Accurate but more likely to be intercepted by AMS"
+			"Full": "Holly SRM: increased accuracy; more vulnerable to AMS"
 		},
 		{
 			"Bonus": "IrianSRM",
 			"Short": "Irian",
 			"Long": "Irian",
-			"Full": "Irian SRM have reduced Accuracy but are less likely to be intercepted by AMS"
+			"Full": "Irian SRM: resistance to AMS; reduced accuracy"
 		},
 		{
 			"Bonus": "ValiantSRM",
 			"Short": "Valiant",
 			"Long": "Valiant",
-			"Full": "Valiant SRM have improved Damage but are less Heat Efficient"
+			"Full": "Valiant SRM: increased damage; increased heat"
 		},
 		{
 			"Bonus": "ExostarLaser",
 			"Short": "Exostar",
 			"Long": "Exostar",
-			"Full": "Exostar Lasers have improved Accuracy but generate more Heat"
+			"Full": "Exostar Laser: increased accuracy; increased heat"
 		},
 		{
 			"Bonus": "MaxellLaser",
 			"Short": "Maxell",
 			"Long": "Maxell",
-			"Full": "Exostar Lasers ignore 1 Evasion but generate more Heat"
+			"Full": "Exostar Laser: ignore 1 Evasion; increased heat"
 		},
 		{
 			"Bonus": "DiverseOpticsLaser",
 			"Short": "DiverseOptics",
 			"Long": "Diverse Optics",
-			"Full": "Diverse Optics Lasers have improved Range but generate more Heat"
+			"Full": "Diverse Optics Laser: increased range; increased heat"
 		},
 		{
 			"Bonus": "IntekLaser",
 			"Short": "Intek",
 			"Long": "Intek",
-			"Full": "Intek Lasers trade Range and Damage for reduced Heat generation"
+			"Full": "Intek Laser: reduced heat; reduced range; reduced damage"
 		},
 		{
 			"Bonus": "RakerLaser",
 			"Short": "Raker",
 			"Long": "Raker",
-			"Full": "Raker Lasers fires a single large beam with increased Accuracy"
+			"Full": "Raker Laser: increased accuracy; single beam"
 		},
 		{
 			"Bonus": "BrightBloomLaser",
 			"Short": "BrightBloom",
 			"Long": "BrightBloom",
-			"Full": "BrightBloom Lasers has extreme Range but has Damage Falloff"
+			"Full": "BrightBloom Laser: increased range; damage falloff"
 		},
 		{
 			"Bonus": "MagnaLaser",
 			"Short": "Magna",
 			"Long": "Magna",
-			"Full": "Magna Lasers deal superior Damage but generate more Heat"
+			"Full": "Magna Laser: increased damage; increased heat"
 		},
 		{
 			"Bonus": "BlazeFireLaser",
 			"Short": "BlazeFire",
 			"Long": "BlazeFire",
-			"Full": "BlazeFire Lasers deal superior Damage but have a chance to 'Jam'"
+			"Full": "BlazeFire Laser: increased damage; chance to jam"
 		},
 		{
 			"Bonus": "BlankenburgLaser",
 			"Short": "Blankenburg",
 			"Long": "Blankenburg",
-			"Full": "Blankenburg Lasers has vastly superior Crit Chance but its Damage fluctuates"
+			"Full": "Blankenburg Laser: increased crit chance; variable damage"
 		},
 		{
 			"Bonus": "ThunderboltLaser",
 			"Short": "Thunderbolt",
 			"Long": "Thunderbolt",
-			"Full": "Thunderbolt Lasers have reduced Weight at cost of Size"
+			"Full": "Thunderbolt Laser: reduced weight; increased size"
 		},
 		{
 			"Bonus": "CeresArmsPPC",
 			"Short": "CeresArms",
 			"Long": "Ceres Arms",
-			"Full": "Ceres Arms PPC trade Damage for improved Recharge Speed(Less Recoil)"
+			"Full": "Ceres Arms PPC: reduced recoil; reduced damage"
 		},
 		{
 			"Bonus": "DonalPPC",
 			"Short": "Donal",
 			"Long": "Donal",
-			"Full": "Donal PPC have a stronger EM field but generate more Heat"
+			"Full": "Donal PPC: increased sensor disruption on target; increased heat"
 		},
 		{
 			"Bonus": "TiegartPPC",
 			"Short": "Tiegart",
 			"Long": "Tiegart",
-			"Full": "Tiegart PPC have superior Damage but generate more Heat and have inferior Recharge Speed(More Recoil)"
+			"Full": "Tiegart PPC: increased damage; increased heat; increased recoil"
 		},
 		{
 			"Bonus": "DefiancePPC",
 			"Short": "Defiance",
 			"Long": "Defiance",
-			"Full": "Defiance PPC has no Minimum Range, Overall improved Specifications but may 'Jam'"
+			"Full": "Defiance PPC: no minimum range; improved specifications; chance to jam"
 		},
 		{
 			"Bonus": "MagnaPPC",
 			"Short": "Magna",
 			"Long": "Magna",
-			"Full": "Magna PPC has reduced Weight and Size at cost of Recharge Speed(Recoil)"
+			"Full": "Magna PPC: reduced weight; reduced size; increased recoil"
 		},
 		{
 			"Bonus": "EmergencyCoolant",


### PR DESCRIPTION
First iteration for approval purposes.

Goal: Shorten weapon trait descriptions as much as possible while keeping essential information. Make weapon trait descriptions consistent (replace all mentions of 'heat efficiency' or 'increased heat' with simpler terms that include an indicator of direction (reduced/increased) and the trait (range/heat/damage))

Rationale: Bonus traits are a source of specifications for each item. Players are generally reading these traits solely for information in the process of buying/selling parts or fitting a 'mech and therefore, want information to be as simple an accessible as possible. 

Previous trait descriptions were inconsistent - sometimes they listed a drawback first, sometimes they listed a benefit first. They also used varying terminology, such as "trades off x for y," "has increased x, but less y" etc. These descriptions were inconsistent, making memorising a pattern impossible and they added a large number of extra words.

My proposed change is to create an internally consistent, shorter and simplified system that reduces confusion.

Changes as follows: Bonus traits are now listed in the following format:

[Manufacturer][Weapon Type]: [benefits (e.g. increased damage)]; [neutral/situational effects (single beam)]; [drawbacks (e.g. reduced range)]

This system is also grammatically consistent with itself. Manufacturers and Weapon Type are capitalised as they are the title. Traits are introduced with a colon. Traits are in lower-case for easy reading. Traits are separated by semi-colons. No fullstops, as they are not complete sentences. 

I have also removed mentions of manufacturer lore ammunition types like "Imperator AutoCannons fire High Explosive Shells" because they may cause confusion, if a player actually starts thinking this weapon requires unique ammunition. If I am incorrect and there ARE such things are HE AC ammunition or HE Gauss ammunition that can ONLY be used by that weapon, then please revert this change, as this is vital information.