### PR TITLE
Clan arrow IV turret

### DIFF
--- a/ArtilleryUnits/Turret/turretdef_Heavy_ArrowIV.json
+++ b/ArtilleryUnits/Turret/turretdef_Heavy_ArrowIV.json
@@ -45,23 +45,6 @@
       "auriganpirates",
       "aurigandirectorate",
       "auriganrestoration",
-      "clansgeneric",
-      "clanwolf",
-      "clanfiremandrill",
-      "clanstaradder",
-      "clancoyote",
-      "clanjadefalcon",
-      "clansteelviper",
-      "clanicehellion",
-      "clangoliathscorpion",
-      "clandiamondshark",
-      "clanhellshorses",
-      "clansnowraven",
-      "clanghostbear",
-      "clansmokejaguar",
-      "clancloudcobra",
-      "clannovacat",
-      "clanburrock",
       "nofaction",
       "betrayers",
       "mercenaryreviewboard",
@@ -107,35 +90,35 @@
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
-	{
-         "ComponentDefID": "emod_engine_200",
-         "ComponentDefType": "HeatSink",
-         "HardpointSlot": 2,
-         "DamageLevel": "Functional"
-      },
-	  {
-         "ComponentDefID": "Turret_Coolant_System",
-         "ComponentDefType": "HeatSink",
-         "HardpointSlot": 2,
-         "DamageLevel": "Functional"
-      },
-      {
-         "ComponentDefID": "emod_engineslots_std_center",
-         "ComponentDefType": "HeatSink",
-         "HardpointSlot": 2,
-         "DamageLevel": "Functional"
-      },
-      {
-         "ComponentDefID": "Tank_CrewBunker_Assault",
-         "ComponentDefType": "Upgrade",
-         "HardpointSlot": 2,
-         "DamageLevel": "Functional"
-      },
-      {
-         "ComponentDefID": "Turret_Systems_Assault",
-         "ComponentDefType": "Upgrade",
-         "HardpointSlot": 2,
-         "DamageLevel": "Functional"
-      }
+    {
+      "ComponentDefID": "emod_engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
   ]
 }

--- a/ArtilleryUnits/Turret/turretdef_Heavy_ArrowIV_Clan.json
+++ b/ArtilleryUnits/Turret/turretdef_Heavy_ArrowIV_Clan.json
@@ -1,0 +1,105 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "turretdef_Heavy_ArrowIV_Clan",
+        "Name": "Arrow IV Turret",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "turretchassisdef_Heavy_ArrowIV_Clan",
+    "TurretTags": {
+        "items": [
+            "unit_artilleryturret",
+            "unit_turret",
+            "unit_assault",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock",
+            "mr-resize-0.75"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "CurrentArmor": 450,
+    "CurrentInternalStructure": 1,
+    "AssignedArmor": 450,
+    "DamageLevel": "Functional",
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Artillery_ArrowIV_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Guided_ArrowIV",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Guided_ArrowIV",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_ArrowIV",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_ArrowIV",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "emod_engine_200",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Turret_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewBunker_Assault",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Turret_Systems_Assault",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/ArtilleryUnits/TurretChassis/turretchassisdef_Heavy_ArrowIV_Clan.json
+++ b/ArtilleryUnits/TurretChassis/turretchassisdef_Heavy_ArrowIV_Clan.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_ArrowIV_Clan",
+		"Name": "ArrowIV Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID" : "hardpointdatadef_arrowivturret",
+	"PrefabIdentifier" : "chrprftrt_arrowivturret",
+	"PrefabBase" : "arrowivturret",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 10,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1.4,
+	"VisibilityMultiplier": 0.5,
+	"SensorRangeMultiplier": 1.4,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}


### PR DESCRIPTION
Removed Clan tags from the standard Arrow IV turret. Made a Clan Arrow IV turret with 2 tons of Inferno and 2 tons of Guided Ammo