### PR TITLE
Add missing 0 to mech cost

### DIFF
--- a/Base 3061/chassis/chassisdef_bombard_BMB-010.json
+++ b/Base 3061/chassis/chassisdef_bombard_BMB-010.json
@@ -14,7 +14,7 @@
     ]
   },
   "Description": {
-    "Cost": 437632,
+    "Cost": 4376320,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",

--- a/CivilWar 3062-3067/chassis/chassisdef_bombard_BMB-013.json
+++ b/CivilWar 3062-3067/chassis/chassisdef_bombard_BMB-013.json
@@ -20,7 +20,7 @@
     ]
   },
   "Description": {
-    "Cost": 437632,
+    "Cost": 4376320,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",

--- a/CivilWar 3062-3067/chassis/chassisdef_bombard_BMB-P.json
+++ b/CivilWar 3062-3067/chassis/chassisdef_bombard_BMB-P.json
@@ -14,7 +14,7 @@
     ]
   },
   "Description": {
-    "Cost": 437632,
+    "Cost": 4376320,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",

--- a/CivilWar 3062-3067/chassis/chassisdef_locust_LCT-1V2.json
+++ b/CivilWar 3062-3067/chassis/chassisdef_locust_LCT-1V2.json
@@ -6,7 +6,7 @@
     }
   },
   "Description": {
-    "Cost": 134896,
+    "Cost": 1348960,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "",

--- a/DarkAge/chassis/chassisdef_bombard_BMB-016.json
+++ b/DarkAge/chassis/chassisdef_bombard_BMB-016.json
@@ -36,7 +36,7 @@
     ]
   },
   "Description": {
-    "Cost": 437632,
+    "Cost": 4376320,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",

--- a/Jihad 3068-3080/chassis/chassisdef_bombard_BMB-1X.json
+++ b/Jihad 3068-3080/chassis/chassisdef_bombard_BMB-1X.json
@@ -20,7 +20,7 @@
     ]
   },
   "Description": {
-    "Cost": 437632,
+    "Cost": 4376320,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",


### PR DESCRIPTION
These mechs had obvious typos. LCT-1V2 now has the same price as LCT-1E, while all Bombards cost 4.3M instead of 437k which is more appropriate for medium class.