### PR TITLE
Fix multi-laser damage

### DIFF
--- a/RogueModuleTech/Pirate/Weapons/Weapon_SmallLaser_JuryRigged.json
+++ b/RogueModuleTech/Pirate/Weapons/Weapon_SmallLaser_JuryRigged.json
@@ -56,6 +56,8 @@
   "Instability": 3,
   "FireTerrainChance": 0.03,
   "ImprovedBallistic": true,
+  "BallisticDamagePerPallet": true,
+  "DamageNotDivided": true,
   "FireDelayMultiplier": 0.03,
   "WeaponEffectID": "WeaponEffect-Weapon_Laser_Small",
   "Description": {


### PR DESCRIPTION
The multi-laser aspect was missing two lines in order to correctly apply two instances of damage.