### PR TITLE
Added gunnery mitigation

### DIFF
--- a/CustomAmmoCategories/ammunition/Ammunition_AC10_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_AC10_Caseless.json
@@ -14,6 +14,8 @@
    "HeatGenerated": 0,
    "RefireModifier": 0,
    "FlatJammingChance": 0.12,
+   "GunneryJammingMult": 0.018,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.9,
    "HeatGeneratedModifier": 1,
    "ArmorDamageModifier": 1,

--- a/CustomAmmoCategories/ammunition/Ammunition_AC20_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_AC20_Caseless.json
@@ -14,6 +14,8 @@
    "HeatGenerated": 0,
    "RefireModifier": 0,
    "FlatJammingChance": 0.13,
+   "GunneryJammingMult": 0.0195,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.9,
    "HeatGeneratedModifier": 1,
    "ArmorDamageModifier": 1,

--- a/CustomAmmoCategories/ammunition/Ammunition_AC2_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_AC2_Caseless.json
@@ -14,6 +14,8 @@
    "HeatGenerated": 0,
    "RefireModifier": 0,
    "FlatJammingChance": 0.1,
+   "GunneryJammingMult": 0.015,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.9,
    "HeatGeneratedModifier": 1,
    "ArmorDamageModifier": 1,

--- a/CustomAmmoCategories/ammunition/Ammunition_AC5_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_AC5_Caseless.json
@@ -14,6 +14,8 @@
    "HeatGenerated": 0,
    "RefireModifier": 0,
    "FlatJammingChance": 0.11,
+   "GunneryJammingMult": 0.0165,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.9,
    "HeatGeneratedModifier": 1,
    "ArmorDamageModifier": 1,

--- a/CustomAmmoCategories/ammunition/Ammunition_AntiMissile_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_AntiMissile_Caseless.json
@@ -11,13 +11,14 @@
    },
    "Type": "Normal",
    "Category": "AntiMissile",
-   "HeatGenerated": 0,
+   "HeatGenerated": 2,
    "HeatGeneratedModifier": 1,
    "ArmorDamageModifier": 1,
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "AMSHitChance": -0.15,
    "FlatJammingChance": 0.15,
-   "ShotsWhenFired" : 4,
-   "HeatGenerated" : 2
+   "GunneryJammingMult": 0.0225,
+   "GunneryJammingBase": 5,
+   "ShotsWhenFired" : 4
 }

--- a/CustomAmmoCategories/ammunition/Ammunition_LBX10_AOE.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_LBX10_AOE.json
@@ -21,5 +21,7 @@
    "AOERange": 45,
    "AOEDamage": 45,
    "DamagePerShot": -45.0,
-   "FlatJammingChance": 0.16
+   "FlatJammingChance": 0.16,
+   "GunneryJammingMult": 0.024,
+   "GunneryJammingBase": 5
 }

--- a/CustomAmmoCategories/ammunition/Ammunition_LBX20_AOE.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_LBX20_AOE.json
@@ -21,5 +21,7 @@
    "AOERange": 75,
    "AOEDamage": 75,
    "DamagePerShot": -75.0,
-   "FlatJammingChance": 0.2
+   "FlatJammingChance": 0.2,
+   "GunneryJammingMult": 0.03,
+   "GunneryJammingBase": 5
 }

--- a/CustomAmmoCategories/ammunition/Ammunition_LBX2_AOE.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_LBX2_AOE.json
@@ -21,5 +21,7 @@
    "AOERange": 19,
    "AOEDamage": 19,
    "DamagePerShot": -19.0,
-   "FlatJammingChance": 0.08
+   "FlatJammingChance": 0.08,
+   "GunneryJammingMult": 0.012,
+   "GunneryJammingBase": 5
 }

--- a/CustomAmmoCategories/ammunition/Ammunition_LBX5_AOE.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_LBX5_AOE.json
@@ -21,5 +21,7 @@
    "AOERange": 33,
    "AOEDamage": 33,
    "DamagePerShot": -33.0,
-   "FlatJammingChance": 0.12
+   "FlatJammingChance": 0.12,
+   "GunneryJammingMult": 0.018,
+   "GunneryJammingBase": 5
 }

--- a/CustomAmmoCategories/ammunition/Ammunition_LRM_Tandem.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_LRM_Tandem.json
@@ -19,6 +19,8 @@
    "APDamage": 1,
    "DamageMultiplier": 0.1,
    "FlatJammingChance": 0.35,
+   "GunneryJammingMult": 0.0525,
+   "GunneryJammingBase": 5,
    "ColorsTable" : [
     {
       "C":"#EE82EE",

--- a/CustomAmmoCategories/ammunition/Ammunition_MRM_Tandem.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_MRM_Tandem.json
@@ -19,6 +19,8 @@
    "APDamage": 1,
    "DamagePerShot": -3,
    "FlatJammingChance": 0.2,
+   "GunneryJammingMult": 0.03,
+   "GunneryJammingBase": 5,
    "ColorsTable" : [
     {
       "C":"#EE82EE",

--- a/CustomAmmoCategories/ammunition/Ammunition_RAC10_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_RAC10_Caseless.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.14,
+   "GunneryJammingMult": 0.021,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/CustomAmmoCategories/ammunition/Ammunition_RAC20_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_RAC20_Caseless.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.16,
+   "GunneryJammingMult": 0.024,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/CustomAmmoCategories/ammunition/Ammunition_RAC2_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_RAC2_Caseless.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.1,
+   "GunneryJammingMult": 0.015,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/CustomAmmoCategories/ammunition/Ammunition_RAC5_Caseless.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_RAC5_Caseless.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.12,
+   "GunneryJammingMult": 0.018,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/CustomAmmoCategories/ammunition/Ammunition_UAC10_CL.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_UAC10_CL.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.14,
+   "GunneryJammingMult": 0.021,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/CustomAmmoCategories/ammunition/Ammunition_UAC20_CL.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_UAC20_CL.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.16,
+   "GunneryJammingMult": 0.024,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/CustomAmmoCategories/ammunition/Ammunition_UAC2_CL.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_UAC2_CL.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.1,
+   "GunneryJammingMult": 0.015,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/CustomAmmoCategories/ammunition/Ammunition_UAC5_CL.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_UAC5_CL.json
@@ -17,6 +17,8 @@
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
    "FlatJammingChance": 0.12,
+   "GunneryJammingMult": 0.018,
+   "GunneryJammingBase": 5,
    "DamageMultiplier":0.85,
    "ColorsTable" : [
 	{

--- a/ExperimentalWeapons/AMS/Weapon_Laser_AMS_CLAN_Advanced.json
+++ b/ExperimentalWeapons/AMS/Weapon_Laser_AMS_CLAN_Advanced.json
@@ -96,6 +96,8 @@
 			"ShotsWhenFired" : 50,
 			"AMSHitChance": 0.50,
 			"FlatJammingChance": 0.4,
+            "GunneryJammingMult": 0.06,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 40
 		},
 		{

--- a/ExperimentalWeapons/weapon/Weapon_Gauss_Rotary_AntiPersonal_Large_Bore_Gauss_Rifle.json
+++ b/ExperimentalWeapons/weapon/Weapon_Gauss_Rotary_AntiPersonal_Large_Bore_Gauss_Rifle.json
@@ -100,6 +100,8 @@
 			"UIName": "x3",
 			"isBaseMode": true,
 			"FlatJammingChance": 0.1,
+			"GunneryJammingMult": 0.015,
+			"GunneryJammingBase": 5,
 			"AIHitChanceCap": 0.2
 		},
 		{
@@ -109,6 +111,8 @@
 			"ShotsWhenFired": 1,
 			"RefireModifier": 2,
 			"FlatJammingChance": 0.2,
+			"GunneryJammingMult": 0.03,
+			"GunneryJammingBase": 5,
 			"EvasivePipsIgnored": 1,
 			"HeatGenerated": 10,
 			"AIHitChanceCap": 0.25

--- a/ExperimentalWeapons/weapon/Weapon_Gauss_Rotary_Gauss_Rifle.json
+++ b/ExperimentalWeapons/weapon/Weapon_Gauss_Rotary_Gauss_Rifle.json
@@ -99,6 +99,8 @@
 			"ShotsWhenFired": -1,
 			"RefireModifier": -1,
 			"FlatJammingChance": 0.1,
+			"GunneryJammingMult": 0.015,
+			"GunneryJammingBase": 5,
 			"HeatGenerated": -15,
 			"AIHitChanceCap": 0.20
 		},
@@ -107,6 +109,8 @@
 			"UIName": "x4",
 			"isBaseMode": true,
 			"FlatJammingChance": 0.2,
+			"GunneryJammingMult": 0.03,
+			"GunneryJammingBase": 5,
 			"AIHitChanceCap": 0.25
 		},
 		{
@@ -116,6 +120,8 @@
 			"ShotsWhenFired": 1,
 			"RefireModifier": 2,
 			"FlatJammingChance": 0.3,
+			"GunneryJammingMult": 0.045,
+			"GunneryJammingBase": 5,
 			"HeatGenerated": 15,
 			"AIHitChanceCap": 0.30
 		},
@@ -126,6 +132,8 @@
 			"ShotsWhenFired": 2,
 			"RefireModifier": 4,
 			"FlatJammingChance": 0.4,
+			"GunneryJammingMult": 0.06,
+			"GunneryJammingBase": 5,
 			"HeatGenerated": 30,
 			"AIHitChanceCap": 0.35
 		},
@@ -143,6 +151,8 @@
 			"ShotsWhenFired": -3,
 			"RefireModifier": 7,
 			"FlatJammingChance": 0.66,
+			"GunneryJammingMult": 0.099,
+			"GunneryJammingBase": 5,
 			"HeatGenerated": 75,
 			"DamageOnJamming": true,
 			"AIHitChanceCap": 0.70

--- a/RogueModuleTech/AMS/Weapon_AMS.json
+++ b/RogueModuleTech/AMS/Weapon_AMS.json
@@ -96,6 +96,8 @@
             "ShotsWhenFired": 20,
             "AMSHitChance": 0.3,
             "FlatJammingChance": 0.4,
+            "GunneryJammingMult": 0.06,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 2,
             "AMSShootsEveryAttack": true
         },
@@ -113,7 +115,9 @@
             "DamagePerShot": 1.0,
             "HeatGenerated": 6,
             "ShotsWhenFired": 5,
-            "FlatJammingChance": 0.1
+            "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/AMS/Weapon_AMS_CLAN.json
+++ b/RogueModuleTech/AMS/Weapon_AMS_CLAN.json
@@ -96,6 +96,8 @@
             "ShotsWhenFired": 30,
             "AMSHitChance": 0.35,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 4,
             "AMSShootsEveryAttack": true
         },
@@ -113,7 +115,9 @@
             "DamagePerShot": 1.0,
             "HeatGenerated": 12,
             "ShotsWhenFired": 10,
-            "FlatJammingChance": 0.1
+            "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/AMS/Weapon_AMS_MK2.json
+++ b/RogueModuleTech/AMS/Weapon_AMS_MK2.json
@@ -99,6 +99,8 @@
             "ShotsWhenFired": 40,
             "AMSHitChance": 0.3,
             "FlatJammingChance": 0.5,
+            "GunneryJammingMult": 0.075,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 4,
             "MaxRange": 90.0
         },
@@ -116,7 +118,9 @@
             "DamagePerShot": 1.0,
             "HeatGenerated": 18,
             "ShotsWhenFired": 15,
-            "FlatJammingChance": 0.1
+            "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/AMS/Weapon_Laser_AMS.json
+++ b/RogueModuleTech/AMS/Weapon_Laser_AMS.json
@@ -94,6 +94,8 @@
             "ShotsWhenFired": 15,
             "AMSHitChance": 0.3,
             "FlatJammingChance": 0.4,
+            "GunneryJammingMult": 0.06,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 12,
             "MaxRange": 90.0,
             "AMSShootsEveryAttack": true
@@ -112,7 +114,9 @@
             "ShotsWhenFired": 0,
             "DamagePerShot": 15.0,
             "HeatGenerated": 10,
-            "FlatJammingChance": 0.1
+            "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/AMS/Weapon_Laser_AMS_Apollo.json
+++ b/RogueModuleTech/AMS/Weapon_Laser_AMS_Apollo.json
@@ -122,6 +122,8 @@
             "ShotsWhenFired": 20,
             "AMSHitChance": 0.4,
             "FlatJammingChance": 0.5,
+            "GunneryJammingMult": 0.075,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 10,
             "MaxRange": 180.0
         },

--- a/RogueModuleTech/AMS/Weapon_Laser_AMS_CLAN.json
+++ b/RogueModuleTech/AMS/Weapon_Laser_AMS_CLAN.json
@@ -95,6 +95,8 @@
             "ShotsWhenFired": 30,
             "AMSHitChance": 0.35,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 22,
             "AMSShootsEveryAttack": true
         },
@@ -112,7 +114,9 @@
             "ShotsWhenFired": 0,
             "DamagePerShot": 25.0,
             "HeatGenerated": 15,
-            "FlatJammingChance": 0.1
+            "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/AMS/Weapon_Laser_AMS_Integrated.json
+++ b/RogueModuleTech/AMS/Weapon_Laser_AMS_Integrated.json
@@ -111,6 +111,8 @@
             "ShotsWhenFired": 20,
             "AMSHitChance": 0.4,
             "FlatJammingChance": 0.4,
+            "GunneryJammingMult": 0.06,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 16,
             "MaxRange": 90.0,
             "IsAAMS": true

--- a/RogueModuleTech/AMS/Weapon_Laser_AMS_Pirate.json
+++ b/RogueModuleTech/AMS/Weapon_Laser_AMS_Pirate.json
@@ -93,7 +93,9 @@
             "ShotsWhenFired": 20,
             "AMSHitChance": 0.2,
             "HeatGenerated": 8,
-            "FlatJammingChance": 0.05
+            "FlatJammingChance": 0.05,
+            "GunneryJammingMult": 0.0075,
+            "GunneryJammingBase": 5
         },
         {
             "Id": "Overload",
@@ -104,6 +106,8 @@
             "ShotsWhenFired": 40,
             "AMSHitChance": 0.4,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 16
         },
         {
@@ -120,7 +124,9 @@
             "ShotsWhenFired": 1,
             "DamagePerShot": 50.0,
             "HeatGenerated": 45,
-            "FlatJammingChance": 0.1
+            "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/AMS/Weapon_Laser_AMS_Prototype.json
+++ b/RogueModuleTech/AMS/Weapon_Laser_AMS_Prototype.json
@@ -103,6 +103,8 @@
 			"ShotsWhenFired" : 20,
 			"AMSHitChance": 0.4,
 			"FlatJammingChance": 0.6,
+            "GunneryJammingMult": 0.09,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 10,
 			"MaxRange": 180.0
 		},

--- a/RogueModuleTech/Clan/weapons/Weapon_MachineGun_HEAVY_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_MachineGun_HEAVY_CLAN.json
@@ -99,6 +99,8 @@
             "ShotsWhenFired": 0,
             "RefireModifier": 2,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 0
         },
         {
@@ -108,6 +110,8 @@
             "ShotsWhenFired": 1,
             "RefireModifier": 2,
             "FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 3
         },
         {
@@ -117,6 +121,8 @@
             "ShotsWhenFired": 2,
             "RefireModifier": 3,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 6
         }
     ],

--- a/RogueModuleTech/Clan/weapons/Weapon_MachineGun_LIGHT_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_MachineGun_LIGHT_CLAN.json
@@ -99,6 +99,8 @@
 			"ShotsWhenFired":0,
 			"RefireModifier" : 0,
 			"FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 0
 		},
 		{
@@ -108,6 +110,8 @@
 			"ShotsWhenFired": 1,
 			"RefireModifier" : 2,
 			"FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 4
 		},
 		{
@@ -117,6 +121,8 @@
 			"ShotsWhenFired": 2,
 			"RefireModifier" : 3,
 			"FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 5
 		}		
 	],

--- a/RogueModuleTech/Clan/weapons/Weapon_MachineGun_MachineGun_CLAN.json
+++ b/RogueModuleTech/Clan/weapons/Weapon_MachineGun_MachineGun_CLAN.json
@@ -98,6 +98,8 @@
             "ShotsWhenFired": 0,
             "RefireModifier": 2,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 0
         },
         {
@@ -107,6 +109,8 @@
             "ShotsWhenFired": 1,
             "RefireModifier": 2,
             "FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 2
         },
         {
@@ -116,6 +120,8 @@
             "ShotsWhenFired": 2,
             "RefireModifier": 3,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 4
         }
     ],

--- a/RogueModuleTech/HandHelds/Hand_Weapon_Autocannon_RAC2_JuryRigged.json
+++ b/RogueModuleTech/HandHelds/Hand_Weapon_Autocannon_RAC2_JuryRigged.json
@@ -125,6 +125,8 @@
 			"ShotsWhenFired": 1,
 			"RefireModifier" : 1,
 			"FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 5,
 			"AIHitChanceCap": 0.25
 		},
@@ -135,6 +137,8 @@
 			"ShotsWhenFired": 2,
 			"RefireModifier" : 2,
 			"FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 10,
 			"AIHitChanceCap": 0.3
 		},
@@ -145,6 +149,8 @@
 			"ShotsWhenFired": 3,
 			"RefireModifier" : 3,
 			"FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 15,
 			"AIHitChanceCap": 0.4
 		}		

--- a/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_RAC5_JuryRigged.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Autocannon_RAC5_JuryRigged.json
@@ -119,6 +119,8 @@
       "ShotsWhenFired": 1,
       "RefireModifier": 1,
       "FlatJammingChance": 0.1,
+      "GunneryJammingMult": 0.015,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 7,
       "AIHitChanceCap": 0.25
     },
@@ -129,6 +131,8 @@
       "ShotsWhenFired": 2,
       "RefireModifier": 2,
       "FlatJammingChance": 0.2,
+      "GunneryJammingMult": 0.03,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 14,
       "AIHitChanceCap": 0.3
     },
@@ -139,6 +143,8 @@
       "ShotsWhenFired": 3,
       "RefireModifier": 3,
       "FlatJammingChance": 0.3,
+      "GunneryJammingMult": 0.045,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 21,
       "AIHitChanceCap": 0.4
     }

--- a/RogueModuleTech/Pirate/weapons/Weapon_LRM_Thunderbolt30-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_LRM_Thunderbolt30-jrig.json
@@ -105,7 +105,9 @@
       "UIName": "x3",
       "isBaseMode": true,
       "SpreadRange": 35,
-      "FlatJammingChance": 0.1
+      "FlatJammingChance": 0.1,
+      "GunneryJammingMult": 0.015,
+      "GunneryJammingBase": 5
     },
     {
       "Id": "x6",
@@ -116,6 +118,8 @@
       "ShotsWhenFired": 3,
       "Cooldown": 1,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 38
     }
   ],

--- a/RogueModuleTech/Pirate/weapons/Weapon_Laser_LargeLaser_Chemical_Rotary.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Laser_LargeLaser_Chemical_Rotary.json
@@ -105,6 +105,8 @@
       "RefireModifier": -1,
       "HeatGenerated": -12,
       "FlatJammingChance": 0.07,
+      "GunneryJammingMult": 0.0105,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.12
     },
     {
@@ -112,6 +114,8 @@
       "UIName": "x3",
       "isBaseMode": true,
       "FlatJammingChance": 0.14,
+      "GunneryJammingMult": 0.021,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.1
     },
     {
@@ -122,6 +126,8 @@
       "RefireModifier": 1,
       "HeatGenerated": 12,
       "FlatJammingChance": 0.21,
+      "GunneryJammingMult": 0.0315,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.08
     },
     {
@@ -131,6 +137,8 @@
       "ShotsWhenFired": 2,
       "RefireModifier": 2,
       "FlatJammingChance": 0.28,
+      "GunneryJammingMult": 0.042,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 24,
       "FireDelayMultiplier": 0.06
     },
@@ -141,6 +149,8 @@
       "ShotsWhenFired": 3,
       "RefireModifier": 3,
       "FlatJammingChance": 0.35,
+      "GunneryJammingMult": 0.0525,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 36,
       "FireDelayMultiplier": 0.04
     }

--- a/RogueModuleTech/Pirate/weapons/Weapon_Laser_LargeLaser_MediumHeavy.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Laser_LargeLaser_MediumHeavy.json
@@ -100,6 +100,8 @@
       "EvasivePipsIgnored": 2,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.2,
+      "GunneryJammingMult": 0.03,
+      "GunneryJammingBase": 5,
       "FireTerrainChance": -0.0375
     },
     {
@@ -110,6 +112,8 @@
       "DamagePerShot": 35,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.25,
+      "GunneryJammingMult": 0.0375,
+      "GunneryJammingBase": 5,
       "FireTerrainChance": 0.0875
     }
   ],

--- a/RogueModuleTech/Pirate/weapons/Weapon_Laser_MediumLaser_Chemical_Rotary.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Laser_MediumLaser_Chemical_Rotary.json
@@ -105,6 +105,8 @@
       "RefireModifier": -1,
       "HeatGenerated": -6,
       "FlatJammingChance": 0.05,
+      "GunneryJammingMult": 0.0075,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.12
     },
     {
@@ -112,6 +114,8 @@
       "UIName": "x3",
       "isBaseMode": true,
       "FlatJammingChance": 0.1,
+      "GunneryJammingMult": 0.015,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.1
     },
     {
@@ -122,6 +126,8 @@
       "RefireModifier": 1,
       "HeatGenerated": 6,
       "FlatJammingChance": 0.15,
+      "GunneryJammingMult": 0.0225,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.08
     },
     {
@@ -131,6 +137,8 @@
       "ShotsWhenFired": 2,
       "RefireModifier": 2,
       "FlatJammingChance": 0.2,
+      "GunneryJammingMult": 0.03,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 12,
       "FireDelayMultiplier": 0.06
     },
@@ -141,6 +149,8 @@
       "ShotsWhenFired": 3,
       "RefireModifier": 3,
       "FlatJammingChance": 0.25,
+      "GunneryJammingMult": 0.0375,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 18,
       "FireDelayMultiplier": 0.04
     }

--- a/RogueModuleTech/Pirate/weapons/Weapon_Laser_SmallLaser_Chemical_Rotary.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Laser_SmallLaser_Chemical_Rotary.json
@@ -105,6 +105,8 @@
       "RefireModifier": -1,
       "HeatGenerated": -3,
       "FlatJammingChance": 0.04,
+      "GunneryJammingMult": 0.006,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.12
     },
     {
@@ -112,6 +114,8 @@
       "UIName": "x3",
       "isBaseMode": true,
       "FlatJammingChance": 0.08,
+      "GunneryJammingMult": 0.012,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.1
     },
     {
@@ -122,6 +126,8 @@
       "RefireModifier": 1,
       "HeatGenerated": 3,
       "FlatJammingChance": 0.12,
+      "GunneryJammingMult": 0.018,
+      "GunneryJammingBase": 5,
       "FireDelayMultiplier": 0.08
     },
     {
@@ -131,6 +137,8 @@
       "ShotsWhenFired": 2,
       "RefireModifier": 2,
       "FlatJammingChance": 0.16,
+      "GunneryJammingMult": 0.024,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 6,
       "FireDelayMultiplier": 0.06
     },
@@ -141,6 +149,8 @@
       "ShotsWhenFired": 3,
       "RefireModifier": 3,
       "FlatJammingChance": 0.2,
+      "GunneryJammingMult": 0.03,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 9,
       "FireDelayMultiplier": 0.04
     }

--- a/RogueModuleTech/Pirate/weapons/Weapon_MachineGun_Heavy_JuryRigged.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_MachineGun_Heavy_JuryRigged.json
@@ -119,6 +119,8 @@
 			"UIName":"x4",
 			"isBaseMode":true,
 			"FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
 			"AIHitChanceCap": 0.25
 		},
 		{
@@ -128,6 +130,8 @@
 			"ShotsWhenFired": 3,
 			"RefireModifier" : 1,
 			"FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 7,
 			"AIHitChanceCap": 0.3
 		},
@@ -138,6 +142,8 @@
 			"ShotsWhenFired": 6,
 			"RefireModifier" : 2,
 			"FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 14,
 			"AIHitChanceCap": 0.4
 		}		

--- a/RogueModuleTech/Pirate/weapons/Weapon_Pirate_PLASMA.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_Pirate_PLASMA.json
@@ -86,6 +86,8 @@
    "AdditionalImpactVFXScaleY": 1,
    "AdditionalImpactVFXScaleZ": 1,
    "FlatJammingChance": 0.1,
+   "GunneryJammingMult": 0.015,
+   "GunneryJammingBase": 5,
    "DamageOnJamming": true,
    "ColorsTable" : [
     {

--- a/RogueModuleTech/RISC/Weapons/Weapon_AMS_Advanced.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_AMS_Advanced.json
@@ -105,6 +105,8 @@
             "ShotsWhenFired": 20,
             "AMSHitChance": 0.45,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 6,
             "AMSShootsEveryAttack": true
         },
@@ -122,7 +124,9 @@
             "DamagePerShot": 1.0,
             "HeatGenerated": 20,
             "ShotsWhenFired": 25,
-            "FlatJammingChance": 0.25
+            "FlatJammingChance": 0.25,
+            "GunneryJammingMult": 0.0375,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/RISC/Weapons/Weapon_AMS_Head.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_AMS_Head.json
@@ -112,6 +112,8 @@
             "ShotsWhenFired": 40,
             "AMSHitChance": 0.5,
             "FlatJammingChance": 0.5,
+            "GunneryJammingMult": 0.075,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 4,
             "MaxRange": 90.0
         },
@@ -129,7 +131,9 @@
             "DamagePerShot": 1.0,
             "HeatGenerated": 18,
             "ShotsWhenFired": 15,
-            "FlatJammingChance": 0.1
+            "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5
         }
     ],
     "statusEffects": [],

--- a/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_10.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_10.json
@@ -59,6 +59,8 @@
   "Instability": 1.5,
   "FireTerrainChance": 0.005,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "StatusEffectsPerHit": true,
   "HitGenerator": "Individual",
   "MissileVolleySize": 10,

--- a/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_20.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_20.json
@@ -59,6 +59,8 @@
   "Instability": 1.5,
   "FireTerrainChance": 0.005,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "StatusEffectsPerHit": true,
   "HitGenerator": "Individual",
   "MissileVolleySize": 10,

--- a/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_30.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_30.json
@@ -59,6 +59,8 @@
   "Instability": 1.5,
   "FireTerrainChance": 0.005,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "StatusEffectsPerHit": true,
   "HitGenerator": "Individual",
   "MissileVolleySize": 10,

--- a/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_40.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_HEAVY_MRM_40.json
@@ -59,6 +59,8 @@
   "Instability": 1.5,
   "FireTerrainChance": 0.005,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "StatusEffectsPerHit": true,
   "HitGenerator": "Individual",
   "MissileVolleySize": 10,

--- a/RogueModuleTech/VanillaWeapons/Weapon_Autocannon_AC10_1-Defiance.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_Autocannon_AC10_1-Defiance.json
@@ -50,6 +50,8 @@
   "AttackRecoil": 3,
   "Instability": 15,
   "FlatJammingChance": 0.2,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.05,
   "WeaponEffectID": "WeaponEffect-Weapon_AC10_Single",
   "Description": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_0-STOCK.json
@@ -91,6 +91,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.2,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 10,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_3-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_3-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 10,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_0-STOCK.json
@@ -91,6 +91,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.2,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 15,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_3-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_3-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 15,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_0-STOCK.json
@@ -91,6 +91,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.2,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 20,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_3-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_3-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 20,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_0-STOCK.json
@@ -91,6 +91,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Delta.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-LongFire.json
@@ -93,6 +93,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Telos.json
@@ -95,6 +95,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.2,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 5,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_3-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_3-Zeus.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 1.25,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.005,
   "StatusEffectsPerHit": true,
   "MissileVolleySize": 5,
@@ -94,6 +96,8 @@
       "DamageOnJamming": true,
       "AccuracyModifier": 1.0,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -180.0,
       "AIHitChanceCap": 0.99
     }

--- a/RogueModuleTech/VanillaWeapons/Weapon_Laser_LargeLaserER_2-BlazeFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_Laser_LargeLaserER_2-BlazeFire.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 8.3,
   "FlatJammingChance": 0.2,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.15,
   "WeaponEffectID": "WeaponEffect-Weapon_LaserER_Large",
   "Description": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_Laser_SmallLaserER_2-BlazeFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_Laser_SmallLaserER_2-BlazeFire.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 1,
   "Instability": 2.6,
   "FlatJammingChance": 0.2,
+  "GunneryJammingMult": 0.03,
+  "GunneryJammingBase": 5,
   "FireTerrainChance": 0.05,
   "WeaponEffectID": "WeaponEffect-Weapon_LaserER_Small",
   "Description": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_MachineGun_MachineGun_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_MachineGun_MachineGun_0-STOCK.json
@@ -97,6 +97,8 @@
             "ShotsWhenFired": 0,
             "RefireModifier": 2,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 0
         },
         {
@@ -106,6 +108,8 @@
             "ShotsWhenFired": 1,
             "RefireModifier": 2,
             "FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 2
         },
         {
@@ -115,6 +119,8 @@
             "ShotsWhenFired": 2,
             "RefireModifier": 3,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 4
         }
     ],

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_0-STOCK.json
@@ -83,6 +83,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Ceres_Arms.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Ceres_Arms.json
@@ -84,6 +84,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Donal.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Donal.json
@@ -84,6 +84,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Tiegart.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Tiegart.json
@@ -84,6 +84,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_2-Ceres_Arms.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_2-Ceres_Arms.json
@@ -84,6 +84,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_2-Donal.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_2-Donal.json
@@ -84,6 +84,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_2-Tiegart.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_2-Tiegart.json
@@ -84,6 +84,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_3-Defiance.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_3-Defiance.json
@@ -49,6 +49,8 @@
   "AttackRecoil": 3,
   "Instability": 9,
   "FlatJammingChance": 0.25,
+  "GunneryJammingMult": 0.0375,
+  "GunneryJammingBase": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_PPC",
   "Description": {
     "Cost": 660000,

--- a/RogueModuleTech/Weapons/Weapon_Autocannon_AC10_HYPER.json
+++ b/RogueModuleTech/Weapons/Weapon_Autocannon_AC10_HYPER.json
@@ -51,6 +51,8 @@
   "AttackRecoil": 3,
   "Instability": 15,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "DamageOnJamming": true,
   "FireTerrainChance": 0.05,
   "WeaponEffectID": "WeaponEffect-Weapon_AC10_Single",

--- a/RogueModuleTech/Weapons/Weapon_Autocannon_AC20_HYPER.json
+++ b/RogueModuleTech/Weapons/Weapon_Autocannon_AC20_HYPER.json
@@ -51,6 +51,8 @@
   "AttackRecoil": 4,
   "Instability": 25,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "DamageOnJamming": true,
   "FireTerrainChance": 0.08,
   "WeaponEffectID": "WeaponEffect-Weapon_AC20_Single",

--- a/RogueModuleTech/Weapons/Weapon_Autocannon_AC2_HYPER.json
+++ b/RogueModuleTech/Weapons/Weapon_Autocannon_AC2_HYPER.json
@@ -52,6 +52,8 @@
   "Instability": 6.25,
   "FireTerrainChance": 0.02,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "DamageOnJamming": true,
   "WeaponEffectID": "WeaponEffect-Weapon_AC2",
   "Description": {

--- a/RogueModuleTech/Weapons/Weapon_Autocannon_AC5_HYPER.json
+++ b/RogueModuleTech/Weapons/Weapon_Autocannon_AC5_HYPER.json
@@ -51,6 +51,8 @@
   "AttackRecoil": 2,
   "Instability": 11.25,
   "FlatJammingChance": 0.1,
+  "GunneryJammingMult": 0.015,
+  "GunneryJammingBase": 5,
   "DamageOnJamming": true,
   "FireTerrainChance": 0.0375,
   "WeaponEffectID": "WeaponEffect-Weapon_AC5",

--- a/RogueModuleTech/Weapons/Weapon_MachineGun_ARRAY.json
+++ b/RogueModuleTech/Weapons/Weapon_MachineGun_ARRAY.json
@@ -100,6 +100,8 @@
 			"isBaseMode":true,
 			"RefireModifier" : 1,
 			"FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
 			"AIHitChanceCap": 0.25
 		},
 		{
@@ -109,6 +111,8 @@
 			"ShotsWhenFired": 4,
 			"RefireModifier" : 2,
 			"FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 6,
 			"AIHitChanceCap": 0.3
 		},
@@ -119,6 +123,8 @@
 			"ShotsWhenFired": 8,
 			"RefireModifier" : 3,
 			"FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 12,
 			"AIHitChanceCap": 0.4
 		}		

--- a/RogueModuleTech/Weapons/Weapon_MachineGun_ARRAY_HEAVY.json
+++ b/RogueModuleTech/Weapons/Weapon_MachineGun_ARRAY_HEAVY.json
@@ -102,6 +102,8 @@
             "isBaseMode": true,
             "RefireModifier": 2,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "AIHitChanceCap": 0.25
         },
         {
@@ -111,6 +113,8 @@
             "ShotsWhenFired": 3,
             "RefireModifier": 2,
             "FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 7,
             "AIHitChanceCap": 0.3
         },
@@ -121,6 +125,8 @@
             "ShotsWhenFired": 6,
             "RefireModifier": 3,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 14,
             "AIHitChanceCap": 0.4
         }

--- a/RogueModuleTech/Weapons/Weapon_MachineGun_ARRAY_LIGHT.json
+++ b/RogueModuleTech/Weapons/Weapon_MachineGun_ARRAY_LIGHT.json
@@ -100,6 +100,8 @@
 			"isBaseMode":true,
 			"RefireModifier" : 1,
 			"FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
 			"AIHitChanceCap": 0.25
 		},
 		{
@@ -109,6 +111,8 @@
 			"ShotsWhenFired": 4,
 			"RefireModifier" : 2,
 			"FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 3,
 			"AIHitChanceCap": 0.3
 		},
@@ -119,6 +123,8 @@
 			"ShotsWhenFired": 8,
 			"RefireModifier" : 3,
 			"FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
 			"HeatGenerated" : 6,
 			"AIHitChanceCap": 0.4
 		}		

--- a/RogueModuleTech/Weapons/Weapon_MachineGun_Blackwell.json
+++ b/RogueModuleTech/Weapons/Weapon_MachineGun_Blackwell.json
@@ -99,6 +99,8 @@
             "ShotsWhenFired": 0,
             "RefireModifier": 2,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 0
         },
         {
@@ -108,6 +110,8 @@
             "ShotsWhenFired": 1,
             "RefireModifier": 2,
             "FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 2
         },
         {
@@ -117,6 +121,8 @@
             "ShotsWhenFired": 2,
             "RefireModifier": 3,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 4
         }
     ],

--- a/RogueModuleTech/Weapons/Weapon_MachineGun_HEAVY.json
+++ b/RogueModuleTech/Weapons/Weapon_MachineGun_HEAVY.json
@@ -99,6 +99,8 @@
             "ShotsWhenFired": 0,
             "RefireModifier": 2,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 0
         },
         {
@@ -108,6 +110,8 @@
             "ShotsWhenFired": 1,
             "RefireModifier": 2,
             "FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 3
         },
         {
@@ -117,6 +121,8 @@
             "ShotsWhenFired": 2,
             "RefireModifier": 3,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 6
         }
     ],

--- a/RogueModuleTech/Weapons/Weapon_MachineGun_LIGHT.json
+++ b/RogueModuleTech/Weapons/Weapon_MachineGun_LIGHT.json
@@ -98,6 +98,8 @@
             "ShotsWhenFired": 0,
             "RefireModifier": 2,
             "FlatJammingChance": 0.1,
+            "GunneryJammingMult": 0.015,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 0
         },
         {
@@ -107,6 +109,8 @@
             "ShotsWhenFired": 1,
             "RefireModifier": 2,
             "FlatJammingChance": 0.2,
+            "GunneryJammingMult": 0.03,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 1
         },
         {
@@ -116,6 +120,8 @@
             "ShotsWhenFired": 2,
             "RefireModifier": 3,
             "FlatJammingChance": 0.3,
+            "GunneryJammingMult": 0.045,
+            "GunneryJammingBase": 5,
             "HeatGenerated": 2
         }
     ],

--- a/RogueModuleTech/Weapons/Weapon_PPC_PPC_HEAVY.json
+++ b/RogueModuleTech/Weapons/Weapon_PPC_PPC_HEAVY.json
@@ -90,6 +90,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/Weapons/Weapon_PPC_PPC_LIGHT.json
+++ b/RogueModuleTech/Weapons/Weapon_PPC_PPC_LIGHT.json
@@ -85,6 +85,8 @@
       "isBaseMode": false,
       "DamageOnJamming": true,
       "FlatJammingChance": 0.5,
+      "GunneryJammingMult": 0.075,
+      "GunneryJammingBase": 5,
       "MinRange": -90.0,
       "AccuracyModifier": 1.0,
       "AIHitChanceCap": 0.99

--- a/RogueModuleTech/quirks/weapon/Weapon_Laser_AMS_RAINDANCER.json
+++ b/RogueModuleTech/quirks/weapon/Weapon_Laser_AMS_RAINDANCER.json
@@ -106,6 +106,8 @@
       "ShotsWhenFired": 20,
       "AMSHitChance": 0.4,
       "FlatJammingChance": 0.6,
+      "GunneryJammingMult": 0.09,
+      "GunneryJammingBase": 5,
       "HeatGenerated": 10,
       "MaxRange": 180.0
     },


### PR DESCRIPTION
Added gunnery mitigation to all the items that were missing it other than the suicide weapons.

Gunnery mitigation is 15% of jam chance, per level above 5.
Gunnery 10 means 75% reduction in jam chance.

Largest changes are Hotloading LRMs, PPC FiOff, and MGs are now safer at high gunnery (and worse at gunnery lower than 5)