### PR TITLE
fix GAR-B

### DIFF
--- a/Base 3061/chassis/chassisdef_gargoyle_GAR-B.json
+++ b/Base 3061/chassis/chassisdef_gargoyle_GAR-B.json
@@ -277,6 +277,23 @@
       "InternalStructure": 85
     }
   ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 14,
+      "z": 0
+    },
+    {
+      "x": 4,
+      "y": 15,
+      "z": -1
+    },
+    {
+      "x": -4,
+      "y": 15,
+      "z": -1
+    }
+  ],
   "LOSTargetPositions": [
     {
       "x": 0,


### PR DESCRIPTION
missing "LOSSourcePositions":  caused spawn fail