### PR TITLE
Missing lance tags

### DIFF
--- a/RogueTech Core/Lances/MechBattle/lancedef_mech_d2_dynamic_battle_small.json
+++ b/RogueTech Core/Lances/MechBattle/lancedef_mech_d2_dynamic_battle_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mech",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MechCavalry/lancedef_mech_d1_dynamic_cavalry_small.json
+++ b/RogueTech Core/Lances/MechCavalry/lancedef_mech_d1_dynamic_cavalry_small.json
@@ -38,7 +38,7 @@
             "excludedUnitTagSet": {
                 "items": [
                     "unit_noncombatant",
-					"unit_legendary"
+					"unit_legendary",
                     "unit_bracket_med",
                     "unit_bracket_high",
                     "unit_lance_support",

--- a/RogueTech Core/Lances/MechCavalry/lancedef_mech_d2_dynamic_cavalry_small.json
+++ b/RogueTech Core/Lances/MechCavalry/lancedef_mech_d2_dynamic_cavalry_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mech",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MechFire/lancedef_mech_d2_dynamic_fire_small.json
+++ b/RogueTech Core/Lances/MechFire/lancedef_mech_d2_dynamic_fire_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mech",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MechRecon/lancedef_mech_d2_dynamic_recon_small.json
+++ b/RogueTech Core/Lances/MechRecon/lancedef_mech_d2_dynamic_recon_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mech",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MechSupport/lancedef_mech_d2_dynamic_support_small.json
+++ b/RogueTech Core/Lances/MechSupport/lancedef_mech_d2_dynamic_support_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mech",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MixedAgnosticBattle/lancedef_agnostic_d1_dynamic_lightBattle_small.json
+++ b/RogueTech Core/Lances/MixedAgnosticBattle/lancedef_agnostic_d1_dynamic_lightBattle_small.json
@@ -48,7 +48,7 @@
                     "unit_heavy",
                     "unit_medium",
                     "unit_vbied",
-					"unit_legendary",
+					"unit_legendary"
                 ],
                 "tagSetSourceFile": "Tags/UnitTags"
             },

--- a/RogueTech Core/Lances/MixedBattle/lancedef_mixed_d2_dynamic_battle_small.json
+++ b/RogueTech Core/Lances/MixedBattle/lancedef_mixed_d2_dynamic_battle_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mixed",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MixedCavalry/lancedef_mixed_d2_dynamic_cavalry_small.json
+++ b/RogueTech Core/Lances/MixedCavalry/lancedef_mixed_d2_dynamic_cavalry_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mixed",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MixedFire/lancedef_mixed_d2_dynamic_fire_small.json
+++ b/RogueTech Core/Lances/MixedFire/lancedef_mixed_d2_dynamic_fire_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mixed",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/MixedSupport/lancedef_mixed_d2_dynamic_support_small.json
+++ b/RogueTech Core/Lances/MixedSupport/lancedef_mixed_d2_dynamic_support_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mixed",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/Primitive/lancedef_mech_d2_primitive_small.json
+++ b/RogueTech Core/Lances/Primitive/lancedef_mech_d2_primitive_small.json
@@ -16,6 +16,7 @@
             "lance_type_dynamic",
             "lance_type_mech",
             "lance_type_notallvehicles",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/VTOL/lancedef_mixed_d2_vtol_battle_small.json
+++ b/RogueTech Core/Lances/VTOL/lancedef_mixed_d2_vtol_battle_small.json
@@ -18,6 +18,7 @@
             "lance_type_mixed",
             "lance_type_notallvehicles",
             "lance_type_vtol",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/VehicleBattle/lancedef_vehicle_d2_dynamic_battle_small.json
+++ b/RogueTech Core/Lances/VehicleBattle/lancedef_vehicle_d2_dynamic_battle_small.json
@@ -15,6 +15,7 @@
             "lance_type_battle",
             "lance_type_dynamic",
             "lance_type_vehicle",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/VehicleCavalry/lancedef_vehicle_d2_dynamic_cavalry_small.json
+++ b/RogueTech Core/Lances/VehicleCavalry/lancedef_vehicle_d2_dynamic_cavalry_small.json
@@ -15,6 +15,7 @@
             "lance_type_cavalry",
             "lance_type_dynamic",
             "lance_type_vehicle",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"

--- a/RogueTech Core/Lances/VehicleSupport/lancedef_vehicle_d2_dynamic_support_small.json
+++ b/RogueTech Core/Lances/VehicleSupport/lancedef_vehicle_d2_dynamic_support_small.json
@@ -15,6 +15,7 @@
             "lance_type_support",
             "lance_type_dynamic",
             "lance_type_vehicle",
+            "lance_type_notfull",
             "lance_type_roguetech"
         ],
         "tagSetSourceFile": "Tags/LanceTags"


### PR DESCRIPTION
Added  "lance_type_notfull", to 16 D2 lances with only three units.