### PR TITLE
Make oversized cores fixed - 3061 mechs

### DIFF
--- a/Base 3061/chassis/chassisdef_incubus_1.json
+++ b/Base 3061/chassis/chassisdef_incubus_1.json
@@ -204,6 +204,20 @@
       "InternalStructure": 35
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_270",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base 3061/chassis/chassisdef_locust_LCT-1E.json
+++ b/Base 3061/chassis/chassisdef_locust_LCT-1E.json
@@ -152,6 +152,20 @@
       "InternalStructure": 20
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_170",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base 3061/chassis/chassisdef_locust_LCT-1M.json
+++ b/Base 3061/chassis/chassisdef_locust_LCT-1M.json
@@ -161,6 +161,20 @@
       "InternalStructure": 20
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_170",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base 3061/chassis/chassisdef_locust_LCT-1V.json
+++ b/Base 3061/chassis/chassisdef_locust_LCT-1V.json
@@ -153,6 +153,20 @@
       "InternalStructure": 20
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_170",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base 3061/chassis/chassisdef_locust_LCT-3D.json
+++ b/Base 3061/chassis/chassisdef_locust_LCT-3D.json
@@ -207,5 +207,18 @@
       "InternalStructure": 20
     }
   ],
-  "fixedEquipment": null
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_170",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ]
 }

--- a/Base 3061/chassis/chassisdef_locust_LCT-3M.json
+++ b/Base 3061/chassis/chassisdef_locust_LCT-3M.json
@@ -106,6 +106,20 @@
     }
   ],
   "MechPartCount": 0,
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_170",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "Locations": [
     {
       "Location": "Head",

--- a/Base 3061/chassis/chassisdef_locust_LCT-3S.json
+++ b/Base 3061/chassis/chassisdef_locust_LCT-3S.json
@@ -106,6 +106,20 @@
     }
   ],
   "MechPartCount": 0,
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_170",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "Locations": [
     {
       "Location": "Head",

--- a/Base 3061/chassis/chassisdef_locust_LCT-3V.json
+++ b/Base 3061/chassis/chassisdef_locust_LCT-3V.json
@@ -157,6 +157,20 @@
       "InternalStructure": 20
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_170",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base 3061/chassis/chassisdef_piranha_PIR-1.json
+++ b/Base 3061/chassis/chassisdef_piranha_PIR-1.json
@@ -245,6 +245,20 @@
       "InternalStructure": 20
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_180",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base 3061/mech/mechdef_incubus_1.json
+++ b/Base 3061/mech/mechdef_incubus_1.json
@@ -138,17 +138,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_270",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_cdhs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_locust_LCT-1E.json
+++ b/Base 3061/mech/mechdef_locust_LCT-1E.json
@@ -189,17 +189,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_170",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_locust_LCT-1M.json
+++ b/Base 3061/mech/mechdef_locust_LCT-1M.json
@@ -126,17 +126,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_170",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_locust_LCT-1V.json
+++ b/Base 3061/mech/mechdef_locust_LCT-1V.json
@@ -189,17 +189,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_170",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_locust_LCT-3D.json
+++ b/Base 3061/mech/mechdef_locust_LCT-3D.json
@@ -128,18 +128,6 @@
   "inventory": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_170",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_locust_LCT-3M.json
+++ b/Base 3061/mech/mechdef_locust_LCT-3M.json
@@ -148,18 +148,6 @@
   "inventory": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_170",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_locust_LCT-3S.json
+++ b/Base 3061/mech/mechdef_locust_LCT-3S.json
@@ -128,18 +128,6 @@
   "inventory": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_170",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_locust_LCT-3V.json
+++ b/Base 3061/mech/mechdef_locust_LCT-3V.json
@@ -321,17 +321,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_170",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base 3061/mech/mechdef_piranha_PIR-1.json
+++ b/Base 3061/mech/mechdef_piranha_PIR-1.json
@@ -194,17 +194,6 @@
       "hasPrefabName": false
     },
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_180",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "emod_engineslots_size2",
       "SimGameUID": null,

--- a/Base HeavyMetal/chassis/chassisdef_flea_FLE-16.json
+++ b/Base HeavyMetal/chassis/chassisdef_flea_FLE-16.json
@@ -159,6 +159,20 @@
       "InternalStructure": 20
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_180",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base HeavyMetal/mech/mechdef_flea_FLE-16.json
+++ b/Base HeavyMetal/mech/mechdef_flea_FLE-16.json
@@ -162,17 +162,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engine_180",
-      "SimGameUID": null,
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "GUID": null,
-      "DamageLevel": "Functional",
-      "prefabName": null,
-      "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_kit_shs",
       "SimGameUID": null,
       "ComponentDefType": "HeatSink",

--- a/Base Unique 3061/chassis/chassisdef_cicada_CDA-X5.json
+++ b/Base Unique 3061/chassis/chassisdef_cicada_CDA-X5.json
@@ -160,6 +160,20 @@
       "InternalStructure": 50
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_330",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base Unique 3061/chassis/chassisdef_locust_LCT-PB.json
+++ b/Base Unique 3061/chassis/chassisdef_locust_LCT-PB.json
@@ -172,6 +172,20 @@
       "InternalStructure": 20
     }
   ],
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_engine_190",
+      "SimGameUID": null,
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "GUID": null,
+      "DamageLevel": "Functional",
+      "prefabName": "",
+      "hasPrefabName": true
+    }
+  ],
   "LOSSourcePositions": [
     {
       "x": 0,

--- a/Base Unique 3061/chassis/chassisdef_piranha_PIR-CIPHER.json
+++ b/Base Unique 3061/chassis/chassisdef_piranha_PIR-CIPHER.json
@@ -245,6 +245,20 @@
             "InternalStructure": 20
         }
     ],
+    "FixedEquipment": [
+      {
+        "MountedLocation": "CenterTorso",
+        "ComponentDefID": "emod_engine_180",
+        "SimGameUID": null,
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "IsFixed": false,
+        "GUID": null,
+        "DamageLevel": "Functional",
+        "prefabName": "",
+        "hasPrefabName": true
+      }
+    ],
     "LOSSourcePositions": [
         {
             "x": 0,

--- a/Base Unique 3061/mech/mechdef_cicada_CDA-X5.json
+++ b/Base Unique 3061/mech/mechdef_cicada_CDA-X5.json
@@ -155,17 +155,6 @@
         }, 
         {
             "MountedLocation": "CenterTorso", 
-            "ComponentDefID": "emod_engine_330", 
-            "SimGameUID": null, 
-            "ComponentDefType": "HeatSink", 
-            "HardpointSlot": -1, 
-            "GUID": null, 
-            "DamageLevel": "Functional", 
-            "prefabName": null, 
-            "hasPrefabName": false
-        }, 
-        {
-            "MountedLocation": "CenterTorso", 
             "ComponentDefID": "emod_kit_dhs", 
             "SimGameUID": null, 
             "ComponentDefType": "HeatSink", 

--- a/Base Unique 3061/mech/mechdef_locust_LCT-PB.json
+++ b/Base Unique 3061/mech/mechdef_locust_LCT-PB.json
@@ -154,17 +154,6 @@
         }, 
         {
             "MountedLocation": "CenterTorso", 
-            "ComponentDefID": "emod_engine_190", 
-            "SimGameUID": null, 
-            "ComponentDefType": "HeatSink", 
-            "HardpointSlot": -1, 
-            "GUID": null, 
-            "DamageLevel": "Functional", 
-            "prefabName": null, 
-            "hasPrefabName": false
-        }, 
-        {
-            "MountedLocation": "CenterTorso", 
             "ComponentDefID": "emod_kit_dhs", 
             "SimGameUID": null, 
             "ComponentDefType": "HeatSink", 

--- a/Base Unique 3061/mech/mechdef_piranha_PIR-CIPHER.json
+++ b/Base Unique 3061/mech/mechdef_piranha_PIR-CIPHER.json
@@ -181,17 +181,6 @@
             "hasPrefabName": false
         }, 
         {
-            "MountedLocation": "CenterTorso", 
-            "ComponentDefID": "emod_engine_180", 
-            "SimGameUID": null, 
-            "ComponentDefType": "HeatSink", 
-            "HardpointSlot": -1, 
-            "GUID": null, 
-            "DamageLevel": "Functional", 
-            "prefabName": null, 
-            "hasPrefabName": false
-        }, 
-        {
             "MountedLocation": "LeftTorso", 
             "ComponentDefID": "emod_engineslots_size2", 
             "SimGameUID": null, 


### PR DESCRIPTION
Did a pass over all >8x tonnage cores in the base 3061 folders and made fixed the ones that weren't.

Tested to still load in the skirmish mechbay.