### PR TITLE
Primitive mech nerf

### DIFF
--- a/Base 3061/chassis/chassisdef_banshee_BNC-1E.json
+++ b/Base 3061/chassis/chassisdef_banshee_BNC-1E.json
@@ -1,6 +1,6 @@
 {
-"FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Rugged",
       "ComponentDefType": "Upgrade",
@@ -9,9 +9,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 10947310,
+    "Cost": 10513650,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",
@@ -62,10 +62,6 @@
       "Location": "Head",
       "Hardpoints": [
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
           "WeaponMount": "Energy",
           "Omni": false
         }
@@ -81,10 +77,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],
@@ -140,10 +132,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -157,10 +145,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_blackjack_BJ-0.json
+++ b/Base 3061/chassis/chassisdef_blackjack_BJ-0.json
@@ -9,7 +9,7 @@
     "FiringArc": 150
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Extended_Torso_Twist",
       "ComponentDefType": "Upgrade",
@@ -18,9 +18,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 3454430,
+    "Cost": 3205452,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",
@@ -69,12 +69,7 @@
   "Locations": [
     {
       "Location": "Head",
-      "Hardpoints": [
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 6,
       "MaxArmor": 45,
@@ -84,10 +79,6 @@
     {
       "Location": "LeftArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMount": "Ballistic",
           "Omni": false
@@ -101,16 +92,7 @@
     },
     {
       "Location": "LeftTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 110,
@@ -137,16 +119,7 @@
     },
     {
       "Location": "RightTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 110,
@@ -156,10 +129,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMount": "Ballistic",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_commando_COM-1A.json
+++ b/Base 3061/chassis/chassisdef_commando_COM-1A.json
@@ -1,6 +1,6 @@
 {
-"FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Narrow_Low_Profile",
       "ComponentDefType": "Upgrade",
@@ -8,9 +8,10 @@
       "DamageLevel": "Functional",
       "prefabName": "",
       "hasPrefabName": true
-    }],
+    }
+  ],
   "Description": {
-    "Cost": 1406480,
+    "Cost": 1153319,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",
@@ -72,10 +73,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -130,16 +127,7 @@
     },
     {
       "Location": "RightArm",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 40,

--- a/Base 3061/chassis/chassisdef_dervish_DV-1S.json
+++ b/Base 3061/chassis/chassisdef_dervish_DV-1S.json
@@ -1,9 +1,9 @@
 {
- "CustomParts": {
+  "CustomParts": {
     "FiringArc": 130
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Hyper_Extending_Actuators",
       "ComponentDefType": "Upgrade",
@@ -11,9 +11,10 @@
       "DamageLevel": "Functional",
       "prefabName": "",
       "hasPrefabName": true
-    }],
+    }
+  ],
   "Description": {
-    "Cost": 4220640,
+    "Cost": 3869008,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": "",
@@ -145,10 +146,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -186,10 +183,6 @@
     {
       "Location": "RightTorso",
       "Hardpoints": [
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        },
         {
           "WeaponMount": "Missile",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_emperor-EMP-1A.json
+++ b/Base 3061/chassis/chassisdef_emperor-EMP-1A.json
@@ -6,7 +6,7 @@
     }
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Improved_Cooling_Jacket_Laser",
       "ComponentDefType": "Upgrade",
@@ -15,9 +15,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 12263056,
+    "Cost": 10014900,
     "Rarity": 5,
     "Purchasable": false,
     "Manufacturer": "",
@@ -84,10 +84,6 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -99,10 +95,6 @@
     {
       "Location": "LeftTorso",
       "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMount": "Energy",
           "Omni": false
@@ -138,10 +130,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -155,10 +143,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_firebee_FRB-1E.json
+++ b/Base 3061/chassis/chassisdef_firebee_FRB-1E.json
@@ -11,7 +11,7 @@
     }
 	],
   "Description": {
-    "Cost": 1800480,
+    "Cost": 1786304,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",
@@ -223,6 +223,5 @@
       "MaxRearArmor": -1,
       "InternalStructure": 40
     }
-  ],
-  "FixedEquipment": null
+  ]
 }

--- a/Base 3061/chassis/chassisdef_gladiator_GLD-1R.json
+++ b/Base 3061/chassis/chassisdef_gladiator_GLD-1R.json
@@ -7,7 +7,7 @@
     }
   },
   "FixedEquipment": [
-	{
+    {
       "ComponentDefID": "Special_Cowl",
       "ComponentDefType": "Upgrade",
       "DamageLevel": "Functional",
@@ -21,7 +21,7 @@
     }
   ],
   "Description": {
-    "Cost": 4301000,
+    "Cost": 3827892,
     "Rarity": 5,
     "Purchasable": true,
     "Manufacturer": "",
@@ -189,12 +189,7 @@
     },
     {
       "Location": "RightTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 130,
@@ -206,10 +201,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_hector_HOR-1B.json
+++ b/Base 3061/chassis/chassisdef_hector_HOR-1B.json
@@ -6,7 +6,7 @@
     }
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Narrow_Low_Profile",
       "ComponentDefType": "Upgrade",
@@ -15,9 +15,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 6615650,
+    "Cost": 6346912,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
@@ -83,18 +83,6 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -148,18 +136,6 @@
         },
         {
           "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_helepolis_HEP-0H.json
+++ b/Base 3061/chassis/chassisdef_helepolis_HEP-0H.json
@@ -16,7 +16,7 @@
     }
 	],
   "Description": {
-    "Cost": 6919310,
+    "Cost": 6812925,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": "",
@@ -157,10 +157,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -203,10 +199,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
         {
           "WeaponMount": "Ballistic",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_helepolis_HEP-1H.json
+++ b/Base 3061/chassis/chassisdef_helepolis_HEP-1H.json
@@ -4,8 +4,8 @@
       "RightLimit": "Upper"
     }
   },
-   "FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Stable",
       "ComponentDefType": "Upgrade",
@@ -14,9 +14,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 8081472,
+    "Cost": 6742112,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": "",
@@ -83,10 +83,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -98,10 +94,6 @@
     {
       "Location": "LeftTorso",
       "Hardpoints": [
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        },
         {
           "WeaponMount": "Missile",
           "Omni": false
@@ -147,10 +139,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
         {
           "WeaponMount": "Ballistic",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_hornet_HNT-151.json
+++ b/Base 3061/chassis/chassisdef_hornet_HNT-151.json
@@ -5,7 +5,7 @@
     "Include": true
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Narrow_Low_Profile",
       "ComponentDefType": "Upgrade",
@@ -14,9 +14,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 1278360,
+    "Cost": 1256320,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "",
@@ -121,12 +121,7 @@
   "Locations": [
     {
       "Location": "Head",
-      "Hardpoints": [
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 6,
       "MaxArmor": 45,
@@ -199,10 +194,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
         {
           "WeaponMount": "Energy",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_hornet_HNT-152.json
+++ b/Base 3061/chassis/chassisdef_hornet_HNT-152.json
@@ -5,7 +5,7 @@
     "Include": true
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Narrow_Low_Profile",
       "ComponentDefType": "Upgrade",
@@ -14,9 +14,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 1278360,
+    "Cost": 1256320,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "",
@@ -121,12 +121,7 @@
   "Locations": [
     {
       "Location": "Head",
-      "Hardpoints": [
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 6,
       "MaxArmor": 45,
@@ -199,10 +194,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
         {
           "WeaponMount": "Energy",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_icarusii_ICR-1X.json
+++ b/Base 3061/chassis/chassisdef_icarusii_ICR-1X.json
@@ -16,7 +16,7 @@
     }
 	],
   "Description": {
-    "Cost": 3353390,
+    "Cost": 3045168,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",
@@ -204,10 +204,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_longbow_LGB-OC.json
+++ b/Base 3061/chassis/chassisdef_longbow_LGB-OC.json
@@ -5,8 +5,8 @@
       "RightLimit": "Upper"
     }
   },
-   "FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Anti_Air_Targeting",
       "ComponentDefType": "Upgrade",
@@ -15,9 +15,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 9663860,
+    "Cost": 9417616,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",
@@ -140,10 +140,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -201,10 +197,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        },
         {
           "WeaponMount": "Missile",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_mackie_MSK-5S.json
+++ b/Base 3061/chassis/chassisdef_mackie_MSK-5S.json
@@ -22,7 +22,7 @@
     }
 	],
   "Description": {
-    "Cost": 12722400,
+    "Cost": 10899616,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "",
@@ -140,10 +140,6 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -157,10 +153,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],
@@ -194,10 +186,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -209,10 +197,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMount": "Energy",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_mackie_MSK-6S.json
+++ b/Base 3061/chassis/chassisdef_mackie_MSK-6S.json
@@ -22,7 +22,7 @@
     }
 	],
   "Description": {
-    "Cost": 12722400,
+    "Cost": 10899616,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "",
@@ -140,10 +140,6 @@
         {
           "WeaponMount": "Ballistic",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -157,10 +153,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],
@@ -194,10 +186,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -209,10 +197,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMount": "Energy",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_orion_ON1-C.json
+++ b/Base 3061/chassis/chassisdef_orion_ON1-C.json
@@ -20,7 +20,7 @@
     }
   ],
   "Description": {
-    "Cost": 7050710,
+    "Cost": 6671413,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",
@@ -138,10 +138,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -152,12 +148,7 @@
     },
     {
       "Location": "LeftTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 160,
@@ -201,10 +192,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_orion_ON1-H.json
+++ b/Base 3061/chassis/chassisdef_orion_ON1-H.json
@@ -20,7 +20,7 @@
     }
   ],
   "Description": {
-    "Cost": 7050710,
+    "Cost": 6883852,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",

--- a/Base 3061/chassis/chassisdef_ostwar_OWR-2M.json
+++ b/Base 3061/chassis/chassisdef_ostwar_OWR-2M.json
@@ -17,7 +17,7 @@
     }
 	],
   "Description": {
-    "Cost": 6280450,
+    "Cost": 6141693,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
@@ -149,10 +149,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -188,10 +184,6 @@
         },
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_thorn_THE-S.json
+++ b/Base 3061/chassis/chassisdef_thorn_THE-S.json
@@ -1,6 +1,6 @@
 {
-"FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Easy_To_Maintain",
       "ComponentDefType": "Upgrade",
@@ -9,14 +9,14 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Custom": {
     "ArmActuatorSupport": {
       "LeftLimit": "Lower"
     }
   },
   "Description": {
-    "Cost": 1265250,
+    "Cost": 1319136,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",
@@ -156,10 +156,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         },
         {

--- a/Base 3061/chassis/chassisdef_thorn_THE-T.json
+++ b/Base 3061/chassis/chassisdef_thorn_THE-T.json
@@ -1,6 +1,6 @@
 {
-"FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Easy_To_Maintain",
       "ComponentDefType": "Upgrade",
@@ -9,14 +9,14 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Custom": {
     "ArmActuatorSupport": {
       "LeftLimit": "Lower"
     }
   },
   "Description": {
-    "Cost": 1265250,
+    "Cost": 1319136,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",
@@ -156,10 +156,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         },
         {

--- a/Base 3061/chassis/chassisdef_thunderbolt_TDR-1C.json
+++ b/Base 3061/chassis/chassisdef_thunderbolt_TDR-1C.json
@@ -1,6 +1,6 @@
 {
   "Description": {
-    "Cost": 6396600,
+    "Cost": 6205248,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
@@ -76,14 +76,6 @@
         },
         {
           "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],
@@ -164,10 +156,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_wasp_WSP-1.json
+++ b/Base 3061/chassis/chassisdef_wasp_WSP-1.json
@@ -7,8 +7,8 @@
   "CustomParts": {
     "FiringArc": 150
   },
-   "FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Extended_Torso_Twist",
       "ComponentDefType": "Upgrade",
@@ -17,9 +17,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 1226910,
+    "Cost": 1153319,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
@@ -133,16 +133,7 @@
     },
     {
       "Location": "LeftArm",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 30,
@@ -194,10 +185,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
           "Omni": false
         }
       ],

--- a/Base 3061/chassis/chassisdef_wasp_WSP-1P.json
+++ b/Base 3061/chassis/chassisdef_wasp_WSP-1P.json
@@ -7,8 +7,8 @@
   "CustomParts": {
     "FiringArc": 150
   },
-   "FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Extended_Torso_Twist",
       "ComponentDefType": "Upgrade",
@@ -17,9 +17,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 1291490,
+    "Cost": 1256320,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
@@ -148,10 +148,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -194,10 +190,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMount": "Ballistic",
           "Omni": false

--- a/Base 3061/chassis/chassisdef_wolverine_WVR-1R.json
+++ b/Base 3061/chassis/chassisdef_wolverine_WVR-1R.json
@@ -1,6 +1,6 @@
 {
-"FixedEquipment": [
-  {
+  "FixedEquipment": [
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Improved_Comms",
       "ComponentDefType": "Upgrade",
@@ -9,9 +9,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 4034230,
+    "Cost": 3786852,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": "",
@@ -74,16 +74,7 @@
     },
     {
       "Location": "LeftArm",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 90,
@@ -137,10 +128,6 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
         {
           "WeaponMount": "Ballistic",
           "Omni": false

--- a/Base 3061/mech/mechdef_banshee_BNC-1E.json
+++ b/Base 3061/mech/mechdef_banshee_BNC-1E.json
@@ -43,7 +43,7 @@
   "ChassisID": "chassisdef_banshee_BNC-1E",
   "HeraldryID": null,
   "Description": {
-    "Cost": 2189462,
+    "Cost": 2102730,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": null,
@@ -54,7 +54,7 @@
     "Details": "__/Base_3061.mechdef_banshee_BNC-1E.Details/__",
     "Icon": "uixTxrIcon_banshee"
   },
-  "simGameMechPartCost": 1170000,
+  "simGameMechPartCost": 2102730,
   "Version": 1,
   "Locations": [
     {

--- a/Base 3061/mech/mechdef_blackjack_BJ-0.json
+++ b/Base 3061/mech/mechdef_blackjack_BJ-0.json
@@ -8,6 +8,7 @@
       "unit_lance_assassin",
       "unit_role_flanker",
       "unit_release",
+      "unit_primitive",
       "INVALID_UNSET",
       "NoFaction",
       "Player1sMercUnit",
@@ -42,7 +43,7 @@
   "ChassisID": "chassisdef_blackjack_BJ-0",
   "HeraldryID": null,
   "Description": {
-    "Cost": 690886,
+    "Cost": 641090,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
@@ -53,7 +54,7 @@
     "Details": "__/Base_3061.mechdef_blackjack_BJ-0.Details/__",
     "Icon": "uixTxrIcon_blackjack"
   },
-  "simGameMechPartCost": 440000,
+  "simGameMechPartCost": 641090,
   "Version": 1,
   "Locations": [
     {

--- a/Base 3061/mech/mechdef_commando_COM-1A.json
+++ b/Base 3061/mech/mechdef_commando_COM-1A.json
@@ -45,7 +45,7 @@
   "ChassisID": "chassisdef_commando_COM-1A",
   "HeraldryID": null,
   "Description": {
-    "Cost": 281296,
+    "Cost": 230664,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
@@ -56,7 +56,7 @@
     "Details": "__/Base_3061.mechdef_commando_COM-1A.Details/__",
     "Icon": "uixTxrIcon_commando"
   },
-  "simGameMechPartCost": 250000,
+  "simGameMechPartCost": 230664,
   "Version": 1,
   "Locations": [
     {

--- a/Base 3061/mech/mechdef_dervish_DV-1S.json
+++ b/Base 3061/mech/mechdef_dervish_DV-1S.json
@@ -46,7 +46,7 @@
     "ChassisID": "chassisdef_dervish_DV-1S",
     "HeraldryID": null,
     "Description": {
-        "Cost": 790294,
+        "Cost": 773802,
         "Rarity": 1,
         "Purchasable": false,
         "Manufacturer": null,
@@ -493,5 +493,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 790294
+    "simGameMechPartCost": 773802
 }

--- a/Base 3061/mech/mechdef_emperor-EMP-1A.json
+++ b/Base 3061/mech/mechdef_emperor-EMP-1A.json
@@ -44,7 +44,7 @@
     "tagSetSourceFile": ""
   },
   "Description": {
-    "Cost": 2452611,
+    "Cost": 2002980,
     "Rarity": 0,
     "Purchasable": false,
     "Manufacturer": null,
@@ -56,7 +56,7 @@
     "Icon": "uixTxrIcon_emperor"
   },
   "ChassisID": "chassisdef_emperor-EMP-1A",
-  "simGameMechPartCost": 2452611,
+  "simGameMechPartCost": 2002980,
   "Locations": [
     {
       "DamageLevel": "Functional",

--- a/Base 3061/mech/mechdef_firebee_FRB-1E.json
+++ b/Base 3061/mech/mechdef_firebee_FRB-1E.json
@@ -48,7 +48,7 @@
     "ChassisID": "chassisdef_firebee_FRB-1E",
     "HeraldryID": null,
     "Description": {
-        "Cost": 360096,
+        "Cost": 357261,
         "Rarity": 1,
         "Purchasable": false,
         "Manufacturer": null,
@@ -567,5 +567,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 360096
+    "simGameMechPartCost": 357261
 }

--- a/Base 3061/mech/mechdef_gladiator_GLD-1R.json
+++ b/Base 3061/mech/mechdef_gladiator_GLD-1R.json
@@ -19,7 +19,7 @@
   "ChassisID": "chassisdef_gladiator_GLD-1R",
   "HeraldryID": null,
   "Description": {
-    "Cost": 860200,
+    "Cost": 765578,
     "Rarity": 5,
     "Purchasable": false,
     "Manufacturer": null,
@@ -30,13 +30,6 @@
     "Details": "__/Base_3061.mechdef_gladiator_GLD-1R.Details/__",
     "Icon": "Gladiator"
   },
-  "RequiredToSpawnCompanyTags": {
-    "items": [],
-    "tagSetSourceFile": ""
-  },
-  "MinAppearanceDate": null,
-  "prefabOverride": null,
-  "Version": 1,
   "Locations": [
     {
       "DamageLevel": "Functional",
@@ -533,5 +526,5 @@
       "hasPrefabName": false
     }
   ],
-  "simGameMechPartCost": 860200
+  "simGameMechPartCost": 765578
 }

--- a/Base 3061/mech/mechdef_hector_HOR-1B.json
+++ b/Base 3061/mech/mechdef_hector_HOR-1B.json
@@ -42,7 +42,7 @@
   "ChassisID": "chassisdef_hector_HOR-1B",
   "HeraldryID": null,
   "Description": {
-    "Cost": 1323130,
+    "Cost": 1269382,
     "Rarity": 5,
     "Purchasable": true,
     "Manufacturer": null,
@@ -53,7 +53,7 @@
     "Details": "__/Base_3061.mechdef_hector_HOR-1B.Details/__",
     "Icon": "Hector"
   },
-  "simGameMechPartCost": 870000,
+  "simGameMechPartCost": 1269382,
   "Version": 1,
   "Locations": [
     {

--- a/Base 3061/mech/mechdef_helepolis_HEP-0H.json
+++ b/Base 3061/mech/mechdef_helepolis_HEP-0H.json
@@ -44,7 +44,7 @@
     "ChassisID": "chassisdef_helepolis_HEP-0H",
     "HeraldryID": null,
     "Description": {
-        "Cost": 1383862,
+        "Cost": 1362585,
         "Rarity": 2,
         "Purchasable": false,
         "Manufacturer": null,
@@ -647,5 +647,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 1383862
+    "simGameMechPartCost": 1362585
 }

--- a/Base 3061/mech/mechdef_helepolis_HEP-1H.json
+++ b/Base 3061/mech/mechdef_helepolis_HEP-1H.json
@@ -45,7 +45,7 @@
   "ChassisID": "chassisdef_helepolis_HEP-1H",
   "HeraldryID": null,
   "Description": {
-    "Cost": 1616294,
+    "Cost": 1348422,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
@@ -56,7 +56,7 @@
     "Details": "__/Artillery_Units.mechdef_helepolis_HEP-1H.Details/__",
     "Icon": "helepolis"
   },
-  "simGameMechPartCost": 1616294,
+  "simGameMechPartCost": 1348422,
   "Version": 1,
   "Locations": [
     {

--- a/Base 3061/mech/mechdef_hornet_HNT-151.json
+++ b/Base 3061/mech/mechdef_hornet_HNT-151.json
@@ -65,7 +65,7 @@
   "ChassisID": "chassisdef_hornet_HNT-151",
   "HeraldryID": null,
   "Description": {
-    "Cost": 255672,
+    "Cost": 251264,
     "Rarity": 0,
     "Purchasable": false,
     "Manufacturer": null,
@@ -76,13 +76,6 @@
     "Details": "__/Base_3061.mechdef_hornet_HNT-151.Details/__",
     "Icon": "Hornet"
   },
-  "RequiredToSpawnCompanyTags": {
-    "items": [],
-    "tagSetSourceFile": ""
-  },
-  "MinAppearanceDate": null,
-  "prefabOverride": null,
-  "Version": 1,
   "Locations": [
     {
       "DamageLevel": "Functional",
@@ -627,5 +620,5 @@
       "hasPrefabName": false
     }
   ],
-  "simGameMechPartCost": 255672
+  "simGameMechPartCost": 251264
 }

--- a/Base 3061/mech/mechdef_hornet_HNT-152.json
+++ b/Base 3061/mech/mechdef_hornet_HNT-152.json
@@ -33,7 +33,7 @@
   "ChassisID": "chassisdef_hornet_HNT-152",
   "HeraldryID": null,
   "Description": {
-    "Cost": 255672,
+    "Cost": 251264,
     "Rarity": 0,
     "Purchasable": false,
     "Manufacturer": null,
@@ -44,13 +44,6 @@
     "Details": "__/Base_3061.mechdef_hornet_HNT-152.Details/__",
     "Icon": "Hornet"
   },
-  "RequiredToSpawnCompanyTags": {
-    "items": [],
-    "tagSetSourceFile": ""
-  },
-  "MinAppearanceDate": null,
-  "prefabOverride": null,
-  "Version": 1,
   "Locations": [
     {
       "DamageLevel": "Functional",
@@ -595,5 +588,5 @@
       "hasPrefabName": false
     }
   ],
-  "simGameMechPartCost": 255672
+  "simGameMechPartCost": 251264
 }

--- a/Base 3061/mech/mechdef_icarusii_ICR-1X.json
+++ b/Base 3061/mech/mechdef_icarusii_ICR-1X.json
@@ -44,7 +44,7 @@
     "ChassisID": "chassisdef_icarusii_ICR-1X",
     "HeraldryID": null,
     "Description": {
-        "Cost": 615592,
+        "Cost": 609034,
         "Rarity": 1,
         "Purchasable": false,
         "Manufacturer": null,
@@ -515,5 +515,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 615592
+    "simGameMechPartCost": 609034
 }

--- a/Base 3061/mech/mechdef_longbow_LGB-OC.json
+++ b/Base 3061/mech/mechdef_longbow_LGB-OC.json
@@ -45,7 +45,7 @@
     "ChassisID": "chassisdef_longbow_LGB-OC",
     "HeraldryID": null,
     "Description": {
-        "Cost": 1932772,
+        "Cost": 1883523,
         "Rarity": 4,
         "Purchasable": false,
         "Manufacturer": null,
@@ -564,5 +564,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 1932772
+    "simGameMechPartCost": 1883523
 }

--- a/Base 3061/mech/mechdef_mackie_MSK-5S.json
+++ b/Base 3061/mech/mechdef_mackie_MSK-5S.json
@@ -42,7 +42,7 @@
   "ChassisID": "chassisdef_mackie_MSK-5S",
   "HeraldryID": null,
   "Description": {
-    "Cost": 2544480,
+    "Cost": 2179923,
     "Rarity": 5,
     "Purchasable": false,
     "Manufacturer": null,
@@ -508,5 +508,5 @@
       "hasPrefabName": false
     }
   ],
-  "simGameMechPartCost": 2544480
+  "simGameMechPartCost": 2179923
 }

--- a/Base 3061/mech/mechdef_mackie_MSK-6S.json
+++ b/Base 3061/mech/mechdef_mackie_MSK-6S.json
@@ -42,7 +42,7 @@
   "ChassisID": "chassisdef_mackie_MSK-6S",
   "HeraldryID": null,
   "Description": {
-    "Cost": 2544480,
+    "Cost": 2179923,
     "Rarity": 5,
     "Purchasable": false,
     "Manufacturer": null,
@@ -53,13 +53,6 @@
     "Details": "__/Base_3061.mechdef_mackie_MSK-6S.Details/__",
     "Icon": "mackie"
   },
-  "RequiredToSpawnCompanyTags": {
-    "items": [],
-    "tagSetSourceFile": ""
-  },
-  "MinAppearanceDate": null,
-  "prefabOverride": null,
-  "Version": 1,
   "Locations": [
     {
       "DamageLevel": "Functional",
@@ -496,5 +489,5 @@
       "hasPrefabName": false
     }
   ],
-  "simGameMechPartCost": 2544480
+  "simGameMechPartCost": 2179923
 }

--- a/Base 3061/mech/mechdef_orion_ON1-C.json
+++ b/Base 3061/mech/mechdef_orion_ON1-C.json
@@ -44,7 +44,7 @@
     "ChassisID": "chassisdef_orion_ON1-C",
     "HeraldryID": null,
     "Description": {
-        "Cost": 1376770,
+        "Cost": 1334283,
         "Rarity": 4,
         "Purchasable": false,
         "Manufacturer": null,
@@ -407,5 +407,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 1376770
+    "simGameMechPartCost": 1334283
 }

--- a/Base 3061/mech/mechdef_ostwar_OWR-2M.json
+++ b/Base 3061/mech/mechdef_ostwar_OWR-2M.json
@@ -46,7 +46,7 @@
     "ChassisID": "chassisdef_ostwar_OWR-2M",
     "HeraldryID": null,
     "Description": {
-        "Cost": 1256090,
+        "Cost": 1228339,
         "Rarity": 3,
         "Purchasable": false,
         "Manufacturer": null,
@@ -589,5 +589,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 1256090
+    "simGameMechPartCost": 1228339
 }

--- a/Base 3061/mech/mechdef_thorn_THE-S.json
+++ b/Base 3061/mech/mechdef_thorn_THE-S.json
@@ -19,7 +19,7 @@
     "ChassisID": "chassisdef_thorn_THE-S",
     "HeraldryID": null,
     "Description": {
-        "Cost": 253050,
+        "Cost": 263827,
         "Rarity": 4,
         "Purchasable": false,
         "Manufacturer": null,
@@ -550,5 +550,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 253050
+    "simGameMechPartCost": 263827
 }

--- a/Base 3061/mech/mechdef_thorn_THE-T.json
+++ b/Base 3061/mech/mechdef_thorn_THE-T.json
@@ -18,7 +18,7 @@
     "ChassisID": "chassisdef_thorn_THE-T",
     "HeraldryID": null,
     "Description": {
-        "Cost": 253050,
+        "Cost": 263827,
         "Rarity": 4,
         "Purchasable": false,
         "Manufacturer": null,
@@ -549,5 +549,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 253050
+    "simGameMechPartCost": 263827
 }

--- a/Base 3061/mech/mechdef_thunderbolt_TDR-1C.json
+++ b/Base 3061/mech/mechdef_thunderbolt_TDR-1C.json
@@ -43,7 +43,7 @@
   "ChassisID": "chassisdef_thunderbolt_TDR-1C",
   "HeraldryID": null,
   "Description": {
-    "Cost": 1279320,
+    "Cost": 1241050,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": null,
@@ -54,7 +54,7 @@
     "Details": "__/Base_3061.mechdef_thunderbolt_TDR-1C.Details/__",
     "Icon": "uixTxrIcon_thunderbolt"
   },
-  "simGameMechPartCost": 760000,
+  "simGameMechPartCost": 1241050,
   "Version": 1,
   "Locations": [
     {

--- a/Base 3061/mech/mechdef_wasp_WSP-1.json
+++ b/Base 3061/mech/mechdef_wasp_WSP-1.json
@@ -42,7 +42,7 @@
   "ChassisID": "chassisdef_wasp_WSP-1",
   "HeraldryID": null,
   "Description": {
-    "Cost": 245382,
+    "Cost": 230664,
     "Rarity": 1,
     "Purchasable": false,
     "Manufacturer": null,
@@ -616,5 +616,5 @@
       "hasPrefabName": false
     }
   ],
-  "simGameMechPartCost": 245382
+  "simGameMechPartCost": 230664
 }

--- a/Base 3061/mech/mechdef_wasp_WSP-1P.json
+++ b/Base 3061/mech/mechdef_wasp_WSP-1P.json
@@ -60,7 +60,7 @@
   "ChassisID": "chassisdef_wasp_WSP-1P",
   "HeraldryID": null,
   "Description": {
-    "Cost": 258298,
+    "Cost": 251264,
     "Rarity": 1,
     "Purchasable": false,
     "Manufacturer": null,
@@ -71,13 +71,6 @@
     "Details": "__/Base_3061.mechdef_wasp_WSP-1P.Details/__",
     "Icon": "wasp"
   },
-  "RequiredToSpawnCompanyTags": {
-    "items": [],
-    "tagSetSourceFile": ""
-  },
-  "MinAppearanceDate": null,
-  "prefabOverride": null,
-  "Version": 1,
   "Locations": [
     {
       "DamageLevel": "Functional",
@@ -646,5 +639,5 @@
       "hasPrefabName": false
     }
   ],
-  "simGameMechPartCost": 258298
+  "simGameMechPartCost": 251264
 }

--- a/Base 3061/mech/mechdef_wolverine_WVR-1R.json
+++ b/Base 3061/mech/mechdef_wolverine_WVR-1R.json
@@ -41,7 +41,7 @@
   "ChassisID": "chassisdef_wolverine_WVR-1R",
   "HeraldryID": null,
   "Description": {
-    "Cost": 806846,
+    "Cost": 757370,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
@@ -52,7 +52,7 @@
     "Details": "__/Base_3061.mechdef_wolverine_WVR-1R.Details/__",
     "Icon": "uixTxrIcon_wolverine"
   },
-  "simGameMechPartCost": 630000,
+  "simGameMechPartCost": 757370,
   "Version": 1,
   "Locations": [
     {

--- a/Base HeavyMetal/chassis/chassisdef_archer_ARC-1A.json
+++ b/Base HeavyMetal/chassis/chassisdef_archer_ARC-1A.json
@@ -1,6 +1,6 @@
 {
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Battle_Fists",
       "SimGameUID": null,
@@ -11,9 +11,9 @@
       "prefabName": null,
       "hasPrefabName": false
     }
-	],
+  ],
   "Description": {
-    "Cost": 6481052,
+    "Cost": 6346912,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",
@@ -145,10 +145,6 @@
         {
           "WeaponMount": "Missile",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -186,10 +182,6 @@
     {
       "Location": "RightTorso",
       "Hardpoints": [
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        },
         {
           "WeaponMount": "Missile",
           "Omni": false

--- a/Base HeavyMetal/chassis/chassisdef_flea_FLE-4.json
+++ b/Base HeavyMetal/chassis/chassisdef_flea_FLE-4.json
@@ -6,7 +6,7 @@
     }
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Improved_Lifesupport",
       "ComponentDefType": "Upgrade",
@@ -15,9 +15,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 1454649,
+    "Cost": 1319136,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",
@@ -83,18 +83,6 @@
         {
           "WeaponMount": "Energy",
           "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
         }
       ],
       "Tonnage": 0,
@@ -117,14 +105,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         },
         {
@@ -156,22 +136,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/Base HeavyMetal/chassis/chassisdef_rifleman_RFL-1N.json
+++ b/Base HeavyMetal/chassis/chassisdef_rifleman_RFL-1N.json
@@ -6,7 +6,7 @@
     }
   },
   "FixedEquipment": [
-  {
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Special_Anti_Air_Targeting",
       "ComponentDefType": "Upgrade",
@@ -15,9 +15,9 @@
       "prefabName": "",
       "hasPrefabName": true
     }
-	],
+  ],
   "Description": {
-    "Cost": 3631240,
+    "Cost": 3572608,
     "Rarity": 4,
     "Purchasable": true,
     "Manufacturer": "",
@@ -149,12 +149,7 @@
     },
     {
       "Location": "LeftTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 120,
@@ -181,12 +176,7 @@
     },
     {
       "Location": "RightTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 120,

--- a/Base HeavyMetal/chassis/chassisdef_trooper_TP-1R.json
+++ b/Base HeavyMetal/chassis/chassisdef_trooper_TP-1R.json
@@ -17,7 +17,7 @@
     }
 	],
   "Description": {
-    "Cost": 1454649,
+    "Cost": 1193504,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",

--- a/Base HeavyMetal/mech/mechdef_archer_ARC-1A.json
+++ b/Base HeavyMetal/mech/mechdef_archer_ARC-1A.json
@@ -45,7 +45,7 @@
     "ChassisID": "chassisdef_archer_ARC-1A",
     "HeraldryID": null,
     "Description": {
-        "Cost": 1296210,
+        "Cost": 1269382,
         "Rarity": 4,
         "Purchasable": false,
         "Manufacturer": null,
@@ -564,5 +564,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 1296210
+    "simGameMechPartCost": 1269382
 }

--- a/Base HeavyMetal/mech/mechdef_flea_FLE-4.json
+++ b/Base HeavyMetal/mech/mechdef_flea_FLE-4.json
@@ -54,7 +54,7 @@
   "ChassisID": "chassisdef_flea_FLE-4",
   "HeraldryID": null,
   "Description": {
-    "Cost": 290930,
+    "Cost": 263827,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": null,
@@ -65,7 +65,7 @@
     "Details": "__/Base_3061.mechdef_flea_FLE-4.Details/__",
     "Icon": "flea"
   },
-  "simGameMechPartCost": 506400,
+  "simGameMechPartCost": 263827,
   "Version": 1,
   "Locations": [
     {

--- a/Base HeavyMetal/mech/mechdef_rifleman_RFL-1N.json
+++ b/Base HeavyMetal/mech/mechdef_rifleman_RFL-1N.json
@@ -45,7 +45,7 @@
     "ChassisID": "chassisdef_rifleman_RFL-1N",
     "HeraldryID": null,
     "Description": {
-        "Cost": 726248,
+        "Cost": 714522,
         "Rarity": 4,
         "Purchasable": false,
         "Manufacturer": null,
@@ -504,5 +504,5 @@
             "hasPrefabName": false
         }
     ],
-    "simGameMechPartCost": 726248
+    "simGameMechPartCost": 714522
 }

--- a/Base HeavyMetal/mech/mechdef_trooper_TP-1R.json
+++ b/Base HeavyMetal/mech/mechdef_trooper_TP-1R.json
@@ -33,7 +33,7 @@
   "ChassisID": "chassisdef_trooper_TP-1R",
   "HeraldryID": null,
   "Description": {
-    "Cost": 290930,
+    "Cost": 238701,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": null,
@@ -44,7 +44,7 @@
     "Details": "__/Base_3061.mechdef_trooper_TP-1R.Details/__",
     "Icon": "flea"
   },
-  "simGameMechPartCost": 506400,
+  "simGameMechPartCost": 238701,
   "Version": 1,
   "Locations": [
     {

--- a/Jihad 3068-3080/chassis/chassisdef_piranha_PIR-B.json
+++ b/Jihad 3068-3080/chassis/chassisdef_piranha_PIR-B.json
@@ -288,24 +288,6 @@
                     "Omni": false
                 },
                 {
-                    "WeaponMount": "AntiPersonnel",
-                    "Omni": false
-                }
-            ],
-            "Tonnage": 0,
-            "InventorySlots": 12,
-            "MaxArmor": 50,
-            "MaxRearArmor": 25,
-            "InternalStructure": 25
-        },
-        {
-            "Location": "RightArm",
-            "Hardpoints": [
-                {
-                    "WeaponMount": "Energy",
-                    "Omni": false
-                },
-                {
                     "WeaponMount": "Energy",
                     "Omni": false
                 }


### PR DESCRIPTION
Nerfed all primitive mechs to only have hard points matching their load out (e.g. Wasp 1 has a single laser hard point while the Archer 1A has 2 energy and 2 missile) and updated their costs to reflect this (most where over priced pre nerf, should be the cheapest mechs around now). Also tweaked a few other mech hard points and costs