### PR TITLE
Update mechdef_victor_VTR-9K2.json

### DIFF
--- a/ArtilleryUnits/mech/mechdef_victor_VTR-9K2.json
+++ b/ArtilleryUnits/mech/mechdef_victor_VTR-9K2.json
@@ -370,7 +370,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Artillery_LONGTOM",
+      "ComponentDefID": "Weapon_Artillery_LONGTOM_Cannon",
       "SimGameUID": "",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,


### PR DESCRIPTION
Fixed the mech, Redbat flagged up that it was 10 tons over weight. Somehow the longtom canon was switched for the heavier longtom causing the mech to be overweight