### PR TITLE
Pod effect type and class to missile

### DIFF
--- a/RogueModuleTech/Widget/Pods/Weapon_POD_A.json
+++ b/RogueModuleTech/Widget/Pods/Weapon_POD_A.json
@@ -18,7 +18,7 @@
                 "BoltOn: 1",
                 "1shot",
                 "AreaOfEffect: 120",
-		"AreaOfEffectDmg: 50",
+                "AreaOfEffectDmg: 50",
                 "PipsIgnored: 6",
                 "InternalAmmo: 5",
                 "NoAA"
@@ -34,8 +34,8 @@
         }
     },
     "weaponCategoryID": "SpecialMelee",
-    "Type": "Autocannon",
-    "WeaponSubType": "AC2",
+    "Type": "SRM",
+    "WeaponSubType": "SRM2",
     "MinRange": 0,
     "MaxRange": 90,
     "RangeSplit": [
@@ -70,7 +70,8 @@
     "Instability": 10,
     "CantHitUnaffecedByPathing": true,
     "ImprovedBallistic": true,
-    "WeaponEffectID": "WeaponEffect-Weapon_MachineGun",
+    "AlwaysIndirectVisuals": true,
+    "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
     "Description": {
         "Cost": 10000,
         "Rarity": 0,

--- a/RogueModuleTech/Widget/Pods/Weapon_POD_A.json
+++ b/RogueModuleTech/Widget/Pods/Weapon_POD_A.json
@@ -39,9 +39,9 @@
     "MinRange": 0,
     "MaxRange": 90,
     "RangeSplit": [
-        60,
-        60,
-        60
+        90,
+        90,
+        90
     ],
     "AmmoCategory": "Flamer",
     "StartingAmmoCapacity": 1,

--- a/RogueModuleTech/Widget/Pods/Weapon_POD_B.json
+++ b/RogueModuleTech/Widget/Pods/Weapon_POD_B.json
@@ -18,7 +18,7 @@
                 "BoltOn: 2",
                 "1shot",
                 "AreaOfEffect: 135",
-		"AreaOfEffectDmg: 75",
+                "AreaOfEffectDmg: 75",
                 "PipsIgnored: 6",
                 "InternalAmmo: 10",
                 "NoAA"
@@ -34,8 +34,8 @@
         }
     },
     "weaponCategoryID": "SpecialMelee",
-    "Type": "Autocannon",
-    "WeaponSubType": "AC2",
+    "Type": "SRM",
+    "WeaponSubType": "SRM2",
     "MinRange": 0,
     "MaxRange": 90,
     "RangeSplit": [
@@ -70,7 +70,8 @@
     "Instability": 16,
     "CantHitUnaffecedByPathing": true,
     "ImprovedBallistic": true,
-    "WeaponEffectID": "WeaponEffect-Weapon_AC2",
+    "AlwaysIndirectVisuals": true,
+    "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
     "Description": {
         "Cost": 15000,
         "Rarity": 0,

--- a/RogueModuleTech/Widget/Pods/Weapon_POD_B.json
+++ b/RogueModuleTech/Widget/Pods/Weapon_POD_B.json
@@ -39,9 +39,9 @@
     "MinRange": 0,
     "MaxRange": 90,
     "RangeSplit": [
-        60,
-        60,
-        60
+        90,
+        90,
+        90
     ],
     "AmmoCategory": "Flamer",
     "StartingAmmoCapacity": 1,

--- a/RogueModuleTech/Widget/Pods/Weapon_POD_M.json
+++ b/RogueModuleTech/Widget/Pods/Weapon_POD_M.json
@@ -18,7 +18,7 @@
                 "BoltOn: 3",
                 "1shot",
                 "AreaOfEffect: 150",
-		"AreaOfEffectDmg: 100",
+                "AreaOfEffectDmg: 100",
                 "PipsIgnored: 6",
                 "InternalAmmo: 25",
                 "NoAA"
@@ -34,8 +34,8 @@
         }
     },
     "weaponCategoryID": "SpecialMelee",
-    "Type": "Autocannon",
-    "WeaponSubType": "AC5",
+    "Type": "SRM",
+    "WeaponSubType": "SRM2",
     "MinRange": 0,
     "MaxRange": 90,
     "RangeSplit": [
@@ -52,7 +52,7 @@
     "EvasivePipsIgnored": 6,
     "DamageVariance": 0,
     "HeatDamage": 0,
-    "AccuracyModifier": -1,
+    "AccuracyModifier": -2,
     "CriticalChanceMultiplier": 1,
     "APArmorShardsMod": 0,
     "APMaxArmorThickness": 1,
@@ -70,7 +70,8 @@
     "Instability": 25,
     "CantHitUnaffecedByPathing": true,
     "ImprovedBallistic": true,
-    "WeaponEffectID": "WeaponEffect-Weapon_AC5",
+    "AlwaysIndirectVisuals": true,
+    "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
     "Description": {
         "Cost": 20000,
         "Rarity": 0,


### PR DESCRIPTION
alwaysindirect visuals. Trying to prevent the charge from flying off accross the map on a miss. Should explode right next to the firing unit and it's target.