### PR TITLE
lance fixes

### DIFF
--- a/RogueContracts/lance/MechBattle/lancedef_mech_d6_dynamic_battle.json
+++ b/RogueContracts/lance/MechBattle/lancedef_mech_d6_dynamic_battle.json
@@ -81,8 +81,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d6",
-                    "pilot_npc_med"
+                    "pilot_npc_d6"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -115,8 +114,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d6",
-                    "pilot_npc_low"
+                    "pilot_npc_d6"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -150,8 +148,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d6",
-                    "pilot_npc_low"
+                    "pilot_npc_d6"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechBattle/lancedef_mech_d7_dynamic_battle.json
+++ b/RogueContracts/lance/MechBattle/lancedef_mech_d7_dynamic_battle.json
@@ -81,8 +81,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d7",
-                    "pilot_npc_med"
+                    "pilot_npc_d7"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -116,8 +115,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d7",
-                    "pilot_npc_low"
+                    "pilot_npc_d7"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -150,8 +148,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d7",
-                    "pilot_npc_low"
+                    "pilot_npc_d7"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechBattle/lancedef_mech_d8_dynamic_battle.json
+++ b/RogueContracts/lance/MechBattle/lancedef_mech_d8_dynamic_battle.json
@@ -81,8 +81,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d8",
-                    "pilot_npc_low"
+                    "pilot_npc_d8"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -116,8 +115,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d8",
-                    "pilot_npc_low"
+                    "pilot_npc_d8"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -144,15 +142,14 @@
                 "items": [
                     "unit_noncombatant",
                     "unit_legendary",
-                    "unit_bracket_low"
+                    "unit_bracket_low",
+                    "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d8",
-                    "pilot_npc_low",
-                    "unit_assault"
+                    "pilot_npc_d8"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechBattle/lancedef_mech_d9_dynamic_battle.json
+++ b/RogueContracts/lance/MechBattle/lancedef_mech_d9_dynamic_battle.json
@@ -81,8 +81,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d9",
-                    "pilot_npc_med"
+                    "pilot_npc_d9"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -117,8 +116,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d9",
-                    "pilot_npc_low"
+                    "pilot_npc_d9"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -151,8 +149,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d9",
-                    "pilot_npc_low"
+                    "pilot_npc_d9"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechCavalry/lancedef_mech_d10_dynamic_cavalry.json
+++ b/RogueContracts/lance/MechCavalry/lancedef_mech_d10_dynamic_cavalry.json
@@ -82,8 +82,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d10",
-                    "pilot_npc_med"
+                    "pilot_npc_d10"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -118,8 +117,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d10",
-                    "pilot_npc_low"
+                    "pilot_npc_d10"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -155,8 +153,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d10",
-                    "pilot_npc_low"
+                    "pilot_npc_d10"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechCavalry/lancedef_mech_d8_dynamic_cavalry.json
+++ b/RogueContracts/lance/MechCavalry/lancedef_mech_d8_dynamic_cavalry.json
@@ -119,8 +119,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d8",
-                    "pilot_npc_low"
+                    "pilot_npc_d8"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -155,8 +154,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d8",
-                    "pilot_npc_low"
+                    "pilot_npc_d8"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechCavalry/lancedef_mech_d9_dynamic_cavalry.json
+++ b/RogueContracts/lance/MechCavalry/lancedef_mech_d9_dynamic_cavalry.json
@@ -83,8 +83,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d9",
-                    "pilot_npc_med"
+                    "pilot_npc_d9"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -120,8 +119,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d9",
-                    "pilot_npc_low"
+                    "pilot_npc_d9"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -155,8 +153,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d9",
-                    "pilot_npc_low"
+                    "pilot_npc_d9"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d10_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d10_dynamic_convoy.json
@@ -47,7 +47,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d10",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -84,7 +84,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d10",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d1_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d1_dynamic_convoy.json
@@ -49,7 +49,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d1",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -90,7 +90,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d1",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d2_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d2_dynamic_convoy.json
@@ -48,7 +48,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d2",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -88,7 +88,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d2",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d3_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d3_dynamic_convoy.json
@@ -47,7 +47,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d3",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -86,7 +86,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d3",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d4_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d4_dynamic_convoy.json
@@ -46,7 +46,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d4",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -84,7 +84,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d4",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d5_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d5_dynamic_convoy.json
@@ -47,7 +47,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d5",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -84,7 +84,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d5",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -122,7 +122,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d5",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d6_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d6_dynamic_convoy.json
@@ -47,7 +47,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d6",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -85,7 +85,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d6",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d7_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d7_dynamic_convoy.json
@@ -48,7 +48,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d7",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -85,7 +85,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d7",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d8_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d8_dynamic_convoy.json
@@ -47,7 +47,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d8",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -151,15 +151,15 @@
                     "unit_noconvoy",
                     "unit_noncombatant",
                     "unit_legendary",
-                    "unit_bracket_low"
+                    "unit_bracket_low",
+                    "unit_assault"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d8",
-                    "pilot_npc_low",
-                    "unit_assault"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechConvoy/lancedef_mech_d9_dynamic_convoy.json
+++ b/RogueContracts/lance/MechConvoy/lancedef_mech_d9_dynamic_convoy.json
@@ -47,7 +47,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d9",
-                    "pilot_npc_high"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -85,7 +85,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d9",
-                    "pilot_npc_med"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechGenericBattle/lancedef_mech_d11_generic_battle.json
+++ b/RogueContracts/lance/MechGenericBattle/lancedef_mech_d11_generic_battle.json
@@ -111,7 +111,7 @@
             "unitTagSet": {
                 "items": [
                     "unit_mech",
-                    "{CUR_TEAM.faction}",
+                    "{CUR_TEAM.faction}"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -150,7 +150,7 @@
             "unitTagSet": {
                 "items": [
                     "unit_mech",
-                    "{CUR_TEAM.faction}",
+                    "{CUR_TEAM.faction}"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueContracts/lance/MechGenericBattle/lancedef_mech_d12_generic_battle.json
+++ b/RogueContracts/lance/MechGenericBattle/lancedef_mech_d12_generic_battle.json
@@ -71,7 +71,7 @@
             "unitTagSet": {
                 "items": [
                     "unit_mech",
-                    "{CUR_TEAM.faction}",
+                    "{CUR_TEAM.faction}"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueContracts/lance/MechGenericBattle/lancedef_mech_d13_generic_battle.json
+++ b/RogueContracts/lance/MechGenericBattle/lancedef_mech_d13_generic_battle.json
@@ -164,7 +164,6 @@
 					"unit_legendary",
 					"unit_bracked_low",
                     "unit_bracket_med",
-                    "unit_bracket_high",
                     "unit_assault",
                     "unit_heavy",
 					"unit_light",

--- a/RogueContracts/lance/MechGenericBattle/lancedef_mech_d6_generic_battle.json
+++ b/RogueContracts/lance/MechGenericBattle/lancedef_mech_d6_generic_battle.json
@@ -82,7 +82,7 @@
                     "unit_bracket_high",
                     "unit_assault",
                     "unit_heavy",
-					"unit_light",
+					"unit_light"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueContracts/lance/MechGenericBattle/lancedef_mech_d8_generic_battle.json
+++ b/RogueContracts/lance/MechGenericBattle/lancedef_mech_d8_generic_battle.json
@@ -41,7 +41,6 @@
                     "unit_advanced",
 					"unit_legendary",
                     "unit_bracket_med",
-                    "unit_bracket_high",
                     "unit_heavy",
 					"unit_light",
 					"unit_medium"
@@ -81,7 +80,6 @@
                     "unit_advanced",
 					"unit_legendary",
                     "unit_bracket_med",
-                    "unit_bracket_high",
 					"unit_light",
 					"unit_medium"
                 ],
@@ -121,7 +119,7 @@
                     "unit_bracket_high",
                     "unit_assault",
                     "unit_heavy",
-					"unit_light",
+					"unit_light"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },
@@ -167,8 +165,7 @@
             "pilotTagSet": {
                 "items": [
                     "pilot_npc_d8",
-                    "pilot_npc_low",
-                    "unit_assault"
+                    "pilot_npc_low"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechRecon/lancedef_mech_d1_dynamic_recon.json
+++ b/RogueContracts/lance/MechRecon/lancedef_mech_d1_dynamic_recon.json
@@ -89,8 +89,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d1",
-                    "pilot_npc_med"
+                    "pilot_npc_d1"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -129,8 +128,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d1",
-                    "pilot_npc_low"
+                    "pilot_npc_d1"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -167,8 +165,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d1",
-                    "pilot_npc_low"
+                    "pilot_npc_d1"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechRecon/lancedef_mech_d1_dynamic_recon_small.json
+++ b/RogueContracts/lance/MechRecon/lancedef_mech_d1_dynamic_recon_small.json
@@ -90,8 +90,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d1",
-                    "pilot_npc_med"
+                    "pilot_npc_d1"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -130,8 +129,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d1",
-                    "pilot_npc_low"
+                    "pilot_npc_d1"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechRecon/lancedef_mech_d2_dynamic_recon.json
+++ b/RogueContracts/lance/MechRecon/lancedef_mech_d2_dynamic_recon.json
@@ -88,8 +88,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d2",
-                    "pilot_npc_med"
+                    "pilot_npc_d2"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -127,8 +126,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d2",
-                    "pilot_npc_low"
+                    "pilot_npc_d2"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -165,8 +163,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d2",
-                    "pilot_npc_low"
+                    "pilot_npc_d2"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechRecon/lancedef_mech_d2_dynamic_recon_small.json
+++ b/RogueContracts/lance/MechRecon/lancedef_mech_d2_dynamic_recon_small.json
@@ -88,8 +88,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d2",
-                    "pilot_npc_med"
+                    "pilot_npc_d2"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -127,8 +126,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d2",
-                    "pilot_npc_low"
+                    "pilot_npc_d2"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechRecon/lancedef_mech_d3_dynamic_recon.json
+++ b/RogueContracts/lance/MechRecon/lancedef_mech_d3_dynamic_recon.json
@@ -85,8 +85,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d3",
-                    "pilot_npc_med"
+                    "pilot_npc_d3"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -124,8 +123,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d3",
-                    "pilot_npc_low"
+                    "pilot_npc_d3"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -162,8 +160,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d3",
-                    "pilot_npc_low"
+                    "pilot_npc_d3"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechRecon/lancedef_mech_d4_dynamic_recon.json
+++ b/RogueContracts/lance/MechRecon/lancedef_mech_d4_dynamic_recon.json
@@ -82,8 +82,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d4",
-                    "pilot_npc_med"
+                    "pilot_npc_d4"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -120,8 +119,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d4",
-                    "pilot_npc_low"
+                    "pilot_npc_d4"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -158,8 +156,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d4",
-                    "pilot_npc_low"
+                    "pilot_npc_d4"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/lance/MechRecon/lancedef_mech_d5_dynamic_recon.json
+++ b/RogueContracts/lance/MechRecon/lancedef_mech_d5_dynamic_recon.json
@@ -82,8 +82,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d5",
-                    "pilot_npc_med"
+                    "pilot_npc_d5"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -119,8 +118,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d5",
-                    "pilot_npc_low"
+                    "pilot_npc_d5"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },
@@ -156,8 +154,7 @@
             },
             "pilotTagSet": {
                 "items": [
-                    "pilot_npc_d5",
-                    "pilot_npc_low"
+                    "pilot_npc_d5"
                 ],
                 "tagSetSourceFile": "Tags/PilotTags"
             },

--- a/RogueContracts/mod.json
+++ b/RogueContracts/mod.json
@@ -1,7 +1,7 @@
 {
 	"Name": "RogueTech Lance tweaks",
 	"Enabled": true,
-	"Version": "3.2.1",
+	"Version": "3.2.4",
 	"Description": "Contains tweaks to contracts and lances and new content, by LA and Cargo_Vroom",
 	"Author": "LadyAlekto and Cargo_Vroom",
 	"Website": "",

--- a/RogueContracts/notes.txt
+++ b/RogueContracts/notes.txt
@@ -69,6 +69,12 @@ Make MixedRecon, VehicleFire, VehicleRecon
 
 Changelog:
 
+3.2.4
+
+Gave mech-convoy lances all low teir pilots for skill level, because in context they represent rookie or fatigued pilots.
+Finished some 3.2.1 things I'd overlooked.
+Fixed some contradictory tagging bugs in MechGenericBattle
+
 3.2.1 - 4/28/2019
 
 Removed restrictions on Generic units spawning in higher skulls, except for Difficulty 10.


### PR DESCRIPTION
Gave mech-convoy lances all low teir pilots for skill level, because in context they represent rookie or fatigued pilots.
Finished some 3.2.1 things I'd overlooked.
Fixed some contradictory tagging bugs in MechGenericBattle