### PR TITLE
Railgun UI fixes

### DIFF
--- a/ExperimentalWeapons/quirks/weapon/Weapon_Gauss_Railgun_PROTOTYPE.json
+++ b/ExperimentalWeapons/quirks/weapon/Weapon_Gauss_Railgun_PROTOTYPE.json
@@ -74,7 +74,7 @@
 	"InventorySize": 2,
 	"Tonnage": 22,
 	"AllowedLocations": "CenterTorso",
-	"DisallowedLocations": "All",
+	"DisallowedLocations": "Arms, LeftTorso, RightTorso",
 	"CriticalComponent": false,
 	"Modes": [
 		{

--- a/RogueModuleTech/Quirks/Weapon/Weapon_Gauss_RAILGUN_BFG.json
+++ b/RogueModuleTech/Quirks/Weapon/Weapon_Gauss_RAILGUN_BFG.json
@@ -11,7 +11,7 @@
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 200,
       "StabilityDamagePerAmmo": 50,
-	  "HeatDamagePerAmmo": 15
+      "HeatDamagePerAmmo": 15
     },
     "BonusDescriptions": {
       "Bonuses": [
@@ -107,15 +107,15 @@
   "InventorySize": 2,
   "Tonnage": 20,
   "AllowedLocations": "CenterTorso",
-  "DisallowedLocations": "Arms",
+  "DisallowedLocations": "Arms, LeftTorso, RightTorso",
   "ImprovedBallistic": true,
   "BallisticDamagePerPallet": true,
   "DamageNotDivided": true,
   "CriticalComponent": false,
   "Modes": [
     {
-      "Id": "Cannister",
-      "UIName": "Cannister",
+      "Id": "Canister",
+      "UIName": "Canister",
       "isBaseMode": false,
       "AIHitChanceCap": 0.99,
       "AmmoCategory": "GAUSS",
@@ -146,9 +146,7 @@
       "RefireModifier": 2
     }
   ],
-  "statusEffects": [
-
-  ],
+  "statusEffects": [],
   "ComponentTags": {
     "items": [
       "OmniRestriction.{location}",

--- a/RogueModuleTech/RISC/Weapons/Weapon_Gauss_RISC_HEAVY_SM.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_Gauss_RISC_HEAVY_SM.json
@@ -25,7 +25,8 @@
         "WpnRecoil: 2",
         "IsHeavyGauss",
         "WeaponBoom: 100",
-        "GyroStab: 40"
+        "GyroStab: 40",
+        "WeaponReserved: 6"
       ]
     },
     "Linked": {
@@ -48,10 +49,10 @@
     "InventorySorter": {
       "SortKey": "01417"
     },
-	"Flags": {
+    "Flags": {
       "flags": [
         "not_broken",
-		"not_destroyed"
+        "not_destroyed"
       ]
     }
   },
@@ -105,7 +106,7 @@
     "Model": "Heavy Magnetic Cannon",
     "UIName": "Spinal Mount HGR",
     "Id": "Weapon_Gauss_RISC_HEAVY_SM",
-    "Name": "Heavy Gauss Rifle",
+    "Name": "Spinal Mount HGR",
     "Details": "In an attempt to overcome the natural shortcomings of the Heavy Gauss Rifle's did RISC Engineers took to the Clan produced Stone Rhino and Created a Spinal Mounted Heavy Gauss Rifle, managing to increase its range and decrease the weight.\n\n <b><color=#ffcc00>Uses Heavy Gauss Ammo. \n\n</color></b> <b><color=#099ff2>VOLATILE!</color></b>",
     "Icon": "uixSvgIcon_weapon_Ballistic"
   },
@@ -117,8 +118,8 @@
   "BattleValue": 0,
   "InventorySize": 3,
   "Tonnage": 16,
-  "AllowedLocations": "Torso",
-  "DisallowedLocations": "Arms",
+  "AllowedLocations": "CenterTorso",
+  "DisallowedLocations": "Arms, LeftTorso, RightTorso",
   "ImprovedBallistic": true,
   "CriticalComponent": false,
   "statusEffects": [


### PR DESCRIPTION
added missing reserved slots descriptor to SMHGR, excluded side torsos from mount locations on SMGHR and BFG9000 so the mechlab does't highlight them.