### PR TITLE
Spelling and default corrections

### DIFF
--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Incendiary_AC2.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Incendiary_AC2.json
@@ -40,7 +40,7 @@
         "UIName": "Ammo AC/2 [INC]",
         "Id": "Ammo_AmmunitionBox_Incendiary_AC2",
         "Name": "AC/2 Incendiary Ammo",
-        "Details": "Incendiary ammunition can be used in standard autocannons and their lighter cousins. Developed by NAIS scientists from the Federated Suns, these autocannon rounds contained an Inferno warhead and were covered in a thin coat of magnesium. <b><color=#F79232>13 rounds</color></b>.\n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
+        "Details": "Incendiary ammunition can be used in standard autocannons and their lighter cousins. Developed by NAIS scientists from the Federated Suns, these autocannon rounds contained an Inferno warhead and were covered in a thin coat of magnesium. \n\n <b><color=#00ffff>Left Click on Ammo count during battle to swap Ammo Type. Ctrl+click on ammunition counter to eject ammo.</color> </b>",
         "Icon": "uixSvgIcon_ammoBox_Ballistic"
     },
     "BonusValueA": "+100% Crit.",

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Acid_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Acid_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Acid_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Acid_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Airburst_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Airburst_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Airburst_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Airburst_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar_Acid.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar_Acid.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Flare_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Flare_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Flare_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Flare_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Generic_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Generic_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Generic_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Generic_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Guided_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Guided_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Guided_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Guided_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Inferno_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Inferno_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Inferno_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Inferno_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Smoke_Mortar.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Smoke_Mortar.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Smoke_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Smoke_Mortar_half.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/a/o/mortair" }
+			{ "CategoryID" : "a/a/o/mortar" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB10.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB10.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB15.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB15.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB20 .json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB20 .json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB5.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thermobolt_TB5.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB10.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB10.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB15.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB15.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB20.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB20.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB5.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Feint_TB5.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB10.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB10.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB15.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB15.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB20.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB20.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB5.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_Kinetic_TB5.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_MIRV_TB20.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_MIRV_TB20.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_Guided.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_Guided.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_HE.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_HE.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_Guided.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_Guided.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_HE.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_HE.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_Guided.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_Guided.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_HE.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_HE.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_Guided.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_Guided.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_HE.json
+++ b/CustomAmmoCategories/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_HE.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/CustomComponents/categories/Categories_Ammo.json
+++ b/CustomComponents/categories/Categories_Ammo.json
@@ -15,7 +15,7 @@
         
 		{	"Name" : "a/a/o/mg", "DisplayName" : "Machinegun ammo", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/mg" }}},	
         {	"Name" : "a/a/o/artillery", "DisplayName" : "Artillery cannon ammo", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/artillery" }}},	
-		{	"Name" : "a/a/o/mortair", "DisplayName" : "Mortair ammo", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/mortair" }}},	
+		{	"Name" : "a/a/o/mortar", "DisplayName" : "mortar ammo", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/mortar" }}},	
 		
         {	"Name" : "a/e/l/chemical", "DisplayName" : "Chemical Laser Fuel", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/e/l/chemical" }}},	
         {	"Name" : "a/e/p/plasma", "DisplayName" : "Plasma Cannon Ammo", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/e/p/plasma" }}},	

--- a/CustomComponents/categories/Categories_Ammo.json
+++ b/CustomComponents/categories/Categories_Ammo.json
@@ -33,7 +33,7 @@
 		{	"Name" : "a/m/l/atm", "DisplayName" : "ATM Missiles", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/l/atm" }}},	
 	    {	"Name" : "a/m/l/iatm", "DisplayName" : "iATM Missiles", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/l/iatm" }}},	
 		
-        {	"Name" : "a/m/t/thunderbold", "DisplayName" : "Thunderbold Rockets", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/t/thunderbold" }}},	
+        {	"Name" : "a/m/t/thunderbolt", "DisplayName" : "thunderbolt Rockets", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/t/thunderbolt" }}},	
 	    {	"Name" : "a/m/t/arrowiv", "DisplayName" : "ArrowIV Rockets", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/t/arrowiv" }}},	
         
 		{	"Name" : "a/s/a/ams", "DisplayName" : "AMS Ammo", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/s/a/ams" }}},	

--- a/CustomComponents/categories/Categories_Weapons.json
+++ b/CustomComponents/categories/Categories_Weapons.json
@@ -18,7 +18,7 @@
         
 		{	"Name" : "w/a/o/mg", "DisplayName" : "Machinegun", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/mg" }}},	
         {	"Name" : "w/a/o/artillery", "DisplayName" : "Artillery cannon", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/artillery" }}},	
-		{	"Name" : "w/a/o/mortair", "DisplayName" : "Mortair", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/mortair" }}},	
+		{	"Name" : "w/a/o/mortar", "DisplayName" : "mortar", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/a/o/mortar" }}},	
         
 		
 		{	"Name" : "w/e/l/laser", "DisplayName" : "Laser", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/e/l/laser" }}},	

--- a/CustomComponents/categories/Categories_Weapons.json
+++ b/CustomComponents/categories/Categories_Weapons.json
@@ -57,7 +57,7 @@
         {	"Name" : "w/m/l/atm", "DisplayName" : "ATM", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/l/atm" }}},	
 	    {	"Name" : "w/m/l/iatm", "DisplayName" : "iATM", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/l/iatm" }}},	
 		
-        {	"Name" : "w/m/t/thunderbold", "DisplayName" : "Thunderbold", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/t/thunderbold" }}},	
+        {	"Name" : "w/m/t/thunderbolt", "DisplayName" : "thunderbolt", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/t/thunderbolt" }}},	
 	    {	"Name" : "w/m/t/arrowiv", "DisplayName" : "ArrowIV", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/m/t/arrowiv" }}},	
         
 		{	"Name" : "w/s/a/ams", "DisplayName" : "AMS", "DefaultCustoms" : { "ColorTag" : { "Tag" : "w/s/a/ams" }}},	

--- a/CustomComponents/mod.json
+++ b/CustomComponents/mod.json
@@ -91,7 +91,7 @@
 			{ "Tag" : "w/m/l/atm", "Color" : "#351c75f0" },		
 			{ "Tag" : "w/m/l/iatm", "Color" : "#432395f0" },		
 			
-			{ "Tag" : "w/m/t/thunderbold", "Color" : "#8b1d2cf0" },		
+			{ "Tag" : "w/m/t/thunderbolt", "Color" : "#8b1d2cf0" },		
 			{ "Tag" : "w/m/t/arrowiv", "Color" : "#8b1d2cf0" },	
 
 			{ "Tag" : "w/s/a/ams", "Color" : "#ad5b05f0" },		

--- a/CustomComponents/mod.json
+++ b/CustomComponents/mod.json
@@ -53,7 +53,7 @@
 
 			{ "Tag" : "w/a/o/mg", "Color" : "#009393f0" },		
 			{ "Tag" : "w/a/o/artillery", "Color" : "#7b1d3cf0" },		
-			{ "Tag" : "w/a/o/mortair", "Color" : "#7b1d23f0" },		
+			{ "Tag" : "w/a/o/mortar", "Color" : "#7b1d23f0" },		
 			
 			{ "Tag" : "w/e/l/laser", "Color" : "#4c763ef0" },		
 			{ "Tag" : "w/e/l/pulse", "Color" : "#4c933ef0" },		

--- a/CustomFilters/mod.json
+++ b/CustomFilters/mod.json
@@ -152,7 +152,7 @@
 						"Tooltip" : "Show Artillery class launchers",
 						"Filter" : {
 							"Categories" : [
-								"w/m/t/thunderbold",
+								"w/m/t/thunderbolt",
 								"w/m/t/arrowiv"
 							]
 						}
@@ -259,7 +259,7 @@
 								"w/m/l/iatm",
 								
 								
-								"w/m/t/thunderbold",
+								"w/m/t/thunderbolt",
 								"w/m/t/arrowiv",
 								
 								"w/s/a/ams",
@@ -407,7 +407,7 @@
 						"Tooltip" : "Show Artillery and Thunderbolt rockets",
 						"Filter" : {
 							"Categories" : [
-								"a/m/t/thunderbold", "a/m/t/arrowiv"
+								"a/m/t/thunderbolt", "a/m/t/arrowiv"
 							]
 						}
 					},
@@ -444,7 +444,7 @@
 								"a/s/a/ams", "a/s/t/narc", "a/s/m/melee",
 								"a/s/m/ac", "a/s/m/energy", "a/s/m/pa",
 								"a/e/l/chemical", "a/e/p/plasma", "a/e/p/aflamer",
-								"a/m/t/thunderbold", "a/m/t/arrowiv",
+								"a/m/t/thunderbolt", "a/m/t/arrowiv",
 								"a/m/l/atm", "a/m/l/iatm",
 								"a/m/s/mrm", "a/m/s/hmrm",
 								"a/m/l/lrm", "a/m/l/slrm",

--- a/CustomFilters/mod.json
+++ b/CustomFilters/mod.json
@@ -62,7 +62,7 @@
 							"Categories" : [
 								"w/a/o/mg",
 								"w/a/o/artillery",
-								"w/a/o/mortair"
+								"w/a/o/mortar"
 							]
 						}
 					},
@@ -220,7 +220,7 @@
 								
 								"w/a/o/mg",
 								"w/a/o/artillery",
-								"w/a/o/mortair",
+								"w/a/o/mortar",
 								
 								"w/e/l/laser",
 								"w/e/l/pulse",
@@ -356,7 +356,7 @@
 						"Tooltip" : "Show MG and Artillery ammo",
 						"Filter" : {
 							"Categories" : [
-								"a/a/o/mg", "a/a/o/artillery", "a/a/o/mortair"
+								"a/a/o/mg", "a/a/o/artillery", "a/a/o/mortar"
 							]
 						}
 					},
@@ -449,7 +449,7 @@
 								"a/m/s/mrm", "a/m/s/hmrm",
 								"a/m/l/lrm", "a/m/l/slrm",
 								"a/m/s/srm", "a/m/s/ssrm",
-								"a/a/o/mg", "a/a/o/artillery", "a/a/o/mortair",
+								"a/a/o/mg", "a/a/o/artillery", "a/a/o/mortar",
 								"a/a/a/lbx",
 								"a/a/a/rac", "a/a/a/uac"
 							]

--- a/ExperimentalWeapons/ammobox/Ammo_AmmunitionBox_Thunderbolt_TB20_NEMP.json
+++ b/ExperimentalWeapons/ammobox/Ammo_AmmunitionBox_Thunderbolt_TB20_NEMP.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
 		"Category" : [
-			{ "CategoryID" : "a/m/t/thunderbold" }
+			{ "CategoryID" : "a/m/t/thunderbolt" }
 		],
         "Flags": {
             "flags": [

--- a/MechEngineer/Settings.defaults.json
+++ b/MechEngineer/Settings.defaults.json
@@ -41,7 +41,7 @@
         ],
         "MechDefEngine" : true,
         "MechDefCoolingDef" : "emod_kit_shs",
-        "MechDefHeatBlockDef" : "emod_engine_cooling",
+        "MechDefHeatBlockDef" : "Gear_Engine_Heatsinks",
         "MechDefCoreDummy" : "emod_engine_dummy",
         "UpgradeDefSkip" : [
             

--- a/RogueModuleTech/Pirate/weapons/Weapon_LRM_Thunderbolt30-jrig.json
+++ b/RogueModuleTech/Pirate/weapons/Weapon_LRM_Thunderbolt30-jrig.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/m/t/thunderbold"
+        "CategoryID": "w/m/t/thunderbolt"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Primitive/weapons/Weapon_LRM_Thunderbolt_10_4pack.json
+++ b/RogueModuleTech/Primitive/weapons/Weapon_LRM_Thunderbolt_10_4pack.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/m/t/thunderbold"
+        "CategoryID": "w/m/t/thunderbolt"
       }
     ],
     "ComponentExplosion": {

--- a/RogueModuleTech/Primitive/weapons/Weapon_LRM_Thunderbolt_10_OS.json
+++ b/RogueModuleTech/Primitive/weapons/Weapon_LRM_Thunderbolt_10_OS.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/m/t/thunderbold"
+        "CategoryID": "w/m/t/thunderbolt"
       }
     ],
     "ComponentExplosion": {

--- a/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt10.json
+++ b/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt10.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/m/t/thunderbold"
+        "CategoryID": "w/m/t/thunderbolt"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt15.json
+++ b/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt15.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/m/t/thunderbold"
+        "CategoryID": "w/m/t/thunderbolt"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt20.json
+++ b/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt20.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/m/t/thunderbold"
+        "CategoryID": "w/m/t/thunderbolt"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt5.json
+++ b/RogueModuleTech/Weapons/Weapon_LRM_Thunderbolt5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/m/t/thunderbold"
+        "CategoryID": "w/m/t/thunderbolt"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Weapons/Weapon_MECHMORTAR_2.json
+++ b/RogueModuleTech/Weapons/Weapon_MECHMORTAR_2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/a/o/mortair"
+        "CategoryID": "w/a/o/mortar"
       }
     ],
     "InventorySorter": {

--- a/RogueModuleTech/Weapons/Weapon_MECHMORTAR_4.json
+++ b/RogueModuleTech/Weapons/Weapon_MECHMORTAR_4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/a/o/mortair"
+        "CategoryID": "w/a/o/mortar"
       }
     ],
     "InventorySorter": {

--- a/RogueModuleTech/Weapons/Weapon_MECHMORTAR_6.json
+++ b/RogueModuleTech/Weapons/Weapon_MECHMORTAR_6.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/a/o/mortair"
+        "CategoryID": "w/a/o/mortar"
       }
     ],
     "InventorySorter": {

--- a/RogueModuleTech/Weapons/Weapon_MECHMORTAR_8.json
+++ b/RogueModuleTech/Weapons/Weapon_MECHMORTAR_8.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/a/o/mortair"
+        "CategoryID": "w/a/o/mortar"
       }
     ],
     "InventorySorter": {

--- a/RogueModuleTech/Weapons/Weapon_VehicleGrenadeLauncher.json
+++ b/RogueModuleTech/Weapons/Weapon_VehicleGrenadeLauncher.json
@@ -1,7 +1,7 @@
 {
     "Custom": {
         "Category": [
-			{ "CategoryID": "w/a/o/mortair" }
+			{ "CategoryID": "w/a/o/mortar" }
 		],
         "InventorySorter": {
             "SortKey": "03011"

--- a/RogueModuleTech/quirks/weapon/Weapon_MECHMORTAR_10.json
+++ b/RogueModuleTech/quirks/weapon/Weapon_MECHMORTAR_10.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/a/o/mortair"
+        "CategoryID": "w/a/o/mortar"
       }
     ],
     "InventorySorter": {


### PR DESCRIPTION
Fixed "Mortair" and "Thunderbold"
Tested on my save game, does not break saves with the relevant items (at least for me).
Also swapped out one last example of "emod_engine_cooling" I found.