### PR TITLE
Update itemCollection_Upgrades_fp_theRaid.csv

### DIFF
--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB10.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB10.json
@@ -36,7 +36,7 @@
         "UIName": "Ammo Thermobolt10",
         "Id": "Ammo_AmmunitionBox_Thermobolt_TB10",
         "Name": "Thermobolt 10 Ammo",
-        "Details": "This Thunderbolt Missile was retooled to fire a specialised Thermobaric Warhead igniting everything around the impact and dealing massive amounts of heat.\n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
+        "Details": "This Thunderbolt Missile was retooled to fire a specialized Thermobaric Warhead igniting everything around the impact and dealing massive amounts of heat.\n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
         "Icon": "uixSvgIcon_ammoBox_Missile"
     },
     "BonusValueA": "",

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB15.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB15.json
@@ -36,7 +36,7 @@
         "UIName": "Ammo Thermobolt15",
         "Id": "Ammo_AmmunitionBox_Thermobolt_TB15",
         "Name": "Thermobolt 15 Ammo",
-        "Details": "This Thunderbolt Missile was retooled to fire a specialised Thermobaric Warhead igniting everything around the impact and dealing massive amounts of heat.\n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
+        "Details": "This Thunderbolt Missile was retooled to fire a specialized Thermobaric Warhead igniting everything around the impact and dealing massive amounts of heat.\n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
         "Icon": "uixSvgIcon_ammoBox_Missile"
     },
     "BonusValueA": "",

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB20 .json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB20 .json
@@ -36,7 +36,7 @@
         "UIName": "Ammo Thermobolt20",
         "Id": "Ammo_AmmunitionBox_Thermobolt_TB20",
         "Name": "Thermobolt 20 Ammo",
-        "Details": "This Thunderbolt Missile was retooled to fire a specialised Thermobaric Warhead igniting everything around the impact and dealing massive amounts of heat.\n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
+        "Details": "This Thunderbolt Missile was retooled to fire a specialized Thermobaric Warhead igniting everything around the impact and dealing massive amounts of heat.\n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
         "Icon": "uixSvgIcon_ammoBox_Missile"
     },
     "BonusValueA": "",

--- a/Flashpoint-The-Raid/itemCollections/itemCollection_Upgrades_fp_theRaid.csv
+++ b/Flashpoint-The-Raid/itemCollections/itemCollection_Upgrades_fp_theRaid.csv
@@ -1,5 +1,5 @@
 itemCollection_Upgrades_fp_theRaid,,,
-Gear_Actuator_Coventry_Alpha,Upgrade,1,1
+Gear_Actuator_Coventry_B60-Extended,Upgrade,1,1
 Gear_Cockpit_Ceres_Metals_Hardened,Upgrade,2,3
 Gear_Cockpit_Majesty_M_M_180KL,Upgrade,1,1
 Gear_Cockpit_StarCorps_Dalban,Upgrade,1,1

--- a/Republic 3081-3130/chassis/chassisdef_orion_ON2-K.json
+++ b/Republic 3081-3130/chassis/chassisdef_orion_ON2-K.json
@@ -14,7 +14,7 @@
     "UIName": "Orion",
     "Id": "chassisdef_orion_ON2-K",
     "Name": "Orion",
-    "Details": "The Orion 2K is a prototype upgrade of an already impressive design, adding 2 PPCs with upgraded capacitors, and an AC/5 with specialised ammo as well as heat-dissipating armour. <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
+    "Details": "The Orion 2K is a prototype upgrade of an already impressive design, adding 2 PPCs with upgraded capacitors, and an AC/5 with specialized ammo as well as heat-dissipating armour. <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b>",
     "Icon": "uixTxrIcon_orion"
   },
   "MovementCapDefID": "movedef_orion_ON1-K",
@@ -226,5 +226,5 @@
     "tagSetSourceFile": ""
   },
   "StockRole": "Direct Fire Support",
-  "YangsThoughts": "The Orion 2K is a prototype upgrade of an already impressive design, adding 2 PPCs with upgraded capacitors, and an AC/5 with specialised ammo as well as heat-dissipating armour. "
+  "YangsThoughts": "The Orion 2K is a prototype upgrade of an already impressive design, adding 2 PPCs with upgraded capacitors, and an AC/5 with specialized ammo as well as heat-dissipating armour. "
 }

--- a/Republic 3081-3130/mech/mechdef_orion_ON2-K.json
+++ b/Republic 3081-3130/mech/mechdef_orion_ON2-K.json
@@ -29,7 +29,7 @@
 		"UIName": "Orion ON2-K",
 		"Id": "mechdef_orion_ON2-K",
 		"Name": "Orion",
-		"Details": "The Orion 2K is a prototype upgrade of an already impressive design, adding 2 PPCs with upgraded capacitors, and an AC/5 with specialised ammo as well as heat-dissipating armour. <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b> ",
+		"Details": "The Orion 2K is a prototype upgrade of an already impressive design, adding 2 PPCs with upgraded capacitors, and an AC/5 with specialized ammo as well as heat-dissipating armour. <b><color=#53ff1a>Restricted Actuators- Left: Lower, Right: Lower</color></b> ",
 		"Icon": "uixTxrIcon_orion"
 	},
 	"simGameMechPartCost": 890000,

--- a/RogueModuleTech/Cockpit/Sensors/Gear_Owens_C3BAP.json
+++ b/RogueModuleTech/Cockpit/Sensors/Gear_Owens_C3BAP.json
@@ -38,7 +38,7 @@
         "UIName": "Sensor Sentinel",
         "Id": "Gear_Owens_C3BAP",
         "Name": "Beagle Active Probe with C3",
-        "Details": "This Specialised Sensor Package was created for the Owens OmniMech, combining a C3 Slave system with a Beagle Active Probe.",
+        "Details": "This specialized Sensor Package was created for the Owens OmniMech, combining a C3 Slave system with a Beagle Active Probe.",
         "Icon": "uixSvgIcon_equipment_Comms"
     },
     "BonusValueA": "+1 Health/Resolve.",

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_B20-Extended.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_B20-Extended.json
@@ -33,7 +33,7 @@
         "UIName": "Hands Melee",
         "Id": "Gear_Actuator_Coventry_B20-Extended",
         "Name": "Coventry B20 Extended Arm Mod",
-        "Details": "Actuators control a 'Mech\u2019s limbs and are used to perform Melee attacks at close quarters. All 'Mechs come equipped with stock Actuators, which can be upgraded for improved performance. <b><color=#800080>MELEE HAND ACTUATOR.</color></b> Disables Arm Mounted Weapon Bonus.",
+        "Details": "Actuators control a 'Mech's limbs and are used to perform Melee attacks at close quarters. All 'Mechs come equipped with stock Actuators, which can be upgraded for improved performance. <b><color=#800080>MELEE HAND ACTUATOR.</color></b> Disables Arm Mounted Weapon Bonus.",
         "Icon": "uixSvgIcon_equipment_ActuatorArm"
     },
     "BonusValueA": "+ 20% Melee Dmg.",

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_B40-Extended.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_B40-Extended.json
@@ -33,7 +33,7 @@
         "UIName": "Hands Melee +",
         "Id": "Gear_Actuator_Coventry_B40-Extended",
         "Name": "Coventry B40 Extended Arm Mod ",
-        "Details": "Actuators control a 'Mech\u2019s limbs and are used to perform Melee attacks at close quarters. All 'Mechs come equipped with stock Actuators, which can be upgraded for improved performance. <b><color=#800080>MELEE HAND ACTUATOR.</color></b> Disables Arm Mounted Weapon Bonus.",
+        "Details": "Actuators control a 'Mech's limbs and are used to perform Melee attacks at close quarters. All 'Mechs come equipped with stock Actuators, which can be upgraded for improved performance. <b><color=#800080>MELEE HAND ACTUATOR.</color></b> Disables Arm Mounted Weapon Bonus.",
         "Icon": "uixSvgIcon_equipment_ActuatorArm"
     },
     "BonusValueA": "+ 30 % Melee Dmg.",

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_B60-Extended.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_B60-Extended.json
@@ -33,7 +33,7 @@
         "UIName": "Hands Melee + +",
         "Id": "Gear_Actuator_Coventry_B60-Extended",
         "Name": "Coventry B60 Extended Arm Mod  ",
-        "Details": "Actuators control a 'Mech\u2019s limbs and are used to perform Melee attacks at close quarters. All 'Mechs come equipped with stock Actuators, which can be upgraded for improved performance. <b><color=#800080>MELEE HAND ACTUATOR.</color></b> Disables Arm Mounted Weapon Bonus.",
+        "Details": "Actuators control a 'Mech's limbs and are used to perform Melee attacks at close quarters. All 'Mechs come equipped with stock Actuators, which can be upgraded for improved performance. <b><color=#800080>MELEE HAND ACTUATOR.</color></b> Disables Arm Mounted Weapon Bonus.",
         "Icon": "uixSvgIcon_equipment_ActuatorArm"
     },
     "BonusValueA": "+ 40% Melee Dmg.",

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_X55-Standard.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_X55-Standard.json
@@ -33,7 +33,7 @@
         "UIName": "Weapon Mount",
         "Id": "Gear_Actuator_Coventry_X55-Standard",
         "Name": "Coventry X55 Standard Arm Mod",
-        "Details": "Weapon Actuators are a collection of specialised Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
+        "Details": "Weapon Actuators are a collection of specialized Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
         "Icon": "uixSvgIcon_equipment_ActuatorArm"
     },
     "BonusValueA": "+ 2 Arm Mounted Accuracy|",

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_X65-Standard.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_X65-Standard.json
@@ -34,7 +34,7 @@
         "UIName": "Weapon Mount +",
         "Id": "Gear_Actuator_Coventry_X65-Standard",
         "Name": "Coventry X65 Standard Arm Mod ",
-        "Details": "Weapon Actuators are a collection of specialised Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
+        "Details": "Weapon Actuators are a collection of specialized Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
         "Icon": "uixSvgIcon_equipment_ActuatorArm"
     },
     "BonusValueA": "+2 Arm Mounted Accuracy|",

--- a/RogueModuleTech/actuators/Gear_Actuator_Coventry_X75-Standard.json
+++ b/RogueModuleTech/actuators/Gear_Actuator_Coventry_X75-Standard.json
@@ -34,7 +34,7 @@
         "UIName": "Weapon Mount + +",
         "Id": "Gear_Actuator_Coventry_X75-Standard",
         "Name": "Coventry X75 Standard Arm Mod  ",
-        "Details": "Weapon Actuators are a collection of specialised Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
+        "Details": "Weapon Actuators are a collection of specialized Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
         "Icon": "uixSvgIcon_equipment_ActuatorArm"
     },
     "BonusValueA": "+3 Arm Mounted Accuracy|",

--- a/RogueModuleTech/actuators/Gear_Leg_Talons.json
+++ b/RogueModuleTech/actuators/Gear_Leg_Talons.json
@@ -31,7 +31,7 @@
         "UIName": "Talons",
         "Id": "Gear_Leg_Talons",
         "Name": "Talon Leg Actuators",
-        "Details": "This rare specialised set of Leg actuators enhance all Melee and DFA actions, why the engineer chose to mold them like the talons of a Bird of Prey is open to discussion.",
+        "Details": "This rare specialized set of Leg actuators enhance all Melee and DFA actions, why the engineer chose to mold them like the talons of a Bird of Prey is open to discussion.",
         "Icon": "uixSvgIcon_ability_angelofdeath"
     },
     "BonusValueA": "+20 DFA&Melee Dmg.",

--- a/RogueModuleTech/quirks/upgrade/Gear_Actuator_Coventry_X100.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Actuator_Coventry_X100.json
@@ -17,7 +17,7 @@
             "Bonuses": [
                 "ArmAccuracy: +3",
                 "Recoil: -3",
-                "MeleeAcc: -2",
+                "MeleeAcc: -2"
             ]
         },
         "InventorySorter": {
@@ -47,7 +47,7 @@
         "UIName": "Weapon Armature",
         "Id": "Gear_Actuator_Coventry_X100",
         "Name": "Coventry X75 Standard Arm Mod  ",
-        "Details": "Weapon Actuators are a collection of specialised Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
+        "Details": "Weapon Actuators are a collection of specialized Servos and Compensators allowing a BattleMech's Arm mounted Weapons to Fire with greater Accuracy. <b><color=#800080>WEAPON LOWER ARM ACTUATOR.</color></b> Reduces Melee, Improves Arm Mounted Weapons.",
         "Icon": "uixSvgIcon_equipment_ActuatorArm"
     },
     "BonusValueA": "+3 Arm Mounted Accuracy|",

--- a/RogueModuleTech/quirks/upgrade/Gear_Actuator_Prototype_JadeTalons.json
+++ b/RogueModuleTech/quirks/upgrade/Gear_Actuator_Prototype_JadeTalons.json
@@ -34,7 +34,7 @@
         "UIName": "Jade Talons",
         "Id": "Gear_Actuator_Prototype_JadeTalons",
         "Name": "JadeFalcon Leg Talons",
-        "Details": "This rare specialised set of Leg actuators enhance all Melee and DFA actions Crafted specificly in embracing the change in doctrine to use DFA attacks to great effect.",
+        "Details": "This rare specialized set of Leg actuators enhance all Melee and DFA actions Crafted specifically in embracing the change in doctrine to use DFA attacks to great effect.",
         "Icon": "uixSvgIcon_ability_angelofdeath"
     },
     "BonusValueA": "+20 DFA&Melee Dmg.",

--- a/RogueTechGenerals/GameTips/general.txt
+++ b/RogueTechGenerals/GameTips/general.txt
@@ -202,7 +202,7 @@ A trained sniper not only has deadly weapons, but keen eyesight. Same applies to
 Any shot not taken is a miss.
 Round 1: don't park somewhere stupid.
 Our commander is a military historian, his knowledge of the Star League is not due to 'being old enough to remember it'.
-Melee combat in Roguetech is dramatically more difficult to start with, but a specialised melee 'Mech is a nightmare.
+Melee combat in Roguetech is dramatically more difficult to start with, but a specialized melee 'Mech is a nightmare.
 Railguns and Gauss rifles deal tremendous damage at equally tremendous ranges. Reach out and touch someone.
 Killing Rocket Launcher or RL units before they blow their load is tactically advisable.
 Generous use of Thunder LRMs or other mine-laying ammunition can destroy lighter mechs before they get close by removing their legs.

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_CoveringFire.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_CoveringFire.json
@@ -3075,7 +3075,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3234,7 +3234,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3394,8 +3394,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_support",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3733,7 +3732,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3907,8 +3906,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_assault",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4235,7 +4233,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4409,8 +4407,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_defense",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4567,7 +4564,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4735,7 +4732,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4899,8 +4896,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_support",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5058,8 +5054,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_cavalry",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5217,8 +5212,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_assault",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5386,7 +5380,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5558,7 +5552,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5751,7 +5745,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5925,7 +5919,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Evacuation.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Evacuation.json
@@ -3075,7 +3075,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3234,7 +3234,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3394,8 +3394,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_support",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3733,7 +3732,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3907,8 +3906,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_assault",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4235,7 +4233,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4409,8 +4407,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_defense",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4567,7 +4564,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4735,7 +4732,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4899,8 +4896,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_support",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5058,8 +5054,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_cavalry",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5217,8 +5212,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_assault",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5386,7 +5380,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5558,7 +5552,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5751,7 +5745,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5925,7 +5919,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_HighTide.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_HighTide.json
@@ -3043,7 +3043,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3202,7 +3202,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3716,7 +3716,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3892,7 +3892,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -4222,7 +4221,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4396,7 +4395,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -4556,7 +4554,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4725,7 +4723,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -4886,7 +4883,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -5047,7 +5043,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -5208,8 +5203,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
-                        "lance_type_assault"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5379,7 +5373,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5551,7 +5545,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5744,7 +5738,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5919,8 +5913,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
-                        "lance_type_assault"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Pirate_Breakout.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Pirate_Breakout.json
@@ -3073,7 +3073,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3232,7 +3232,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3392,8 +3392,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_support",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3731,7 +3730,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3905,8 +3904,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_assault",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4233,7 +4231,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4407,8 +4405,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_defense",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4565,7 +4562,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4733,7 +4730,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4897,8 +4894,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_support",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5056,8 +5052,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_cavalry",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5215,8 +5210,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_assault",
-                        "lance_type_dynamic_difficulty"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5384,7 +5378,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5556,7 +5550,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5749,7 +5743,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5923,7 +5917,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_PowerUp.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_PowerUp.json
@@ -3005,7 +3005,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3164,7 +3164,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3678,7 +3678,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3852,8 +3852,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
-                        "lance_type_assault"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4197,7 +4196,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4370,7 +4369,7 @@
                 "name" : "Lance_Enemy_Defenders_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4543,7 +4542,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4712,7 +4711,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -4876,7 +4874,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -5040,7 +5037,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -5214,7 +5210,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -5398,7 +5393,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5570,7 +5565,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5763,7 +5758,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5937,7 +5932,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_ProxyWar.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_ProxyWar.json
@@ -3059,7 +3059,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3218,7 +3218,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3732,7 +3732,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3906,7 +3906,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -4234,7 +4233,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4408,7 +4407,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -4566,7 +4564,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4734,7 +4732,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4898,7 +4896,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -5057,7 +5054,6 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
                         "lance_type_support"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
@@ -5216,8 +5212,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
-                        "lance_type_assault"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5385,7 +5380,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5557,7 +5552,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5750,7 +5745,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5925,8 +5920,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_dynamic_difficulty",
-                        "lance_type_assault"
+                        "lance_type_fire"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Reconquest.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Reconquest.json
@@ -3123,7 +3123,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3282,7 +3282,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3796,7 +3796,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3969,7 +3969,7 @@
                 "name" : "Lance_Enemy_Attackers_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4312,7 +4312,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4485,7 +4485,7 @@
                 "name" : "Lance_Enemy_Defenders_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4658,7 +4658,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4826,7 +4826,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4989,7 +4989,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave1",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5152,7 +5152,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave2",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5325,7 +5325,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave3",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5509,7 +5509,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5681,7 +5681,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5874,7 +5874,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -6048,7 +6048,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Retaliation.json
+++ b/RogueUrbanWarfareModule/contracts/attackdefend/AttackDefend_Retaliation.json
@@ -3051,7 +3051,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3210,7 +3210,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3724,7 +3724,7 @@
                 "name" : "Lance_Enemy_Attackers_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3897,7 +3897,7 @@
                 "name" : "Lance_Enemy_Attackers_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4240,7 +4240,7 @@
                 "name" : "Lance_Enemy_Defenders_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4413,7 +4413,7 @@
                 "name" : "Lance_Enemy_Defenders_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4586,7 +4586,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4754,7 +4754,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4917,7 +4917,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave1",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5080,7 +5080,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave2",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5253,7 +5253,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave3",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5437,7 +5437,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5609,7 +5609,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5802,7 +5802,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5976,7 +5976,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/flashpoint/doubleAgent_a1_3wayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/doubleAgent_a1_3wayBattle.json
@@ -3407,7 +3407,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3898,7 +3898,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "TaurianConcordat"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5376,7 +5376,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Davion"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/doubleAgent_b1_3wayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/doubleAgent_b1_3wayBattle.json
@@ -3407,7 +3407,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "TaurianConcordat"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3898,7 +3898,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5376,7 +5376,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Davion"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/doubleAgent_c1_3wayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/doubleAgent_c1_3wayBattle.json
@@ -3407,7 +3407,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "MagistracyOfCanopus"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3898,7 +3898,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5376,7 +5376,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "TaurianConcordat"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/lastChance_a1_3wayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/lastChance_a1_3wayBattle.json
@@ -2892,7 +2892,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3543,7 +3543,7 @@
                 "name" : "Lance_Target_EnemyForce",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/flashpoint/lastChance_b1_defendBase.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/lastChance_b1_defendBase.json
@@ -1014,7 +1014,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -1172,7 +1172,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/redHunt_2_ThreeWayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/redHunt_2_ThreeWayBattle.json
@@ -3590,7 +3590,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3748,7 +3748,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3906,7 +3906,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4064,7 +4064,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4222,7 +4222,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/redHunt_3a_DestroyBase.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/redHunt_3a_DestroyBase.json
@@ -777,7 +777,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -1093,7 +1093,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/redHunt_3b_CaptureBase.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/redHunt_3b_CaptureBase.json
@@ -840,7 +840,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -998,7 +998,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_kurita"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_1_3wayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_1_3wayBattle.json
@@ -3316,7 +3316,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3971,7 +3971,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4134,7 +4134,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_2_3wayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_2_3wayBattle.json
@@ -3332,7 +3332,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3987,7 +3987,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4470,7 +4470,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },

--- a/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_a1_attackDefend.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_a1_attackDefend.json
@@ -3346,7 +3346,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3503,7 +3503,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4018,7 +4018,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4188,7 +4188,7 @@
                 "name" : "Lance_Enemy_Attackers_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4532,7 +4532,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4702,7 +4702,7 @@
                 "name" : "Lance_Enemy_Defenders_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4875,7 +4875,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5043,7 +5043,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5206,7 +5206,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave1",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5369,7 +5369,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave2",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5542,7 +5542,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave3",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5726,7 +5726,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5898,7 +5898,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -6091,7 +6091,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -6265,7 +6265,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_b1_attackDefend.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_b1_attackDefend.json
@@ -3362,7 +3362,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -3519,7 +3519,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4034,7 +4034,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4204,7 +4204,7 @@
                 "name" : "Lance_Enemy_Attackers_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4548,7 +4548,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4718,7 +4718,7 @@
                 "name" : "Lance_Enemy_Defenders_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4891,7 +4891,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5059,7 +5059,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5222,7 +5222,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave1",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5385,7 +5385,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave2",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5558,7 +5558,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave3",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5742,7 +5742,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5914,7 +5914,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -6107,7 +6107,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -6281,7 +6281,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_c1_attackDefend.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/siegebreaker_c1_attackDefend.json
@@ -3361,7 +3361,7 @@
                 "name" : "LanceSpawner",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -3520,7 +3520,7 @@
                 "name" : "LanceSpawner (1)",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4035,7 +4035,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4205,7 +4205,7 @@
                 "name" : "Lance_Enemy_Attackers_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4549,7 +4549,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Steiner"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4719,7 +4719,7 @@
                 "name" : "Lance_Enemy_Defenders_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4892,7 +4892,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5060,7 +5060,7 @@
                 "name" : "Lance_Enemy_AdditionalForces_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5223,7 +5223,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave1",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5386,7 +5386,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave2",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5559,7 +5559,7 @@
                 "name" : "Lance_EnemyReinforcements_Wave3",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5743,7 +5743,7 @@
                 "name" : "Lance_EnemyAlly_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -5915,7 +5915,7 @@
                 "name" : "Lance_EnemyAlly_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -6108,7 +6108,7 @@
                 "name" : "Lance_HostileAll_Primary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -6282,7 +6282,7 @@
                 "name" : "Lance_HostileAll_Secondary",
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {

--- a/RogueUrbanWarfareModule/contracts/flashpoint/succession_1_assassinate.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/succession_1_assassinate.json
@@ -817,8 +817,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_battle",
-                        "lance_type_light"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -830,7 +829,7 @@
                     "items" : [],
                     "tagSetSourceFile" : "tags/SpawnEffectTags"
                 },
-                "lanceDifficultyAdjustment" : 0,
+                "lanceDifficultyAdjustment" : -1,
                 "selectedLanceDefId" : "",
                 "selectedLanceDifficulty" : 0,
                 "unitSpawnPointOverrideList" : [
@@ -976,8 +975,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_cavalry",
-                        "lance_type_light"
+                        "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -989,7 +987,7 @@
                     "items" : [],
                     "tagSetSourceFile" : "tags/SpawnEffectTags"
                 },
-                "lanceDifficultyAdjustment" : 0,
+                "lanceDifficultyAdjustment" : -1,
                 "selectedLanceDefId" : "",
                 "selectedLanceDifficulty" : 0,
                 "unitSpawnPointOverrideList" : [
@@ -1135,8 +1133,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_battle",
-                        "lance_type_medium"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -1148,7 +1145,7 @@
                     "items" : [],
                     "tagSetSourceFile" : "tags/SpawnEffectTags"
                 },
-                "lanceDifficultyAdjustment" : 0,
+                "lanceDifficultyAdjustment" : 1,
                 "selectedLanceDefId" : "",
                 "selectedLanceDifficulty" : 0,
                 "unitSpawnPointOverrideList" : [

--- a/RogueUrbanWarfareModule/contracts/flashpoint/succession_a1_assassinate.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/succession_a1_assassinate.json
@@ -721,8 +721,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_battle",
-                        "lance_type_light"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -734,7 +733,7 @@
                     "items" : [],
                     "tagSetSourceFile" : "tags/SpawnEffectTags"
                 },
-                "lanceDifficultyAdjustment" : 0,
+                "lanceDifficultyAdjustment" : -1,
                 "selectedLanceDefId" : "",
                 "selectedLanceDifficulty" : 0,
                 "unitSpawnPointOverrideList" : [
@@ -880,8 +879,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_cavalry",
-                        "lance_type_light"
+                        "lance_type_cavalry"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -1039,8 +1037,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_battle",
-                        "lance_type_medium"
+                        "lance_type_battle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -1052,7 +1049,7 @@
                     "items" : [],
                     "tagSetSourceFile" : "tags/SpawnEffectTags"
                 },
-                "lanceDifficultyAdjustment" : 0,
+                "lanceDifficultyAdjustment" : 1,
                 "selectedLanceDefId" : "",
                 "selectedLanceDifficulty" : 0,
                 "unitSpawnPointOverrideList" : [

--- a/RogueUrbanWarfareModule/contracts/flashpoint/uw1_1_3wayBattle.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/uw1_1_3wayBattle.json
@@ -3701,7 +3701,7 @@
                 "name" : "Lance_EmployerAlly_Primary",
                 "lanceDefId" : "Manual",
                 "lanceTagSet" : {
-                    "items" : [],
+                    "items" : ["lance_type_notallvehicles"],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
                 "lanceExcludedTagSet" : {
@@ -4041,7 +4041,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -4524,7 +4524,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "Liao"
+                        "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },
@@ -5522,7 +5522,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_fast",
+                        "lance_type_cavalry",
                         "lance_type_notallvehicles"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"

--- a/RogueUrbanWarfareModule/contracts/flashpoint/uw1_2_ambushConvoy.json
+++ b/RogueUrbanWarfareModule/contracts/flashpoint/uw1_2_ambushConvoy.json
@@ -716,8 +716,7 @@
                 "lanceDefId" : "Tagged",
                 "lanceTagSet" : {
                     "items" : [
-                        "lance_type_vehicle",
-                        "lance_type_light"
+                        "lance_type_vehicle"
                     ],
                     "tagSetSourceFile" : "tags/LanceTags"
                 },


### PR DESCRIPTION
Coventry Alpha is a vanilla item that we don't have adapted to roguetech, which gives a flat +60 to melee damage. It was getting into player inventories. I think the only way to get it in RT is this flashpoint so this seemed like the easiest fix.