### PR TITLE
For discussion: Nerf quicsell flare ams to 50 shots

### DIFF
--- a/RogueModuleTech/AMS/Weapon_LRM_FLARELAUNCHER_AMS.json
+++ b/RogueModuleTech/AMS/Weapon_LRM_FLARELAUNCHER_AMS.json
@@ -48,7 +48,7 @@
         400
     ],
     "AmmoCategory": "Rocket",
-    "StartingAmmoCapacity": 100,
+    "StartingAmmoCapacity": 50,
     "HeatGenerated": 1,
     "Damage": 0,
     "OverheatedDamageMultiplier": 0,


### PR DESCRIPTION
in order to match the fluff about 5 salvos (and to make it a bit less ridiculous, basically everyone loads this on their assault mechs instead of proper amses these days, since it has 100 shots built in and 80% accuracy)