### PR TITLE
Melee chassis fixes (Base 3061)

### DIFF
--- a/Base 3061/chassis/chassisdef_albatross_ALB-3U.json
+++ b/Base 3061/chassis/chassisdef_albatross_ALB-3U.json
@@ -32,10 +32,10 @@
     "MaxJumpjets": 4, 
     "PrefabBase": "hellbringer", 
     "weightClass": "ASSAULT", 
-    "DFAInstability": 33, 
-    "MeleeToHitModifier": 2, 
+    "DFAInstability": 48, 
+    "MeleeToHitModifier": 0, 
     "HardpointDataDefID": "hardpointdatadef_hellbringer", 
-    "MeleeDamage": 33, 
+    "MeleeDamage": 48, 
     "LOSSourcePositions": [
         {
             "y": 16, 
@@ -55,7 +55,7 @@
     ], 
     "InitialTonnage": 9.5, 
     "Tonnage": 95, 
-    "DFAToHitModifier": 2, 
+    "DFAToHitModifier": 0, 
     "Signature": 0, 
     "BattleValue": 7124000, 
     "Heatsinks": 0, 
@@ -65,7 +65,7 @@
     }, 
     "PathingCapDefID": "pathingdef_heavy", 
     "TurnRadius": 90, 
-    "DFADamage": 65, 
+    "DFADamage": 95, 
     "LOSTargetPositions": [
         {
             "y": 16, 
@@ -239,8 +239,8 @@
     "MovementCapDefID": "movedef_hellbringer", 
     "Radius": 8, 
     "VariantName": "ALB-3U", 
-    "DFASelfDamage": 65, 
+    "DFASelfDamage": 95, 
     "TopSpeed": 150, 
     "StockRole": "Juggernaut", 
-    "MeleeInstability": 17
+    "MeleeInstability": 24
 }

--- a/Base 3061/chassis/chassisdef_mistlynx_MLX-B.json
+++ b/Base 3061/chassis/chassisdef_mistlynx_MLX-B.json
@@ -111,13 +111,13 @@
     "Signature": 0,
     "Radius": 4,
     "PunchesWithLeftArm": true,
-    "MeleeDamage": 45,
-    "MeleeInstability": 35,
+    "MeleeDamage": 13,
+    "MeleeInstability": 7,
     "MeleeToHitModifier": 0,
-    "DFADamage": 45,
+    "DFADamage": 25,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 45,
-    "DFAInstability": 45,
+    "DFASelfDamage": 25,
+    "DFAInstability": 13,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_mistlynx_MLX-C.json
+++ b/Base 3061/chassis/chassisdef_mistlynx_MLX-C.json
@@ -111,13 +111,13 @@
     "Signature": 0,
     "Radius": 4,
     "PunchesWithLeftArm": true,
-    "MeleeDamage": 45,
-    "MeleeInstability": 35,
+    "MeleeDamage": 13,
+    "MeleeInstability": 7,
     "MeleeToHitModifier": 0,
-    "DFADamage": 45,
+    "DFADamage": 25,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 45,
-    "DFAInstability": 45,
+    "DFASelfDamage": 25,
+    "DFAInstability": 13,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_mistlynx_MLX-PRIME.json
+++ b/Base 3061/chassis/chassisdef_mistlynx_MLX-PRIME.json
@@ -112,13 +112,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 45,
-  "MeleeInstability": 35,
+  "MeleeDamage": 13,
+  "MeleeInstability": 7,
   "MeleeToHitModifier": 0,
-  "DFADamage": 45,
+  "DFADamage": 25,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 45,
-  "DFAInstability": 45,
+  "DFASelfDamage": 25,
+  "DFAInstability": 13,
   "Locations": [
     {
       "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostroc_OSR-2C.json
+++ b/Base 3061/chassis/chassisdef_ostroc_OSR-2C.json
@@ -45,13 +45,13 @@
     "Signature": 0,
     "Radius": 8,
     "PunchesWithLeftArm": false,
-    "MeleeDamage": 55,
-    "MeleeInstability": 60,
+    "MeleeDamage": 30,
+    "MeleeInstability": 15,
     "MeleeToHitModifier": 0,
-    "DFADamage": 75,
+    "DFADamage": 60,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 75,
-    "DFAInstability": 75,
+    "DFASelfDamage": 60,
+    "DFAInstability": 30,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostroc_OSR-2CB.json
+++ b/Base 3061/chassis/chassisdef_ostroc_OSR-2CB.json
@@ -45,13 +45,13 @@
     "Signature": 0,
     "Radius": 8,
     "PunchesWithLeftArm": false,
-    "MeleeDamage": 55,
-    "MeleeInstability": 60,
+    "MeleeDamage": 30,
+    "MeleeInstability": 15,
     "MeleeToHitModifier": 0,
-    "DFADamage": 75,
+    "DFADamage": 60,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 75,
-    "DFAInstability": 75,
+    "DFASelfDamage": 60,
+    "DFAInstability": 30,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostroc_OSR-2M.json
+++ b/Base 3061/chassis/chassisdef_ostroc_OSR-2M.json
@@ -45,13 +45,13 @@
     "Signature": 0,
     "Radius": 8,
     "PunchesWithLeftArm": false,
-    "MeleeDamage": 55,
-    "MeleeInstability": 60,
+    "MeleeDamage": 30,
+    "MeleeInstability": 15,
     "MeleeToHitModifier": 0,
-    "DFADamage": 75,
+    "DFADamage": 60,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 75,
-    "DFAInstability": 75,
+    "DFASelfDamage": 60,
+    "DFAInstability": 30,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostroc_OSR-3C.json
+++ b/Base 3061/chassis/chassisdef_ostroc_OSR-3C.json
@@ -45,13 +45,13 @@
     "Signature": 0,
     "Radius": 8,
     "PunchesWithLeftArm": false,
-    "MeleeDamage": 55,
-    "MeleeInstability": 60,
+    "MeleeDamage": 30,
+    "MeleeInstability": 15,
     "MeleeToHitModifier": 0,
-    "DFADamage": 75,
+    "DFADamage": 60,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 75,
-    "DFAInstability": 75,
+    "DFASelfDamage": 60,
+    "DFAInstability": 30,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostsol_OTL-4D.json
+++ b/Base 3061/chassis/chassisdef_ostsol_OTL-4D.json
@@ -45,13 +45,13 @@
     "Signature": 0,
     "Radius": 8,
     "PunchesWithLeftArm": false,
-    "MeleeDamage": 55,
-    "MeleeInstability": 60,
+    "MeleeDamage": 30,
+    "MeleeInstability": 15,
     "MeleeToHitModifier": 0,
-    "DFADamage": 75,
+    "DFADamage": 60,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 75,
-    "DFAInstability": 75,
+    "DFASelfDamage": 60,
+    "DFAInstability": 30,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostsol_OTL-4F.json
+++ b/Base 3061/chassis/chassisdef_ostsol_OTL-4F.json
@@ -45,13 +45,13 @@
     "Signature": 0,
     "Radius": 8,
     "PunchesWithLeftArm": false,
-    "MeleeDamage": 55,
-    "MeleeInstability": 60,
+    "MeleeDamage": 30,
+    "MeleeInstability": 15,
     "MeleeToHitModifier": 0,
-    "DFADamage": 75,
+    "DFADamage": 60,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 75,
-    "DFAInstability": 75,
+    "DFASelfDamage": 60,
+    "DFAInstability": 30,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostsol_OTL-5M.json
+++ b/Base 3061/chassis/chassisdef_ostsol_OTL-5M.json
@@ -45,13 +45,13 @@
     "Signature": 0,
     "Radius": 8,
     "PunchesWithLeftArm": false,
-    "MeleeDamage": 55,
-    "MeleeInstability": 60,
+    "MeleeDamage": 30,
+    "MeleeInstability": 15,
     "MeleeToHitModifier": 0,
-    "DFADamage": 75,
+    "DFADamage": 60,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 75,
-    "DFAInstability": 75,
+    "DFASelfDamage": 60,
+    "DFAInstability": 30,
     "Locations": [
         {
             "Location": "Head",

--- a/Base 3061/chassis/chassisdef_ostwar_OWR-2MB.json
+++ b/Base 3061/chassis/chassisdef_ostwar_OWR-2MB.json
@@ -47,13 +47,13 @@
     "Signature" : 0,
     "Radius" : 8,
     "PunchesWithLeftArm" : false,
-    "MeleeDamage" : 60,
-    "MeleeInstability" : 65,
+    "MeleeDamage" : 33,
+    "MeleeInstability" : 17,
     "MeleeToHitModifier" : 0,
-    "DFADamage" : 80,
+    "DFADamage" : 65,
     "DFAToHitModifier" : 0,
-    "DFASelfDamage" : 80,
-    "DFAInstability" : 80,
+    "DFASelfDamage" : 65,
+    "DFAInstability" : 33,
     "ChassisTags" : {
         "items" : [
            "SLDFMech"

--- a/Base 3061/chassis/chassisdef_piranha_PIR-1.json
+++ b/Base 3061/chassis/chassisdef_piranha_PIR-1.json
@@ -39,13 +39,13 @@
     "Signature": 0,
     "Radius": 4,
     "PunchesWithLeftArm": true,
-    "MeleeDamage": 25,
-    "MeleeInstability": 35,
+    "MeleeDamage": 10,
+    "MeleeInstability": 5,
     "MeleeToHitModifier": 0,
-    "DFADamage": 25,
+    "DFADamage": 20,
     "DFAToHitModifier": 0,
-    "DFASelfDamage": 45,
-    "DFAInstability": 45,
+    "DFASelfDamage": 20,
+    "DFAInstability": 10,
     "Locations": [
         {
             "Location": "Head",


### PR DESCRIPTION
So I was investigating why one Piranha was doing twice as much damage with a punch as another, even though it had no fancy melee equipment. Doing that I found a few more base mechs that did strange amounts of damage compared to their tonnage. Did a little cleanup pass in the Base 3061 folder.