### PR TITLE
Custom Copperhead light tank

### DIFF
--- a/Base 3061/PrimitiveTanks/vehicle/vehicledef_Copperhead.json
+++ b/Base 3061/PrimitiveTanks/vehicle/vehicledef_Copperhead.json
@@ -1,0 +1,173 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_Copperhead",
+        "Name": "Copperhead CH-1",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_Copperhead",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_noconvoy",
+            "unit_generic",
+            "unit_bracket_low",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "magistracyofcanopus",
+            "marian",
+            "taurianconcordat",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "jarnfolk",
+            "delphi",
+            "hanse",
+            "castile",
+            "chainelane",
+            "tortuga",
+            "axumite",
+            "auriganpirates",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Rifle_Medium",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Medium_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Medium_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/PrimitiveTanks/vehicle/vehicledef_CopperheadII_CHII-1.json
+++ b/Base 3061/PrimitiveTanks/vehicle/vehicledef_CopperheadII_CHII-1.json
@@ -1,0 +1,171 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_CopperheadII_CHII-1",
+        "Name": "Copperhead MKII CHII-1",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_CopperheadII_CHII-1",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_noconvoy",
+            "unit_generic",
+            "unit_bracket_low",
+            "magistracyofcanopus",
+            "marian",
+            "taurianconcordat",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "jarnfolk",
+            "delphi",
+            "hanse",
+            "castile",
+            "chainelane",
+            "tortuga",
+            "axumite",
+            "auriganpirates",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Rifle_Heavy",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Heavy_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Heavy_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Heavy_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Heavy_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_FuelCell",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/PrimitiveTanks/vehicle/vehicledef_CopperheadII_CHII-2.json
+++ b/Base 3061/PrimitiveTanks/vehicle/vehicledef_CopperheadII_CHII-2.json
@@ -1,0 +1,192 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_CopperheadII_CHII-2",
+        "Name": "Copperhead MKII CHII-2",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_CopperheadII_CHII-2",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_noconvoy",
+            "unit_generic",
+            "unit_bracket_low",
+            "magistracyofcanopus",
+            "marian",
+            "taurianconcordat",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "jarnfolk",
+            "delphi",
+            "hanse",
+            "castile",
+            "chainelane",
+            "tortuga",
+            "axumite",
+            "auriganpirates",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Rifle_Medium",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM6_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Medium_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Medium_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_FuelCell",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/PrimitiveTanks/vehicle/vehicledef_CopperheadII_CHII-3.json
+++ b/Base 3061/PrimitiveTanks/vehicle/vehicledef_CopperheadII_CHII-3.json
@@ -1,0 +1,193 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_CopperheadII_CHII-3",
+        "Name": "Copperhead MKII CHII-3",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_CopperheadII_CHII-3",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_indirectFire",
+            "unit_lance_vanguard",
+            "unit_noconvoy",
+            "unit_advanced",
+            "unit_bracket_low",
+            "magistracyofcanopus",
+            "marian",
+            "taurianconcordat",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "jarnfolk",
+            "delphi",
+            "hanse",
+            "castile",
+            "chainelane",
+            "tortuga",
+            "axumite",
+            "auriganpirates",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Rifle_Light",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_LRM10_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Light_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Light_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_FuelCell",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/PrimitiveTanks/vehicle/vehicledef_Copperhead_CH-2.json
+++ b/Base 3061/PrimitiveTanks/vehicle/vehicledef_Copperhead_CH-2.json
@@ -1,0 +1,180 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_Copperhead_CH-2",
+        "Name": "Copperhead CH-2",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_Copperhead_CH-2",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_noconvoy",
+            "unit_generic",
+            "unit_bracket_low",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "magistracyofcanopus",
+            "marian",
+            "taurianconcordat",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "jarnfolk",
+            "delphi",
+            "hanse",
+            "castile",
+            "chainelane",
+            "tortuga",
+            "axumite",
+            "auriganpirates",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Rifle_Light",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER20",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Light_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Light_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/PrimitiveTanks/vehicle/vehicledef_Copperhead_CH-3.json
+++ b/Base 3061/PrimitiveTanks/vehicle/vehicledef_Copperhead_CH-3.json
@@ -1,0 +1,187 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_Copperhead_CH-3",
+        "Name": "Copperhead CH-3",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_Copperhead_CH-3",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_noconvoy",
+            "unit_generic",
+            "unit_bracket_low",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "magistracyofcanopus",
+            "marian",
+            "taurianconcordat",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "jarnfolk",
+            "delphi",
+            "hanse",
+            "castile",
+            "chainelane",
+            "tortuga",
+            "axumite",
+            "auriganpirates",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Rifle_Light",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Light_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Rifle_Light_APFSDS",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_Copperhead.json
+++ b/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_Copperhead.json
@@ -1,0 +1,123 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_Copperhead",
+		"Name": "Copperhead Tank Destroyer",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_scorpion",
+	"PrefabIdentifier": "chrPrfVhcl_scorpion",
+	"PrefabBase": "scorpion",
+	"Tonnage": 30,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 70,
+			"InternalStructure": 15
+		}
+	]
+}

--- a/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_CopperheadII_CHII-1.json
+++ b/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_CopperheadII_CHII-1.json
@@ -1,0 +1,123 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_CopperheadII_CHII-1",
+		"Name": "Copperhead MKII Tank Destroyer",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_scorpion",
+	"PrefabIdentifier": "chrPrfVhcl_scorpion",
+	"PrefabBase": "scorpion",
+	"Tonnage": 30,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 70,
+			"InternalStructure": 15
+		}
+	]
+}

--- a/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_CopperheadII_CHII-2.json
+++ b/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_CopperheadII_CHII-2.json
@@ -1,0 +1,123 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_CopperheadII_CHII-2",
+		"Name": "Copperhead MKII Tank Destroyer",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_scorpion",
+	"PrefabIdentifier": "chrPrfVhcl_scorpion",
+	"PrefabBase": "scorpion",
+	"Tonnage": 30,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 70,
+			"InternalStructure": 15
+		}
+	]
+}

--- a/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_CopperheadII_CHII-3.json
+++ b/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_CopperheadII_CHII-3.json
@@ -1,0 +1,123 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_CopperheadII_CHII-3",
+		"Name": "Copperhead MKII Tank Destroyer",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_scorpion",
+	"PrefabIdentifier": "chrPrfVhcl_scorpion",
+	"PrefabBase": "scorpion",
+	"Tonnage": 30,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 70,
+			"InternalStructure": 15
+		}
+	]
+}

--- a/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_Copperhead_CH-2.json
+++ b/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_Copperhead_CH-2.json
@@ -1,0 +1,123 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_Copperhead_CH-2",
+		"Name": "Copperhead Tank Destroyer",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_scorpion",
+	"PrefabIdentifier": "chrPrfVhcl_scorpion",
+	"PrefabBase": "scorpion",
+	"Tonnage": 30,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 70,
+			"InternalStructure": 15
+		}
+	]
+}

--- a/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_Copperhead_CH-3.json
+++ b/Base 3061/PrimitiveTanks/vehiclechassis/vehiclechassisdef_Copperhead_CH-3.json
@@ -1,0 +1,123 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_Copperhead_CH-3",
+		"Name": "Copperhead Tank Destroyer",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_scorpion",
+	"PrefabIdentifier": "chrPrfVhcl_scorpion",
+	"PrefabBase": "scorpion",
+	"Tonnage": 30,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 3,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 55,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 70,
+			"InternalStructure": 15
+		}
+	]
+}


### PR DESCRIPTION
Added 3 Copperhead light tanks with ICE engines and 3 with fuell cells designed for periphery low tech factions