### PR TITLE
buff unintentionally weak riscpult legs

### DIFF
--- a/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R1.json
+++ b/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R1.json
@@ -267,9 +267,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     },
     {
       "Location": "RightLeg",
@@ -278,9 +278,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     }
   ],
   "LOSSourcePositions": [

--- a/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R2.json
+++ b/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R2.json
@@ -267,9 +267,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     },
     {
       "Location": "RightLeg",
@@ -278,9 +278,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     }
   ],
   "LOSSourcePositions": [

--- a/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R3.json
+++ b/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R3.json
@@ -267,9 +267,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     },
     {
       "Location": "RightLeg",
@@ -278,9 +278,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     }
   ],
   "LOSSourcePositions": [

--- a/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R4.json
+++ b/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R4.json
@@ -267,9 +267,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     },
     {
       "Location": "RightLeg",
@@ -278,9 +278,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     }
   ],
   "LOSSourcePositions": [

--- a/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R5.json
+++ b/RISCtech module/chassis/chassisdef_catapultIII_CPLT-R5.json
@@ -267,9 +267,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     },
     {
       "Location": "RightLeg",
@@ -278,9 +278,9 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 6,
-      "MaxArmor": 100,
+      "MaxArmor": 140,
       "MaxRearArmor": -1,
-      "InternalStructure": 45
+      "InternalStructure": 65
     }
   ],
   "LOSSourcePositions": [


### PR DESCRIPTION
At least seems unintentional, since current structure in mechdef > max structure in chassisdef.

(Fixes ticket-2039.)