### PR TITLE
Reduced hardpoint numbers on the Malak

### DIFF
--- a/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-O.json
+++ b/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-O.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],

--- a/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OA.json
+++ b/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OA.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],

--- a/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OB.json
+++ b/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OB.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],

--- a/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OC.json
+++ b/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OC.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],

--- a/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OD.json
+++ b/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OD.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],

--- a/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OE.json
+++ b/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OE.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],

--- a/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OS.json
+++ b/Jihad 3068-3080/chassis/chassisdef_malak_C-MK-OS.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],

--- a/Jihad Unique/chassis/chassisdef_malak_C-MK-Mi.json
+++ b/Jihad Unique/chassis/chassisdef_malak_C-MK-Mi.json
@@ -158,10 +158,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -179,14 +175,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -206,14 +194,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -231,14 +211,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],
@@ -261,10 +233,6 @@
         },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": true
         }
       ],


### PR DESCRIPTION
Forgot to reduce the hardpoints, after I copied the mech using the Preta. The mech doesn't use that much weapons that would ask for that many hardpoints it had when I made it first. 
I remedied this mistake now and reduced the omni hardpoints.