### PR TITLE
Tanks

### DIFF
--- a/Base 3061/CLANK/vehicle/vehicledef_ALACORN_IIC_CLAN.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_ALACORN_IIC_CLAN.json
@@ -133,13 +133,13 @@
                   "HardpointSlot": -1,
                   "DamageLevel": "Functional"
             },
-			{
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Tank_Coolant_System",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
+            {
+                  "MountedLocation": "Rear",
+                  "ComponentDefID": "Tank_Coolant_System",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
             {
                   "MountedLocation": "Rear",
                   "ComponentDefID": "emod_engine_285",

--- a/Base 3061/CLANK/vehicle/vehicledef_ARES_CLAN.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_ARES_CLAN.json
@@ -135,20 +135,20 @@
             "HardpointSlot": -1,
             "DamageLevel": "Functional"
         },
-		{
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Tank_Coolant_System",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "emod_engineslots_std_center",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
         {
             "MountedLocation": "Left",
             "ComponentDefID": "Gear_HeatSink_Generic_Standard",

--- a/Base 3061/CLANK/vehicle/vehicledef_ASSHUR_RECON_CLAN.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_ASSHUR_RECON_CLAN.json
@@ -143,19 +143,19 @@
 			"DamageLevel": "Functional"
 		},
 		{
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Tank_Coolant_System",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "emod_engineslots_std_center",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
+			"MountedLocation": "Rear",
+			"ComponentDefID": "Tank_Coolant_System",
+			"ComponentDefType": "HeatSink",
+			"HardpointSlot": -1,
+			"DamageLevel": "Functional"
+		},
+		{
+			"MountedLocation": "Rear",
+			"ComponentDefID": "emod_engineslots_std_center",
+			"ComponentDefType": "HeatSink",
+			"HardpointSlot": -1,
+			"DamageLevel": "Functional"
+		},
 		{
 			"MountedLocation": "Rear",
 			"ComponentDefID": "emod_engine_095",

--- a/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_A.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_A.json
@@ -1,0 +1,236 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_A",
+        "Name": "Badger (C) Tracked Transport (A)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_A",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 5,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 6,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 7,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 8,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CASE_CLAN",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_B.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_B.json
@@ -1,0 +1,187 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_B",
+        "Name": "Badger (C) Tracked Transport (B)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_B",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+			"ComponentDefID": "Tank_CASE_CLAN",
+			"ComponentDefType": "Upgrade",
+			"MountedLocation": "Rear",
+			"HardpointSlot": -1,
+			"DamageLevel": "Functional"
+		},
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_C.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_C.json
@@ -1,0 +1,187 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_C",
+        "Name": "Badger (C) Tracked Transport (C)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_C",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_LRM10_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+			"ComponentDefID": "Tank_CASE_CLAN",
+			"ComponentDefType": "Upgrade",
+			"MountedLocation": "Rear",
+			"HardpointSlot": -1,
+			"DamageLevel": "Functional"
+		},
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_D.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_D.json
@@ -1,0 +1,180 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_D",
+        "Name": "Badger (C) Tracked Transport (D)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_D",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CASE_CLAN",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_PRIME.json
+++ b/Base 3061/CLANK/vehicle/vehicledef_BADGER_C_PRIME.json
@@ -1,0 +1,187 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_PRIME",
+        "Name": "Badger (C) Tracked Transport (Prime)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_PRIME",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_SRM_SRM4_STREAK_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+			"ComponentDefID": "Tank_CASE_CLAN",
+			"ComponentDefType": "Upgrade",
+			"MountedLocation": "Rear",
+			"HardpointSlot": -1,
+			"DamageLevel": "Functional"
+		},
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_A.json
+++ b/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_A.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_A",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_B.json
+++ b/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_B.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_B",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_C.json
+++ b/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_C.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_C",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_D.json
+++ b/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_D.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_D",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_PRIME.json
+++ b/Base 3061/CLANK/vehiclechassis/vehiclechassisdef_BADGER_C_PRIME.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_PRIME",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicle/apc/vehicledef_BADGER_A.json
+++ b/Base 3061/vehicle/apc/vehicledef_BADGER_A.json
@@ -1,0 +1,192 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_A",
+        "Name": "Badger Tracked Transport (A)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_A",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/apc/vehicledef_BADGER_B.json
+++ b/Base 3061/vehicle/apc/vehicledef_BADGER_B.json
@@ -1,0 +1,178 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_B",
+        "Name": "Badger Tracked Transport (B)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_B",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_SRM_SRM4_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM4_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/apc/vehicledef_BADGER_C.json
+++ b/Base 3061/vehicle/apc/vehicledef_BADGER_C.json
@@ -1,0 +1,178 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C",
+        "Name": "Badger Tracked Transport (C)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/apc/vehicledef_BADGER_D.json
+++ b/Base 3061/vehicle/apc/vehicledef_BADGER_D.json
@@ -1,0 +1,192 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_D",
+        "Name": "Badger Tracked Transport (D)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_D",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/apc/vehicledef_BADGER_E.json
+++ b/Base 3061/vehicle/apc/vehicledef_BADGER_E.json
@@ -1,0 +1,227 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_E",
+        "Name": "Badger Tracked Transport (E)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_E",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Left",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Right",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "WWeapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 5,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "WWeapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 6,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/apc/vehicledef_BADGER_F.json
+++ b/Base 3061/vehicle/apc/vehicledef_BADGER_F.json
@@ -1,0 +1,164 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_F",
+        "Name": "Badger Tracked Transport (F)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_F",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/apc/vehicledef_BADGER_PRIME.json
+++ b/Base 3061/vehicle/apc/vehicledef_BADGER_PRIME.json
@@ -1,0 +1,192 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_PRIME",
+        "Name": "Badger Tracked Transport (Prime)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_PRIME",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/light/vehicledef_CHEVALIER.json
+++ b/Base 3061/vehicle/light/vehicledef_CHEVALIER.json
@@ -1,0 +1,168 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_CHEVALIER",
+        "Name": "Chevalier Light Tank",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_CHEVALIER",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_lance_tank",
+            "unit_advanced",
+            "unit_bracket_low",
+            "WordOfBlake",
+            "comstar",
+            "kurita",
+            "HouseNakano"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 130,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 130,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_LargeLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_190",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/light/vehicledef_CHEVALIER_BAP.json
+++ b/Base 3061/vehicle/light/vehicledef_CHEVALIER_BAP.json
@@ -1,0 +1,188 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_CHEVALIER_BAP",
+        "Name": "Chevalier Light Tank (BAP)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_CHEVALIER_BAP",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_lance_tank",
+            "unit_advanced",
+            "unit_predator",
+            "unit_bracket_low",
+            "WordOfBlake",
+            "comstar"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_LargeLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_BAP",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_190",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/light/vehicledef_CHEVALIER_SPEED.json
+++ b/Base 3061/vehicle/light/vehicledef_CHEVALIER_SPEED.json
@@ -1,0 +1,159 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_CHEVALIER_SPEED",
+        "Name": "Chevalier Light Tank (Speed)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_CHEVALIER_SPEED",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_lance_tank",
+            "unit_advanced",
+            "unit_bracket_low",
+            "WordOfBlake",
+            "comstar"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_LargeLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_225",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/light/vehicledef_GABRIEL.json
+++ b/Base 3061/vehicle/light/vehicledef_GABRIEL.json
@@ -1,0 +1,194 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_GABRIEL",
+        "Name": "Gabriel Reconnaissance Hovercraft",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 3,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_GABRIEL",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_hover",
+            "unit_release",
+            "unit_generic",
+            "unit_lance_vanguard",
+            "unit_bracket_low",
+            "unit_noconvoy",
+            "comstar",
+            "WordOfBlake",
+            "rasalhague"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 25,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaser_2-ExoStar",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Vehicle_Hard_Target",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Vehicle_LOW_PROFILE",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_025",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/light/vehicledef_LIGHTNING.json
+++ b/Base 3061/vehicle/light/vehicledef_LIGHTNING.json
@@ -1,0 +1,163 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_LIGHTNING",
+        "Name": "Lightning Attack Hovercraft",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_LIGHTNING",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_advanced",
+            "unit_bracket_low",
+            "WordOfBlake"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM4_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Left",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM4_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Right",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/light/vehicledef_LIGHTNING_ROYAL.json
+++ b/Base 3061/vehicle/light/vehicledef_LIGHTNING_ROYAL.json
@@ -1,0 +1,189 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_LIGHTNING_ROYAL",
+        "Name": "Lightning Attack Hovercraft (Royal)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_LIGHTNING_ROYAL",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_generic",
+            "unit_predator",
+            "unit_bracket_low",
+            "WordOfBlake",
+            "comstar",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_TAG",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/medium/vehicledef_KANGA.json
+++ b/Base 3061/vehicle/medium/vehicledef_KANGA.json
@@ -1,0 +1,201 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_KANGA",
+        "Name": "Kanga Medium Hovertank",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_KANGA",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_medium",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_indirectFire",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "comstar"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Autocannon_AC5_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_LRM10_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM4_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC5",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_165",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/medium/vehicledef_KANGA_AC.json
+++ b/Base 3061/vehicle/medium/vehicledef_KANGA_AC.json
@@ -1,0 +1,187 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_KANGA_AC",
+        "Name": "Kanga Medium Hovertank",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_KANGA_AC",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_medium",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_indirectFire",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "comstar"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Autocannon_AC10_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_LRM10_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC10_double",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_165",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_A.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_A.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_A",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_B.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_B.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_B",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_C.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_C.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_D.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_D.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_D",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_E.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_E.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_E",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_F.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_F.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_F",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_PRIME.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_BADGER_PRIME.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_PRIME",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_CHEVALIER.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_CHEVALIER.json
@@ -1,0 +1,125 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_CHEVALIER",
+		"Name": "Chevalier Light Tank",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 5,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_CHEVALIER_BAP.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_CHEVALIER_BAP.json
@@ -1,0 +1,125 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_CHEVALIER_BAP",
+		"Name": "Chevalier Light Tank",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 5,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_CHEVALIER_SPEED.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_CHEVALIER_SPEED.json
@@ -1,0 +1,125 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_CHEVALIER_SPEED",
+		"Name": "Chevalier Light Tank",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 5,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_7-11cv",
+	"PathingCapDefID": "pathingdef_light_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_GABRIEL.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_GABRIEL.json
@@ -1,0 +1,116 @@
+{
+	"CustomParts": {
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_GABRIEL",
+		"Name": "Gabriel Reconnaissance Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 3,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_13-20cv",
+	"PathingCapDefID": "pathingdef_ultralight",
+	"HardpointDataDefID": "hardpointdatadef_gabriel",
+	"PrefabIdentifier": "chrprfvhcl_gabriel",
+	"PrefabBase": "gabriel",
+	"Tonnage": 5,
+	"weightClass": "LIGHT",
+	"BattleValue": 993,
+	"TopSpeed": 500,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0.0,
+			"y": 1.6,
+			"z": -4.0
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 30,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 30,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 10,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 20,
+			"InternalStructure": 5
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_KANGA.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_KANGA.json
@@ -1,0 +1,146 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_KANGA",
+		"Name": "Kanga Medium Hovertank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_8-12cv",
+	"PathingCapDefID": "pathingdef_medium_hover",
+	"HardpointDataDefID": "hardpointdatadef_kanga",
+	"PrefabIdentifier": "chrprfvhcl_kanga",
+	"PrefabBase": "kanga",
+	"Tonnage": 50,
+	"weightClass": "MEDIUM",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0.0,
+			"y": 1.6,
+			"z": -4.0
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 175,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_KANGA_AC.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_KANGA_AC.json
@@ -1,0 +1,146 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_KANGA_AC",
+		"Name": "Kanga Medium Hovertank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_8-12cv",
+	"PathingCapDefID": "pathingdef_medium_hover",
+	"HardpointDataDefID": "hardpointdatadef_kanga",
+	"PrefabIdentifier": "chrprfvhcl_kanga",
+	"PrefabBase": "kanga",
+	"Tonnage": 50,
+	"weightClass": "MEDIUM",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0.0,
+			"y": 1.6,
+			"z": -4.0
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 175,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_LIGHTNING.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_LIGHTNING.json
@@ -1,0 +1,124 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_LIGHTNING",
+		"Name": "Lightning Attack Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_11-17cv",
+	"PathingCapDefID": "pathingdef_light_hover",
+	"HardpointDataDefID": "hardpointdatadef_lightning",
+	"PrefabIdentifier": "chrprfvhcl_lightning",
+	"PrefabBase": "lightning",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 125,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_LIGHTNING_ROYAL.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_LIGHTNING_ROYAL.json
@@ -1,0 +1,124 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_LIGHTNING_ROYAL",
+		"Name": "Lightning Attack Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_11-17cv",
+	"PathingCapDefID": "pathingdef_light_hover",
+	"HardpointDataDefID": "hardpointdatadef_lightning",
+	"PrefabIdentifier": "chrprfvhcl_lightning",
+	"PrefabBase": "lightning",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 125,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/CivilWar 3062-3067/vehicle/vehicledef_BADGER_C_E.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_BADGER_C_E.json
@@ -1,0 +1,201 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_E",
+        "Name": "Badger (C) Tracked Transport (E)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_E",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ATM3_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_HE_ATM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_ER_ATM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+			"ComponentDefID": "Tank_CASE_CLAN",
+			"ComponentDefType": "Upgrade",
+			"MountedLocation": "Rear",
+			"HardpointSlot": -1,
+			"DamageLevel": "Functional"
+		},
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/CivilWar 3062-3067/vehicle/vehicledef_BADGER_C_H.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_BADGER_C_H.json
@@ -1,0 +1,208 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_H",
+        "Name": "Badger (C) Tracked Transport (H)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_H",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_HeavyMediumLaser_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_TargetingTrackingSystem_ShortRange",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_TargetingTrackingSystem_MedRange",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CASE_CLAN",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/CivilWar 3062-3067/vehicle/vehicledef_GABRIEL_ERSL.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_GABRIEL_ERSL.json
@@ -1,0 +1,199 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_GABRIEL_ERSL",
+        "Name": "Gabriel Reconnaissance Hovercraft (ERSL)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 3,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_GABRIEL_ERSL",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_hover",
+            "unit_release",
+            "unit_generic",
+            "unit_lance_vanguard",
+            "unit_bracket_low",
+            "unit_noconvoy",
+            "taurianconcordat"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 25,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Vehicle_Hard_Target",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Vehicle_LOW_PROFILE",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_025",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/CivilWar 3062-3067/vehicle/vehicledef_GABRIEL_TDF.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_GABRIEL_TDF.json
@@ -1,0 +1,199 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_GABRIEL_TDF",
+        "Name": "Gabriel Reconnaissance Hovercraft (TDF)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 3,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_GABRIEL_TDF",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_hover",
+            "unit_release",
+            "unit_generic",
+            "unit_lance_vanguard",
+            "unit_bracket_low",
+            "unit_noconvoy",
+            "taurianconcordat"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 25,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 15,
+            "CurrentInternalStructure": 5,
+            "AssignedArmor": 15,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER10",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER10",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Vehicle_Hard_Target",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Vehicle_LOW_PROFILE",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_025",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/CivilWar 3062-3067/vehicle/vehicledef_LIGHTNING_ERML.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_LIGHTNING_ERML.json
@@ -1,0 +1,191 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_LIGHTNING_ERML",
+        "Name": "Lightning Attack Hovercraft (ERML)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_LIGHTNING_ERML",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_advanced",
+            "unit_bracket_low",
+            "WordOfBlake"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 5,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 6,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 7,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 8,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/CivilWar 3062-3067/vehicle/vehicledef_LIGHTNING_ERSL.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_LIGHTNING_ERSL.json
@@ -1,0 +1,198 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_LIGHTNING_ERSL",
+        "Name": "Lightning Attack Hovercraft (ERSL)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_LIGHTNING_ERSL",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_advanced",
+            "unit_bracket_low",
+            "WordOfBlake"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 5,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 6,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 7,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 8,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 9,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/CivilWar 3062-3067/vehicle/vehicledef_LIGHTNING_RL.json
+++ b/CivilWar 3062-3067/vehicle/vehicledef_LIGHTNING_RL.json
@@ -1,0 +1,198 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_LIGHTNING_RL",
+        "Name": "Lightning Attack Hovercraft (RL)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_LIGHTNING_RL",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_advanced",
+            "unit_bracket_low",
+            "WordOfBlake"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_AMS",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_AMS",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 5,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 6,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 7,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 8,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_AntiMissile",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_BADGER_C_E.json
+++ b/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_BADGER_C_E.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_E",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_BADGER_C_H.json
+++ b/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_BADGER_C_H.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_H",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_GABRIEL_ERSL.json
+++ b/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_GABRIEL_ERSL.json
@@ -1,0 +1,116 @@
+{
+	"CustomParts": {
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_GABRIEL_ERSL",
+		"Name": "Gabriel Reconnaissance Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 3,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_13-20cv",
+	"PathingCapDefID": "pathingdef_ultralight",
+	"HardpointDataDefID": "hardpointdatadef_gabriel",
+	"PrefabIdentifier": "chrprfvhcl_gabriel",
+	"PrefabBase": "gabriel",
+	"Tonnage": 5,
+	"weightClass": "LIGHT",
+	"BattleValue": 993,
+	"TopSpeed": 500,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0.0,
+			"y": 1.6,
+			"z": -4.0
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 30,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 30,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 10,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 20,
+			"InternalStructure": 5
+		}
+	]
+}

--- a/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_GABRIEL_TDF.json
+++ b/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_GABRIEL_TDF.json
@@ -1,0 +1,116 @@
+{
+	"CustomParts": {
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_GABRIEL_TDF",
+		"Name": "Gabriel Reconnaissance Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 3,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_13-20cv",
+	"PathingCapDefID": "pathingdef_ultralight",
+	"HardpointDataDefID": "hardpointdatadef_gabriel",
+	"PrefabIdentifier": "chrprfvhcl_gabriel",
+	"PrefabBase": "gabriel",
+	"Tonnage": 5,
+	"weightClass": "LIGHT",
+	"BattleValue": 993,
+	"TopSpeed": 500,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0.0,
+			"y": 1.6,
+			"z": -4.0
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 30,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 30,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 10,
+			"InternalStructure": 5
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 20,
+			"InternalStructure": 5
+		}
+	]
+}

--- a/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_LIGHTNING_ERML.json
+++ b/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_LIGHTNING_ERML.json
@@ -1,0 +1,124 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_LIGHTNING_ERML",
+		"Name": "Lightning Attack Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_11-17cv",
+	"PathingCapDefID": "pathingdef_light_hover",
+	"HardpointDataDefID": "hardpointdatadef_lightning",
+	"PrefabIdentifier": "chrprfvhcl_lightning",
+	"PrefabBase": "lightning",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 125,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_LIGHTNING_ERSL.json
+++ b/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_LIGHTNING_ERSL.json
@@ -1,0 +1,124 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_LIGHTNING_ERSL",
+		"Name": "Lightning Attack Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_11-17cv",
+	"PathingCapDefID": "pathingdef_light_hover",
+	"HardpointDataDefID": "hardpointdatadef_lightning",
+	"PrefabIdentifier": "chrprfvhcl_lightning",
+	"PrefabBase": "lightning",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 125,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_LIGHTNING_RL.json
+++ b/CivilWar 3062-3067/vehicleChassis/vehiclechassisdef_LIGHTNING_RL.json
@@ -1,0 +1,124 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_LIGHTNING_RL",
+		"Name": "Lightning Attack Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_11-17cv",
+	"PathingCapDefID": "pathingdef_light_hover",
+	"HardpointDataDefID": "hardpointdatadef_lightning",
+	"PrefabIdentifier": "chrprfvhcl_lightning",
+	"PrefabBase": "lightning",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 125,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/DarkAge/vehicle/vehicledef_Padilla_Anti-Missile.json
+++ b/DarkAge/vehicle/vehicledef_Padilla_Anti-Missile.json
@@ -1,0 +1,250 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_Padilla_Anti-Missile",
+        "Name": "Padilla Anti-Missile Tank",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_Padilla_Anti-Missile",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.5",
+            "unit_vehicle",
+            "unit_medium",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_support",
+            "unit_lance_assassin",
+            "unit_advanced",
+            "unit_stealth",
+            "unit_bracket_high",
+            "comstar"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 140,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 140,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Gauss_Gauss_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_AMS_Advanced",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_AMS_Advanced",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS_double",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_AntiMissile_double",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_FCS_AdvancedTC",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Crit",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Gunnery",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_ExtremeRange",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Kallon_HardLock",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_STEALTH",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_light_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_145",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/DarkAge/vehiclechassis/vehiclechassisdef_Padilla_Anti-Missile.json
+++ b/DarkAge/vehiclechassis/vehiclechassisdef_Padilla_Anti-Missile.json
@@ -1,0 +1,131 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_Padilla_Anti-Missile",
+		"Name": "Padilla Anti-Missile Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_medium_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 55,
+	"weightClass": "MEDIUM",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		}
+	]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_BADGER_C_F.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_BADGER_C_F.json
@@ -1,0 +1,194 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_C_F",
+        "Name": "Badger (C) Tracked Transport (F)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_C_F",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "clansgeneric",
+            "clanwolf",
+            "clanfiremandrill",
+            "clanstaradder",
+            "clancoyote",
+            "clanjadefalcon",
+            "clansteelviper",
+            "clanicehellion",
+            "clangoliathscorpion",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clansmokejaguar",
+            "clancloudcobra",
+            "clannovacat",
+            "clanburrock"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CASE_CLAN",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_BADGER_G.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_BADGER_G.json
@@ -1,0 +1,178 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_BADGER_G",
+        "Name": "Badger Tracked Transport (G)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_BADGER_G",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracked",
+            "unit_release",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_PPC_PPC_LIGHT",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_CHEVALIER_MML.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_CHEVALIER_MML.json
@@ -1,0 +1,173 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_CHEVALIER_MML",
+        "Name": "Chevalier Light Tank (MML)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_CHEVALIER_MML",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_lance_tank",
+            "unit_advanced",
+            "unit_indirectFire",
+            "unit_bracket_low",
+            "WordOfBlake"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 130,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 130,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 115,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 115,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_LargeLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MML_5",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Swarmi_LRM_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_AugmentedThunder_LRM_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_190",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_Padilla.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_Padilla.json
@@ -1,0 +1,250 @@
+{
+      "Version": 1,
+      "Description": {
+            "Id": "vehicledef_Padilla",
+            "Name": "Padilla Artilery Tank",
+            "Details": "",
+            "Icon": "",
+            "Cost": 993,
+            "Rarity": 0,
+            "Purchasable": false
+      },
+      "ChassisID": "vehiclechassisdef_Padilla",
+      "VehicleTags": {
+            "items": [
+                  "mr-resize-1.5",
+                  "unit_vehicle",
+                  "unit_medium",
+                  "unit_wheels",
+                  "unit_release",
+                  "unit_lance_support",
+                  "unit_lance_assassin",
+                  "unit_advanced",
+                  "unit_indirectFire",
+                  "unit_sniper",
+                  "unit_bracket_high",
+                  "WordOfBlake",
+                  "comstar",
+                  "steiner",
+                  "marik",
+                  "kurita",
+                  "davion",
+                  "liao",
+                  "EmeraldDawn",
+                  "SianTriumphant",
+                  "DuchyOfAndurien",
+                  "BlackCalderaDefense",
+                  "HouseNakano",
+                  "BlackCalderaDefense_Hidden",
+                  "HouseKhulan"
+            ],
+            "tagSetSourceFile": ""
+      },
+      "Locations": [
+            {
+                  "Location": "Front",
+                  "CurrentArmor": 140,
+                  "CurrentInternalStructure": 30,
+                  "AssignedArmor": 140,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "Location": "Left",
+                  "CurrentArmor": 100,
+                  "CurrentInternalStructure": 30,
+                  "AssignedArmor": 100,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "Location": "Right",
+                  "CurrentArmor": 100,
+                  "CurrentInternalStructure": 30,
+                  "AssignedArmor": 100,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "Location": "Rear",
+                  "CurrentArmor": 100,
+                  "CurrentInternalStructure": 30,
+                  "AssignedArmor": 100,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "Location": "Turret",
+                  "CurrentArmor": 110,
+                  "CurrentInternalStructure": 30,
+                  "AssignedArmor": 110,
+                  "DamageLevel": "Functional"
+            }
+      ],
+      "inventory": [
+            {
+                  "ComponentDefID": "Weapon_Artillery_SNIPER",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 0,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 2,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Weapon_Laser_SmallLaserPulse_0-STOCK",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 3,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Weapon_Laser_SmallLaserPulse_0-STOCK",
+                  "ComponentDefType": "Weapon",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 4,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Shaped_Sniper",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Front",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Shaped_Sniper",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Rear",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Incendiary_LRM_half",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Rear",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM_half",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Rear",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Ammo_AmmunitionBox_Deadfire_LRM",
+                  "ComponentDefType": "AmmunitionBox",
+                  "MountedLocation": "Front",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "MountedLocation": "Rear",
+                  "ComponentDefID": "Tank_Coolant_System",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "MountedLocation": "Rear",
+                  "ComponentDefID": "emod_engineslots_light_center",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+              },
+              {
+                  "MountedLocation": "Left",
+                  "ComponentDefID": "emod_engineslots_size2",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+              },
+              {
+                  "MountedLocation": "Right",
+                  "ComponentDefID": "emod_engineslots_size2",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+              },
+            {
+                  "MountedLocation": "Rear",
+                  "ComponentDefID": "emod_engine_145",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "MountedLocation": "Left",
+                  "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "MountedLocation": "Right",
+                  "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "MountedLocation": "Rear",
+                  "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "MountedLocation": "Front",
+                  "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "MountedLocation": "Turret",
+                  "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+                  "ComponentDefType": "HeatSink",
+                  "HardpointSlot": -1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Tank_Turret",
+                  "ComponentDefType": "Upgrade",
+                  "MountedLocation": "Turret",
+                  "HardpointSlot": 1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Tank_CrewCompartment",
+                  "ComponentDefType": "Upgrade",
+                  "MountedLocation": "Front",
+                  "HardpointSlot": 1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Gear_Wheeled_Right",
+                  "ComponentDefType": "Upgrade",
+                  "MountedLocation": "Right",
+                  "HardpointSlot": 1,
+                  "DamageLevel": "Functional"
+            },
+            {
+                  "ComponentDefID": "Gear_Wheeled_Left",
+                  "ComponentDefType": "Upgrade",
+                  "MountedLocation": "Left",
+                  "HardpointSlot": 1,
+                  "DamageLevel": "Functional"
+            }
+      ]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_Padilla_LTC.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_Padilla_LTC.json
@@ -1,0 +1,228 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_Padilla_LTC",
+        "Name": "Padilla Artilery Tank (LTC)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_Padilla_LTC",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.5",
+            "unit_vehicle",
+            "unit_medium",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_support",
+            "unit_lance_assassin",
+            "unit_advanced",
+            "unit_indirectFire",
+            "unit_longtom",
+            "unit_bracket_high",
+            "WordOfBlake",
+            "comstar",
+            "steiner",
+            "kurita",
+            "davion",
+            "HouseNakano"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 140,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 140,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 125,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 125,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 125,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 125,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Artillery_LONGTOM_Cannon",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_SmallLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LongTom",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LongTom",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Deadfire_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_light_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_145",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_Padilla_Thumper.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_Padilla_Thumper.json
@@ -1,0 +1,306 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_Padilla_Thumper",
+        "Name": "Padilla Artilery Tank (Thumper)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_Padilla_Thumper",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.5",
+            "unit_vehicle",
+            "unit_medium",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_support",
+            "unit_lance_assassin",
+            "unit_advanced",
+            "unit_indirectFire",
+            "unit_sniper",
+            "unit_bracket_high",
+            "WordOfBlake",
+            "comstar",
+            "steiner",
+            "marik",
+            "kurita",
+            "davion",
+            "liao",
+            "EmeraldDawn",
+            "SianTriumphant",
+            "DuchyOfAndurien",
+            "BlackCalderaDefense",
+            "HouseNakano",
+            "BlackCalderaDefense_Hidden",
+            "HouseKhulan"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 140,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 140,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Artillery_THUMPER",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MML_3",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MML_3",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MML_3",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MML_3",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 5,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 6,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Shaped_Thumper",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Shaped_Thumper",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_Thumper",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_Thumper",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Fascam_Thumper",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Inferno_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Incendiary_LRM_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM_half",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Deadfire_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Front",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_light_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_145",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_BADGER_C_F.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_BADGER_C_F.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_C_F",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_BADGER_G.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_BADGER_G.json
@@ -1,0 +1,118 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_BADGER_G",
+		"Name": "Badger Tracked Transport",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_tracked",
+	"HardpointDataDefID": "hardpointdatadef_badger",
+	"PrefabIdentifier": "chrprfvhcl_badger",
+	"PrefabBase": "badger",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Tracked",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_CHEVALIER_MML.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_CHEVALIER_MML.json
@@ -1,0 +1,125 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_CHEVALIER_MML",
+		"Name": "Chevalier Light Tank",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 5,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_Padilla.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_Padilla.json
@@ -1,0 +1,131 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_Padilla",
+		"Name": "Padilla Artilery Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_medium_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 55,
+	"weightClass": "MEDIUM",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		}
+	]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_Padilla_LTC.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_Padilla_LTC.json
@@ -1,0 +1,131 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_Padilla_LTC",
+		"Name": "Padilla Artilery Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_medium_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 55,
+	"weightClass": "MEDIUM",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		}
+	]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_Padilla_Thumper.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_Padilla_Thumper.json
@@ -1,0 +1,131 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_Padilla_Thumper",
+		"Name": "Padilla Artilery Tank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_3-5cv",
+	"PathingCapDefID": "pathingdef_medium_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 55,
+	"weightClass": "MEDIUM",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 30
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 30
+		}
+	]
+}

--- a/Jihad Unique/vehicle/vehicledef_KANGA-X.json
+++ b/Jihad Unique/vehicle/vehicledef_KANGA-X.json
@@ -1,0 +1,199 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_KANGA-X",
+        "Name": "Kanga-X",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_KANGA-X",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_medium",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_advanced",
+            "unit_bracket_med",
+            "clanwolf",
+            "clanhellshorses"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 125,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 125,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 120,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 120,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 120,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 120,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_LargeLaser_Chemical_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_LRM10_STREAK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_SRM_SRM4_STREAK_CLANK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Large",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Large",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CASE_CLAN",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_165",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad Unique/vehicle/vehicledef_LIGHTNING_CX-3.json
+++ b/Jihad Unique/vehicle/vehicledef_LIGHTNING_CX-3.json
@@ -1,0 +1,192 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_LIGHTNING_CX-3",
+        "Name": "Lightning Attack Hovercraft (CX-3)",
+        "Details": "",
+        "Icon": "",
+        "Cost": 993,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_LIGHTNING_CX-3",
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_advanced",
+            "unit_bracket_low",
+            "unit_stealth",
+            "comstar"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 40,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 40,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 40,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 40,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 40,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 40,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Front",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Left",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Left",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Right",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Right",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_STEALTH",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad Unique/vehicleChassis/vehiclechassisdef_KANGA-X.json
+++ b/Jihad Unique/vehicleChassis/vehiclechassisdef_KANGA-X.json
@@ -1,0 +1,146 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_KANGA-X",
+		"Name": "Kanga Medium Hovertank",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_8-12cv",
+	"PathingCapDefID": "pathingdef_medium_hover",
+	"HardpointDataDefID": "hardpointdatadef_kanga",
+	"PrefabIdentifier": "chrprfvhcl_kanga",
+	"PrefabBase": "kanga",
+	"Tonnage": 50,
+	"weightClass": "MEDIUM",
+	"BattleValue": 993,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3,
+			"z": -0.5
+		},
+		{
+			"x": 0.0,
+			"y": 1.5,
+			"z": 3.5
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0.0,
+			"y": 1.6,
+			"z": -4.0
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 175,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 100,
+			"InternalStructure": 25
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 135,
+			"InternalStructure": 25
+		}
+	]
+}

--- a/Jihad Unique/vehicleChassis/vehiclechassisdef_LIGHTNING_CX-3.json
+++ b/Jihad Unique/vehicleChassis/vehiclechassisdef_LIGHTNING_CX-3.json
@@ -1,0 +1,124 @@
+{
+	"CustomParts":{
+		"MoveCost": "Hover", "MoveClamp": 0.5
+	},
+	"Description": {
+		"Id": "vehiclechassisdef_LIGHTNING_CX-3",
+		"Name": "Lightning Attack Hovercraft",
+		"Details": "",
+		"Icon": "MANTICORE",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_11-17cv",
+	"PathingCapDefID": "pathingdef_light_hover",
+	"HardpointDataDefID": "hardpointdatadef_lightning",
+	"PrefabIdentifier": "chrprfvhcl_lightning",
+	"PrefabBase": "lightning",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 125,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 2.5,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": -4.5
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 90,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Ballistic",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 105,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Republic 3081-3130/vehicle/vehicledef_ANAT.json
+++ b/Republic 3081-3130/vehicle/vehicledef_ANAT.json
@@ -1,0 +1,171 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_ANAT",
+        "Name": "Anat APC",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_ANAT",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-0.95",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "unit_generic",
+            "unit_bracket_low",
+            "clanwolf",
+            "clanhellshorses",
+            "comstar",
+            "steiner",
+            "locals",
+            "auriganmercenaries",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "EdCorbu",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 80,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 80,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 65,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 65,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_FuelCell",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Republic 3081-3130/vehicle/vehicledef_DIGGS.json
+++ b/Republic 3081-3130/vehicle/vehicledef_DIGGS.json
@@ -1,0 +1,192 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_DIGGS",
+        "Name": "Diggs Drone Control Tank",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_DIGGS",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_lance_tank",
+            "unit_release",
+            "unit_advanced",
+            "unit_bracket_low",
+            "comstar"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 190,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 190,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 145,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 145,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 145,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 145,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 115,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 115,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 145,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 145,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_LIGHT",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Weapon_MachineGun_LIGHT",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LMG_half",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Angel_ECM",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CASE",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_light_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_190",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Republic 3081-3130/vehicle/vehicledef_MHI.json
+++ b/Republic 3081-3130/vehicle/vehicledef_MHI.json
@@ -1,0 +1,195 @@
+{
+    "Version": 1,
+    "Description": {
+        "Id": "vehicledef_MHI",
+        "Name": "MHI Amphibious APC",
+        "Details": "",
+        "Icon": "",
+        "Cost": 564,
+        "Rarity": 0,
+        "Purchasable": false
+    },
+    "ChassisID": "vehiclechassisdef_MHI",
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_release",
+            "unit_noncombatant",
+            "unit_vehicle_apc",
+            "unit_advanced",
+            "unit_bracket_low",
+            "WordOfBlake",
+            "comstar",
+            "steiner",
+            "marik",
+            "kurita",
+            "davion",
+            "liao",
+            "rasalhague",
+            "outworld",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "EmeraldDawn",
+            "SianTriumphant",
+            "RedHareRegiment",
+            "EdCorbu",
+            "DuchyOfAndurien",
+            "BlackCalderaDefense",
+            "HouseNakano",
+            "BlackCalderaDefense_Hidden",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "HouseKhulan",
+            "clanwolf",
+            "clanjadefalcon",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clansnowraven",
+            "clanghostbear",
+            "clannovacat",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 245,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 245,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 75,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 75,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engine_155",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Turret",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Front",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Rear",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Right",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "MountedLocation": "Left",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Republic 3081-3130/vehicleChassis/vehiclechassisdef_ANAT.json
+++ b/Republic 3081-3130/vehicleChassis/vehiclechassisdef_ANAT.json
@@ -1,0 +1,113 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_ANAT",
+		"Name": "Anat APC",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_8-12cv",
+	"PathingCapDefID": "pathingdef_light_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_apc",
+	"PrefabIdentifier": "chrPrfVhcl_apc",
+	"PrefabBase": "apc",
+	"Tonnage": 25,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1.25,
+	"VisibilityMultiplier": 0.85,
+	"SensorRangeMultiplier": 1.5,
+	"Signature": 0,
+	"Radius": 6,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 6,
+			"z": 2.5
+		},
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": 7
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 6,
+			"z": 2.5
+		},
+		{
+			"x": 0,
+			"y": 3.5,
+			"z": 7
+		},
+		{
+			"x": -2,
+			"y": 6,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 6,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 5,
+			"z": -9
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 95,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 95,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 80,
+			"InternalStructure": 15
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Energy",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 50,
+			"InternalStructure": 15
+		}
+	]
+}

--- a/Republic 3081-3130/vehicleChassis/vehiclechassisdef_DIGGS.json
+++ b/Republic 3081-3130/vehicleChassis/vehiclechassisdef_DIGGS.json
@@ -1,0 +1,125 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_DIGGS",
+		"Name": "Diggs Drone Control Tank",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 5,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_6-9cv",
+	"PathingCapDefID": "pathingdef_light_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/Republic 3081-3130/vehicleChassis/vehiclechassisdef_MHI.json
+++ b/Republic 3081-3130/vehicleChassis/vehiclechassisdef_MHI.json
@@ -1,0 +1,125 @@
+{
+	"Description": {
+		"Id": "vehiclechassisdef_MHI",
+		"Name": "MHI Amphibious APC",
+		"Details": "",
+		"Icon": "STRIKER",
+		"Cost": 564,
+		"Rarity": 5,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "movedef_5-8cv",
+	"PathingCapDefID": "pathingdef_light_wheeled",
+	"HardpointDataDefID": "hardpointdatadef_chevalier",
+	"PrefabIdentifier": "chrprfvhcl_chevalier",
+	"PrefabBase": "chevalier",
+	"Tonnage": 35,
+	"weightClass": "LIGHT",
+	"BattleValue": 564,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"movementType": "Wheeled",
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 3,
+	"LOSSourcePositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": 0,
+			"y": 3.25,
+			"z": -0.5
+		},
+		{
+			"x": 0,
+			"y": 1.5,
+			"z": 3
+		},
+		{
+			"x": -1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 1.5,
+			"y": 4,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 2.5,
+			"z": -4
+		}
+	],
+	"Locations": [
+		{
+			"Location": "Front",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Left",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Right",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Rear",
+			"Hardpoints": [],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		},
+		{
+			"Location": "Turret",
+			"Hardpoints": [
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "Missile",
+					"Omni": false
+				}
+			],
+			"Tonnage": 0,
+			"InventorySlots": 0,
+			"MaxArmor": 160,
+			"InternalStructure": 20
+		}
+	]
+}

--- a/RogueTanksChangelog.txt
+++ b/RogueTanksChangelog.txt
@@ -105,6 +105,26 @@ Checked but Raza moved them somewhere:
 LRM_Extended, LRM_Enh,
 
 ----------------------------
+9.5.3 27/03/2020 (Raza)
+Updated the following tanks for Colo's new prefabs:
+Chaparral, Maxim/Maxim II, Zephyr/Zephyr Omni 
+Moved Jihad era XTRO (prototype) vehicles to the Jihad Uniques folder
+Added the Anat APC
+Added the Bandit/Bandit (C) APC's
+Added the Chevalier
+Added the Diggs Drone Control Tank
+Added 3 custom Society Donar's
+Added the Gabriel
+Added the Kanga Jump Tank (sans JJ's)
+Added the Lightning
+Added the MHI APC
+Added the Myrmidon II
+Added the Padilla Tube Artillery/AMS Tank
+Added the Scimitar MKII
+Added the Zephyr Omni Drone
+
+
+
 9.3.9 25/03/2020 (Raza)
 Added the Chaparral Arrow IV tank
 Added the DI Multi Purpose VTOL


### PR DESCRIPTION
Updated the following tanks for Colo's new prefabs:
Chaparral, Maxim/Maxim II, Zephyr/Zephyr Omni 
Moved Jihad era XTRO (prototype) vehicles to the Jihad Uniques folder
Added the Anat APC
Added the Bandit/Bandit (C) APC's
Added the Chevalier
Added the Diggs Drone Control Tank
Added 3 custom Society Donar's
Added the Gabriel
Added the Kanga Jump Tank (sans JJ's)
Added the Lightning
Added the MHI APC
Added the Myrmidon II
Added the Padilla Tube Artillery/AMS Tank
Added the Scimitar MKII
Added the Zephyr Omni Drone