### PR TITLE
LV_HEAT_VISION fix

### DIFF
--- a/RogueModuleTech/PowerArmor/PAinternals/Gear_Cockpit_Elemental.json
+++ b/RogueModuleTech/PowerArmor/PAinternals/Gear_Cockpit_Elemental.json
@@ -102,7 +102,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_70",
+                "modValue": "-1_70_300",
                 "modType": "System.String"
             }
         },

--- a/RogueModuleTech/PowerArmor/PAinternals/PA_Elemental.json
+++ b/RogueModuleTech/PowerArmor/PAinternals/PA_Elemental.json
@@ -102,7 +102,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_70",
+                "modValue": "-1_70_300",
                 "modType": "System.String"
             }
         },

--- a/RogueModuleTech/PowerArmor/PAinternals/PA_Soldier.json
+++ b/RogueModuleTech/PowerArmor/PAinternals/PA_Soldier.json
@@ -156,7 +156,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_80",
+                "modValue": "-1_80_300",
                 "modType": "System.String"
             }
         },

--- a/RogueModuleTech/Quirks/PositiveQuirks/Special_AdvancedOptics_Quirk.json
+++ b/RogueModuleTech/Quirks/PositiveQuirks/Special_AdvancedOptics_Quirk.json
@@ -134,7 +134,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_30_300",
+                "modValue": "-1_30_300",
                 "modType": "System.String"
             }
         }

--- a/RogueModuleTech/Quirks/Upgrade/Gear_FCS_FlexTech.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_FCS_FlexTech.json
@@ -156,7 +156,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_75",
+                "modValue": "1_75_200",
                 "modType": "System.String"
             }
         },

--- a/RogueModuleTech/Quirks/Upgrade/Gear_FCS_FlexTech.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_FCS_FlexTech.json
@@ -156,7 +156,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_75_200",
+                "modValue": "-1_75_200",
                 "modType": "System.String"
             }
         },

--- a/RogueModuleTech/Widget/Specials/Special_AdvancedOptics_MK1.json
+++ b/RogueModuleTech/Widget/Specials/Special_AdvancedOptics_MK1.json
@@ -128,7 +128,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_65_200",
+                "modValue": "-1_65_200",
                 "modType": "System.String"
             }
         }

--- a/RogueModuleTech/Widget/Specials/Special_AdvancedOptics_MK2.json
+++ b/RogueModuleTech/Widget/Specials/Special_AdvancedOptics_MK2.json
@@ -128,7 +128,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "2_60_220",
+                "modValue": "-2_60_220",
                 "modType": "System.String"
             }
         }

--- a/RogueModuleTech/Widget/Specials/Special_AdvancedOptics_MK3.json
+++ b/RogueModuleTech/Widget/Specials/Special_AdvancedOptics_MK3.json
@@ -128,7 +128,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_25_240",
+                "modValue": "-1_25_240",
                 "modType": "System.String"
             }
         }

--- a/RogueModuleTech/Widget/Specials/Special_ThermalVision_MK1.json
+++ b/RogueModuleTech/Widget/Specials/Special_ThermalVision_MK1.json
@@ -77,7 +77,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_70_300",
+                "modValue": "-1_70_300",
                 "modType": "System.String"
             }
         }

--- a/RogueModuleTech/Widget/Specials/Special_ThermalVision_MK2.json
+++ b/RogueModuleTech/Widget/Specials/Special_ThermalVision_MK2.json
@@ -77,7 +77,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_50_330",
+                "modValue": "-1_50_330",
                 "modType": "System.String"
             }
         }

--- a/RogueModuleTech/Widget/Specials/Special_ThermalVision_MK3.json
+++ b/RogueModuleTech/Widget/Specials/Special_ThermalVision_MK3.json
@@ -77,7 +77,7 @@
             "statisticData": {
                 "statName": "LV_HEAT_VISION",
                 "operation": "Set",
-                "modValue": "1_30_360",
+                "modValue": "-1_30_360",
                 "modType": "System.String"
             }
         }


### PR DESCRIPTION
Frosty flipped sign on heatvision (now negative is a bonus)
following ones didnt had range, updated to placeholder values (bonusdesc not updated)
Gear_FCS_FlexTech
PA_Elemental
Gear_Cockpit_Elemental
PA_Soldier