### PR TITLE
Fixed Multi-laser damage

### DIFF
--- a/RogueModuleTech/Pirate/Weapons/Weapon_Laser_DiscoLaser_Chemical.json
+++ b/RogueModuleTech/Pirate/Weapons/Weapon_Laser_DiscoLaser_Chemical.json
@@ -87,6 +87,8 @@
     }
   ],
   "ImprovedBallistic": true,
+  "BallisticDamagePerPallet": true,
+  "DamageNotDivided": true,
   "ColorSpeedChange": 3,
   "ColorChangeRule": "Random",
   "WeaponEffectID": "WeaponEffect-Weapon_Laser_Medium",

--- a/RogueModuleTech/Pirate/Weapons/Weapon_SmallLaser_JuryRigged.json
+++ b/RogueModuleTech/Pirate/Weapons/Weapon_SmallLaser_JuryRigged.json
@@ -56,6 +56,8 @@
   "Instability": 3,
   "FireTerrainChance": 0.03,
   "ImprovedBallistic": true,
+  "BallisticDamagePerPallet": true,
+  "DamageNotDivided": true,
   "FireDelayMultiplier": 0.03,
   "WeaponEffectID": "WeaponEffect-Weapon_Laser_Small",
   "Description": {


### PR DESCRIPTION
The two multi-lasers (DiscoLaser and SmallLaser_JuryRigged) were both missing two lines in order to allow each beam to do damage.