### PR TITLE
Added "unit_indirectFire" to Cargos new tanks

### DIFF
--- a/CivilWar 3062-3067/vehicle/vehicledef_SVANTOVIT_ATM_CLAN.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_SVANTOVIT_ATM_CLAN.json
@@ -16,6 +16,7 @@
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",
+                        "unit_indirectFire",
                         "unit_lance_vanguard",
                         "unit_hover",
                         "unit_apc",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SVANTOVIT_IFV_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SVANTOVIT_IFV_CLAN.json
@@ -16,6 +16,7 @@
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",
+                        "unit_indirectFire",
                         "unit_lance_vanguard",
                         "unit_hover",
                         "unit_apc",

--- a/RogueTanks/CLANK/vehicle/vehicledef_SVANTOVIT_ORIGINAL_CLAN.json
+++ b/RogueTanks/CLANK/vehicle/vehicledef_SVANTOVIT_ORIGINAL_CLAN.json
@@ -16,6 +16,7 @@
                         "unit_vehicle",
                         "unit_light",
                         "unit_release",
+                        "unit_indirectFire",
                         "unit_lance_vanguard",
                         "unit_hover",
                         "unit_apc",


### PR DESCRIPTION
Added "unit_indirectFire" to Cargos new tanks. The Rep-Me that needed the Svantovit to fix called for a clan light indirect fire tank that could operate on a lunar map. Added the tag to fulfill the requirement  