### PR TITLE
Fixing minor typos and descriptions

### DIFF
--- a/ExperimentalWeapons/quirks/targettrackingsystem/Gear_TargetingTrackingSystem_Orssos.json
+++ b/ExperimentalWeapons/quirks/targettrackingsystem/Gear_TargetingTrackingSystem_Orssos.json
@@ -5,7 +5,7 @@
 		}],
 		"BonusDescriptions": {
 			"Bonuses": [
-				"HMRM Damage: +20%",
+				"HMRMDamage: +20%",
 				"CalledShot: 4%",
 				"BattleComputer"
 			]

--- a/ExperimentalWeapons/quirks/targettrackingsystem/Gear_TargetingTrackingSystem_Snafu.json
+++ b/ExperimentalWeapons/quirks/targettrackingsystem/Gear_TargetingTrackingSystem_Snafu.json
@@ -5,7 +5,7 @@
 		}],
 		"BonusDescriptions": {
 			"Bonuses": [
-				"Gauss Damage: +20%",
+				"GaussDamage: +20%",
 				"CalledShot: 4%",
 				"BattleComputer"
 			]

--- a/MechEngineer/bonusDescriptions/BonusDescriptions_AmmoTypes.json
+++ b/MechEngineer/bonusDescriptions/BonusDescriptions_AmmoTypes.json
@@ -151,6 +151,24 @@
       "Full": "AutoCannon/2 Ammo - {0} Shots"
     },
     {
+      "Bonus": "ProtoAC2Ammo",
+      "Short": "Proto AC2 Ammo",
+      "Long": "Protomech AC2 Ammo",
+      "Full": "Protomech AutoCannon/2 Ammo - {0} Shots"
+    },
+    {
+      "Bonus": "ProtoAC4Ammo",
+      "Short": "Proto AC4 Ammo",
+      "Long": "Protomech AC4 Ammo",
+      "Full": "Protomech AutoCannon/4 Ammo - {0} Shots"
+    },
+    {
+      "Bonus": "ProtoAC8Ammo",
+      "Short": "Proto AC8 Ammo",
+      "Long": "Protomech AC8 Ammo",
+      "Full": "Protomech AutoCannon/8 Ammo - {0} Shots"
+    },
+    {
       "Bonus": "AC5Ammo",
       "Short": "AC5 Ammo",
       "Long": "AC5 Ammo",


### PR DESCRIPTION
Added proto AC bonus descriptions and deleted an unnecessary space from two other descriptions in items since I got tired of the errors popping up in the error logs.