### PR TITLE
Remove HSCapacity multiplication

### DIFF
--- a/RogueModuleTech/Armors/Gear_Active_Camouflage.json
+++ b/RogueModuleTech/Armors/Gear_Active_Camouflage.json
@@ -55,11 +55,12 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-	"MimeticEnhance",
-	"MimeticStealth: 35%, 4, 3",
+		"MimeticEnhance",
+		"MimeticStealth: 35%, 4, 3",
                 "StealthReserved: 6",
                 "Visibility: -40%",
-                "ActiveHeatEfficiency: -5%",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +5",
                 "ReqECM",
                 "ArmorTPCost: 15%",
                 "ArmorCBCost: 20%"
@@ -164,11 +165,38 @@
                 "Icon": "uixSvgIcon_equipment_ThermalExchanger"
             },
             "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.95",
-                "modType": "System.Single"
+                    "statisticData": {
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.10",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-5",
+                        "modType": "System.Int32"
             }
         }
       ],

--- a/RogueModuleTech/Armors/Gear_Black_Carapace.json
+++ b/RogueModuleTech/Armors/Gear_Black_Carapace.json
@@ -80,7 +80,8 @@
                 "StealthReserved: 6",
                 "Visibility: -30%",
                 "Signature: -30%",
-                "ActiveHeatEfficiency: -20%",
+		"TEHeatgen: +15%",
+		"HeatPerTurn: +10",
                 "ArmorTPCost: 75%",
                 "ArmorCBCost: 75%"
             ]
@@ -473,10 +474,37 @@
             },
             "nature": "Buff",
             "statisticData": {
-                 "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.8",
-                "modType": "System.Single"
+                "statName": "HeatGenerated",
+                "operation": "Float_Multiply",
+                "modValue": "1.15",
+                "modType": "System.Single",
+                "targetCollection": "Weapon"
+            }
+        },
+        {
+            "durationData": {
+                "duration": -1,
+                "stackLimit": -1
+            },
+            "targetingData": {
+                "effectTriggerType": "Passive",
+                "effectTargetType": "Creator",
+                "showInTargetPreview": false,
+                "showInStatusPanel": false
+            },
+            "effectType": "StatisticEffect",
+            "Description": {
+                "Id": "Stealth_Heat_Capacity_Stealth",
+                "Name": "Decreased Heat Capacity",
+                "Details": "Heat Capacity Penalty",
+                "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+            },
+            "nature": "Debuff",
+            "statisticData": {
+                "statName": "HeatSinkCapacity",
+                "operation": "Int_Add",
+                "modValue": "-10",
+                "modType": "System.Int32"
             }
         },
 		{

--- a/RogueModuleTech/Armors/Gear_HeavyFerro_VoidSignatureSystem.json
+++ b/RogueModuleTech/Armors/Gear_HeavyFerro_VoidSignatureSystem.json
@@ -61,14 +61,15 @@
 		"ErrorMessage": "Stealth Armor requires a ECM!",
         "BonusDescriptions": {
             "Bonuses": [
-	"Mimetic",
-	"MimeticStealth: 80%, 6, 7",
+		"Mimetic",
+		"MimeticStealth: 80%, 6, 7",
                 "StealthReserved: 2",
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-                "ActiveHeatEfficiency: -15%",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +10",
                 "ReqECM",
-				"ArmorFactor: -20%",
+		"ArmorFactor: -20%",
                 "ArmorTPCost: 75%",
                 "ArmorCBCost: 75%"
             ]
@@ -198,11 +199,38 @@
                 "Icon": "uixSvgIcon_equipment_ThermalExchanger"
             },
             "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.85",
-                "modType": "System.Single"
+                    "statisticData": {
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.1",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-10",
+                        "modType": "System.Int32"
             }
         }
       ],

--- a/RogueModuleTech/Armors/Gear_Signature_Damper.json
+++ b/RogueModuleTech/Armors/Gear_Signature_Damper.json
@@ -57,11 +57,11 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "StealthEnhance",
-				"StealthSensors: 40%, 2, 1, 2, 3",
+		"StealthSensors: 40%, 2, 1, 2, 3",
                 "ActiveSignature: -35%",
                 "Reserved: 6",
-                "ActiveHeatEfficiency: -5%",
-                "HeatPerTurn: +3",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +3",
                 "ReqECM",
                 "ArmorTPCost: 10%",
                 "ArmorCBCost: 15%"
@@ -167,10 +167,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.05",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
                         "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.95",
-                "modType": "System.Single"
+                        "operation": "Int_Add",
+                        "modValue": "-3",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Armors/Gear_armorslots_MimeticArmor.json
+++ b/RogueModuleTech/Armors/Gear_armorslots_MimeticArmor.json
@@ -63,7 +63,8 @@
                 "Reserved: 6",
                 "ActiveVisibility: -60%",
                 "ActiveSignature: -10%",
-                "ActiveHeatEfficiency: -5%",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +6",
                 "ReqECM",
                 "ArmorTPCost: 25%",
                 "ArmorCBCost: 30%"
@@ -195,10 +196,37 @@
             },
             "nature": "Buff",
             "statisticData": {
+                "statName": "HeatGenerated",
+                "operation": "Float_Multiply",
+                "modValue": "1.05",
+                "modType": "System.Single",
+                "targetCollection": "Weapon"
+            }
+        },
+        {
+            "durationData": {
+                "duration": -1,
+                "stackLimit": -1
+            },
+            "targetingData": {
+                "effectTriggerType": "Passive",
+                "effectTargetType": "Creator",
+                "showInTargetPreview": false,
+                "showInStatusPanel": false
+            },
+            "effectType": "StatisticEffect",
+            "Description": {
+                "Id": "Stealth_Heat_Capacity_Stealth",
+                "Name": "Decreased Heat Capacity",
+                "Details": "Heat Capacity Penalty",
+                "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+            },
+            "nature": "Debuff",
+            "statisticData": {
                 "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.95",
-                "modType": "System.Single"
+                "operation": "Int_Add",
+                "modValue": "-6",
+                "modType": "System.Int32"
             }
         }
       ],

--- a/RogueModuleTech/Armors/Gear_armorslots_NullSignatureSystem.json
+++ b/RogueModuleTech/Armors/Gear_armorslots_NullSignatureSystem.json
@@ -61,10 +61,11 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 70%, 5, 2, 4, 6",
+		"StealthSensors: 70%, 5, 2, 4, 6",
                 "StealthReserved: 1",
                 "ActiveSignature: -70%",
-                "ActiveHeatEfficiency: -15%",
+                "ActiveTEHeatgen: +15%",
+                "ActiveHeatPerTurn: +10",
                 "ReqECM",
                 "ArmorTPCost: 40%",
                 "ArmorCBCost: 40%"
@@ -168,10 +169,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.85",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.15",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-10",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Armors/Gear_armorslots_VoidSignatureSystem.json
+++ b/RogueModuleTech/Armors/Gear_armorslots_VoidSignatureSystem.json
@@ -58,12 +58,13 @@
 		"ErrorMessage": "Stealth Armor requires a ECM!",
         "BonusDescriptions": {
             "Bonuses": [
-	"Mimetic",
-	"MimeticStealth: 80%, 6, 7",                
+		"Mimetic",
+		"MimeticStealth: 80%, 6, 7",                
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-				"StealthReserved: 1",
-                "ActiveHeatEfficiency: -10%",
+		"StealthReserved: 1",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +10",
                 "ReqECM",
                 "ArmorTPCost: 40%",
                 "ArmorCBCost: 40%"
@@ -194,11 +195,38 @@
                 "Icon": "uixSvgIcon_equipment_ThermalExchanger"
             },
             "nature": "Buff",
-            "statisticData": {
-               "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.9",
-                "modType": "System.Single"
+                    "statisticData": {
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.1",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-10",
+                        "modType": "System.Int32"
             }
         }
       ],

--- a/RogueModuleTech/Armors/Linked_ActiveCamouflage.json
+++ b/RogueModuleTech/Armors/Linked_ActiveCamouflage.json
@@ -21,10 +21,11 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "MimeticEnhance",
-	"MimeticStealth: 35%, 4, 3",
+		"MimeticStealth: 35%, 4, 3",
                 "StealthReserved: 6",
                 "Visibility: -40%",
-                "ActiveHeatEfficiency: -5%",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +5",
                 "ReqECM",
                 "ArmorTPCost: 15%",
                 "ArmorCBCost: 20%"

--- a/RogueModuleTech/Armors/Linked_Black_Carapace.json
+++ b/RogueModuleTech/Armors/Linked_Black_Carapace.json
@@ -38,7 +38,8 @@
                 "StealthReserved: 6",
                 "Visibility: -30%",
                 "Signature: -30%",
-                "ActiveHeatEfficiency: -20%",
+                "TEHeatgen: +15%",
+                "HeatPerTurn: +10",
                 "ArmorTPCost: 75%",
                 "ArmorCBCost: 75%"
             ]

--- a/RogueModuleTech/Armors/Linked_MimeticArmor.json
+++ b/RogueModuleTech/Armors/Linked_MimeticArmor.json
@@ -25,7 +25,8 @@
                 "Reserved: 6",
                 "ActiveVisibility: -60%",
                 "ActiveSignature: -10%",
-                "ActiveHeatEfficiency: -5%",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +6",
                 "ReqECM",
                 "ArmorTPCost: 25%",
                 "ArmorCBCost: 30%"

--- a/RogueModuleTech/Armors/Linked_NullSignatureSystem.json
+++ b/RogueModuleTech/Armors/Linked_NullSignatureSystem.json
@@ -23,10 +23,11 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 70%, 5, 2, 4, 6",
+		"StealthSensors: 70%, 5, 2, 4, 6",
                 "StealthReserved: 1",
                 "ActiveSignature: -70%",
-                "ActiveHeatEfficiency: -15%",
+                "ActiveTEHeatgen: +15%",
+                "ActiveHeatPerTurn: +10",
                 "ReqECM",
                 "ArmorTPCost: 40%",
                 "ArmorCBCost: 40%"

--- a/RogueModuleTech/Armors/Linked_SignatureDamper.json
+++ b/RogueModuleTech/Armors/Linked_SignatureDamper.json
@@ -26,8 +26,8 @@
 				"StealthSensors: 40%, 2, 1, 2, 3",
                 "ActiveSignature: -35%",
                 "Reserved: 6",
-                "ActiveHeatEfficiency: -5%",
-                "HeatPerTurn: +3",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +3",
                 "ReqECM",
                 "ArmorTPCost: 10%",
                 "ArmorCBCost: 15%"

--- a/RogueModuleTech/Armors/Linked_VoidSignatureSystem.json
+++ b/RogueModuleTech/Armors/Linked_VoidSignatureSystem.json
@@ -25,7 +25,8 @@
                 "StealthReserved: 1",
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-                "ActiveHeatEfficiency: -10%",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +10",
                 "ReqECM",
                 "ArmorTPCost: 40%",
                 "ArmorCBCost: 40%"

--- a/RogueModuleTech/Armors/Linked_VoidSignatureSystem_HF.json
+++ b/RogueModuleTech/Armors/Linked_VoidSignatureSystem_HF.json
@@ -21,13 +21,14 @@
         "BonusDescriptions": {
             "Bonuses": [
                "Mimetic",
-	"MimeticStealth: 80%, 6, 7",
+		"MimeticStealth: 80%, 6, 7",
                 "StealthReserved: 2",
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-                "ActiveHeatEfficiency: -15%",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +10",
                 "ReqECM",
-				"ArmorFactor: -20%",
+		"ArmorFactor: -20%",
                 "ArmorTPCost: 75%",
                 "ArmorCBCost: 75%"
             ]

--- a/RogueModuleTech/Armors/Linked_stealth.json
+++ b/RogueModuleTech/Armors/Linked_stealth.json
@@ -27,7 +27,8 @@
                 "ActiveVisibility: -15%",
                 "ActiveSignature: -15%",
                 "StealthReserved: 1",
-                "ActiveHeatEfficiency: -6%",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +3",
                 "ReqECM",
                 "ArmorTPCost: 25%",
                 "ArmorCBCost: 35%"

--- a/RogueModuleTech/Armors/armorslots_ff_stealth.json
+++ b/RogueModuleTech/Armors/armorslots_ff_stealth.json
@@ -64,14 +64,15 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 40%, 3, 2, 2, 3",
+		"StealthSensors: 40%, 3, 2, 2, 3",
                 "ActiveVisibility: -20%",
                 "ActiveSignature: -25%",                
-                "ActiveHeatEfficiency: -6%",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +3",
                 "ReqECM",            
-				"ArmorFactor: -12%",
-				"StealthReserved: 1",
-				"ArmorTPCost: 35%",
+		"ArmorFactor: -12%",
+		"StealthReserved: 1",
+		"ArmorTPCost: 35%",
                 "ArmorCBCost: 50%"
             ]
         },
@@ -199,10 +200,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.94",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.05",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-3",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Armors/emod_armorslots_HeatDissipating.json
+++ b/RogueModuleTech/Armors/emod_armorslots_HeatDissipating.json
@@ -34,8 +34,7 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-                "HeatEfficiency: 10%",
-                "TEHeatgen: -10%",
+                "TEHeatgen: -15%",
                 "ArmorFactor: +10%",
                 "Reserved: 6",
                 "ArmorTPCost: 10%",
@@ -83,32 +82,6 @@
             },
             "effectType": "StatisticEffect",
             "Description": {
-                "Id": "StatusEffect-Heat_Max-FB",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Has a Flame Breath.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.1",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
                 "Id": "StatusEffect-Heat_Armor3",
                 "Name": "HEAT GENERATION DECREASED",
                 "Details": "Heat generation reduced by 20%.",
@@ -118,7 +91,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.9",
+                "modValue": "0.85",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }

--- a/RogueModuleTech/Armors/emod_armorslots_stealth.json
+++ b/RogueModuleTech/Armors/emod_armorslots_stealth.json
@@ -61,11 +61,12 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 40%, 3, 2, 2, 3",
+		"StealthSensors: 40%, 3, 2, 2, 3",
                 "ActiveVisibility: -15%",
                 "ActiveSignature: -15%",
                 "StealthReserved: 1",
-                "ActiveHeatEfficiency: -6%",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +3",
                 "ReqECM",
                 "ArmorTPCost: 25%",
                 "ArmorCBCost: 35%"
@@ -195,10 +196,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.05",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                    "statisticData": {
                         "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.94",
-                "modType": "System.Single"
+                        "operation": "Int_Add",
+                        "modValue": "-3",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Armors/linked_ff_stealth.json
+++ b/RogueModuleTech/Armors/linked_ff_stealth.json
@@ -23,14 +23,15 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 40%, 3, 2, 2, 3",
+		"StealthSensors: 40%, 3, 2, 2, 3",
                 "ActiveVisibility: -20%",
-                "ActiveSignature: -25%",                
-                "ActiveHeatEfficiency: -6%",
-                "ReqECM",            
-				"ArmorFactor: -12%",
-				"StealthReserved: 1",
-				"ArmorTPCost: 35%",
+                "ActiveSignature: -25%",
+                "ActiveTEHeatgen: +5%",
+                "ActiveHeatPerTurn: +3",
+                "ReqECM",
+		"ArmorFactor: -12%",
+		"StealthReserved: 1",
+		"ArmorTPCost: 35%",
                 "ArmorCBCost: 50%"
             ]
         },

--- a/RogueModuleTech/Basic/ChassisDefaults/Gear_FCS_Society.json
+++ b/RogueModuleTech/Basic/ChassisDefaults/Gear_FCS_Society.json
@@ -7,8 +7,7 @@
         ],
         "BonusDescriptions": {
             "Bonuses": [
-                "TEHeatgen: -5%",
-                "HeatEfficiency: +5%"
+                "TEHeatgen: -8%"
             ]
         },
         "InventorySorter": {
@@ -82,7 +81,7 @@
                 "effectsPersistAfterDestruction": false,
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.95",
+                "modValue": "0.92",
                 "modType": "System.Single",
                 "additionalRules": "NotSet",
                 "targetCollection": "Weapon",
@@ -97,32 +96,6 @@
             "vfxData": null,
             "instantModData": null,
             "poorlyMaintainedEffectData": null
-        },
-        {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_15",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.05",
-                "modType": "System.Single"
-            }
         }
     ],
     "ComponentTags": {

--- a/RogueModuleTech/Clan/Internals/emod_armorslots_clanHeatDissipating.json
+++ b/RogueModuleTech/Clan/Internals/emod_armorslots_clanHeatDissipating.json
@@ -37,8 +37,7 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-                "HeatEfficiency: 15%",
-                "TEHeatgen: -15%",
+                "TEHeatgen: -20%",
                 "ArmorFactor: +10%",
                 "Reserved: 6",
                 "ArmorTPCost: 40%",
@@ -77,32 +76,6 @@
         {
             "durationData": {
                 "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "StatusEffect-Heat_Max-FB",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Has a Flame Breath.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.15",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
                 "ticksOnActivations": false,
                 "useActivationsOfTarget": false,
                 "ticksOnEndOfRound": false,
@@ -135,7 +108,7 @@
                 "effectsPersistAfterDestruction": false,
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.85",
+                "modValue": "0.8",
                 "modType": "System.Single",
                 "additionalRules": "NotSet",
                 "targetCollection": "Weapon",

--- a/RogueModuleTech/Heatsink/Gear_HeatSink_Prototype_Double.json
+++ b/RogueModuleTech/Heatsink/Gear_HeatSink_Prototype_Double.json
@@ -16,8 +16,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "HeatPerTurn: -4",
-                "TEHeatgen: -3%",
-                "HeatEfficiency: +2%",
+                "TEHeatgen: -4%",
                 "BankBoom: 20"
             ]
         },
@@ -63,32 +62,6 @@
             },
             "effectType": "StatisticEffect",
             "Description": {
-                "Id": "HeatSinkEfficiency_2",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.02",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
                 "Id": "PDHSHeatGen",
                 "Name": "HEAT GENERATION DECREASED",
                 "Details": "Heat generation reduced by 10%.",
@@ -100,7 +73,7 @@
                 "effectsPersistAfterDestruction": false,
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.97",
+                "modValue": "0.96",
                 "modType": "System.Single",
                 "additionalRules": "NotSet",
                 "targetCollection": "Weapon",

--- a/RogueModuleTech/Heatsink/Gear_LaserInsulator.json
+++ b/RogueModuleTech/Heatsink/Gear_LaserInsulator.json
@@ -26,15 +26,14 @@
         },
 		"BonusDescriptions": {
             "Bonuses": [
-				"HeatPerTurn: -2",
+				"HeatPerTurn: -3",
                 "LaserHeatGenerated: -5%",
-				"HeatEfficiency: 1%",
 				"BankBoom: 10",
 				"LaserInsulator"
             ]
         }
     },
-	"DissipationCapacity": 2,
+	"DissipationCapacity": 3,
     "Description": {
         "Cost": 200000,
         "Rarity": 20,
@@ -59,32 +58,6 @@
     "DisallowedLocations": "All",
     "CriticalComponent": false,
     "statusEffects": [
-        {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "StatusEffect-Heat_Max-FB",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Has a Flame Breath.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.01",
-                "modType": "System.Single"
-            }
-        },
         {
             "durationData": {
                 "duration": -1,

--- a/RogueModuleTech/Heatsink/emod_kit_dhs_proto.json
+++ b/RogueModuleTech/Heatsink/emod_kit_dhs_proto.json
@@ -8,8 +8,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemProtoDHS",
-                "TEHeatgen: -20%",
-                "HeatEfficiency: +20%",
+                "TEHeatgen: -30%",
                 "BankBoom: 40"
             ]
         },
@@ -72,32 +71,6 @@
             },
             "effectType": "StatisticEffect",
             "Description": {
-                "Id": "HeatSinkEfficiency_20",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.2",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
                 "Id": "PDHSKitHeatGen",
                 "Name": "HEAT GENERATION DECREASED",
                 "Details": "Heat generation reduced by 10%.",
@@ -107,7 +80,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.8",
+                "modValue": "0.7",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }

--- a/RogueModuleTech/Lootable/Internals/lootable_ChameleonLightPolarizationShield.json
+++ b/RogueModuleTech/Lootable/Internals/lootable_ChameleonLightPolarizationShield.json
@@ -41,7 +41,8 @@
 				"MimeticStealth: 50%, 4, 4",
                 "ActiveVisibility: -50%",
                 "ActiveSignature: -50%",
-                "ActiveHeatEfficiency: -22%",
+		"ActiveHeatPerTurn: 15",
+		"ActiveTEHeatgen: 20%",
 				"Reserved: 12",
                 "ArmorTPCost: 55%",
                 "ArmorCBCost: 55%"
@@ -193,12 +194,39 @@
                 "Details": "Heat generation",
                 "Icon": "uixSvgIcon_equipment_ThermalExchanger"
             },
-            "nature": "Buff",
+            "nature": "Debuff",
+            "statisticData": {
+                "statName": "HeatGenerated",
+                "operation": "Float_Multiply",
+                "modValue": "1.15",
+                "modType": "System.Single",
+                "targetCollection": "Weapon"
+            }
+        },
+        {
+            "durationData": {
+                "duration": -1,
+                "stackLimit": -1
+            },
+            "targetingData": {
+                "effectTriggerType": "Passive",
+                "effectTargetType": "Creator",
+                "showInTargetPreview": false,
+                "showInStatusPanel": false
+            },
+            "effectType": "StatisticEffect",
+            "Description": {
+                "Id": "Stealth_Heat_Capacity_Stealth",
+                "Name": "Decreased Heat Capacity",
+                "Details": "Heat Capacity Penalty",
+                "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+            },
+            "nature": "Debuff",
             "statisticData": {
                 "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.78",
-                "modType": "System.Single"
+                "operation": "Int_Add",
+                "modValue": "-15",
+                "modType": "System.Int32"
             }
         }
       ],

--- a/RogueModuleTech/Lootable/Internals/lootable_FCS_Society.json
+++ b/RogueModuleTech/Lootable/Internals/lootable_FCS_Society.json
@@ -7,8 +7,7 @@
         ],
         "BonusDescriptions": {
             "Bonuses": [
-                "TEHeatgen: -5%",
-		"HeatEfficiency: +5%"
+                "TEHeatgen: -8%"
             ]
         },
         "InventorySorter": {
@@ -79,7 +78,7 @@
                 "effectsPersistAfterDestruction": false,
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.95",
+                "modValue": "0.92",
                 "modType": "System.Single",
                 "additionalRules": "NotSet",
                 "targetCollection": "Weapon",
@@ -94,32 +93,6 @@
             "vfxData": null,
             "instantModData": null,
             "poorlyMaintainedEffectData": null
-        },
-       {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_15",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.05",
-                "modType": "System.Single"
-            }
         }
     ],
     "ComponentTags": {

--- a/RogueModuleTech/Pirate/Engine/Kit_pdhs_Pirate.json
+++ b/RogueModuleTech/Pirate/Engine/Kit_pdhs_Pirate.json
@@ -8,17 +8,15 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemProtoDHS",
-				"TEHeatgen: -15%",
-                "HeatEfficiency: +15%",
-				"HeatPerTurn: -10",
-				"ActivateHeatLevel: 80%",
-				"DeActivateHeatLevel: 20%",
+		"TEHeatgen: -20%",
+		"HeatPerTurn: -10",
+		"ActivateHeatLevel: 80%",
+		"DeActivateHeatLevel: 20%",
                 "ActiveHeatPerTurn: -30",
-				"ActiveTEHeatgen: -15%",
-                "ActiveHeatEfficiency: +15%",
-				"FailChance: 10%",
-				"FailChanceTurn: 20%",
-				"FailCritSelf",
+		"ActiveTEHeatgen: -20%",
+		"FailChance: 10%",
+		"FailChanceTurn: 20%",
+		"FailCritSelf",
                 "CPBoom: 100"
             ]
         },
@@ -104,32 +102,6 @@
             },
             "nature": "Buff"
         },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_15_APPDHSKit",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.15",
-                "modType": "System.Single"
-            }
-        },
         {
             "durationData": {
                 "duration": -1,
@@ -152,7 +124,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.85",
+                "modValue": "0.80",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }
@@ -434,32 +406,6 @@
     "DisallowedLocations": "All",
     "CriticalComponent": false,
     "statusEffects": [
-	{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_15",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.15",
-                "modType": "System.Single"
-            }
-        },
         {
             "durationData": {
                 "duration": -1,
@@ -487,7 +433,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.85",
+                "modValue": "0.80",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }

--- a/RogueModuleTech/Pirate/Weapons/Weapon_Flamer_JuryRigged_Cockpit.json
+++ b/RogueModuleTech/Pirate/Weapons/Weapon_Flamer_JuryRigged_Cockpit.json
@@ -10,7 +10,7 @@
                 "WpnRecoil: 2",
                 "VariableDmg: 5",
                 "PipsIgnored: 1",
-                "HeatEfficiency: 2%",
+		"HeatPerTurn: -2",
                 "OHDamage: 75%",
                 "DmgFallOff: 35%",
                 "NoAA",
@@ -111,10 +111,10 @@
             },
             "nature": "Buff",
             "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.02",
-                "modType": "System.Single"
+                        "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "2",
+                        "modType": "System.Int32"
             }
         }
     ],

--- a/RogueModuleTech/Quirks/Heatsink/compact_kit_dhs_proto.json
+++ b/RogueModuleTech/Quirks/Heatsink/compact_kit_dhs_proto.json
@@ -8,9 +8,8 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemProtoDHS",
-				"HeatPerTurn: -12",
-                "TEHeatgen: -25%",
-                "HeatEfficiency: 10%",
+		"HeatPerTurn: -12",
+                "TEHeatgen: -30%",
                 "BankBoom: 40"
             ]
         },
@@ -67,32 +66,6 @@
         {
             "durationData": {
                 "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "StatusEffect-Heat_Max-FB",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Has a Flame Breath.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.1",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
                 "ticksOnActivations": false,
                 "useActivationsOfTarget": false,
                 "ticksOnEndOfRound": false,
@@ -123,7 +96,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.75",
+                "modValue": "0.70",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }

--- a/RogueModuleTech/Quirks/Heatsink/emod_kit_dhs_royal.json
+++ b/RogueModuleTech/Quirks/Heatsink/emod_kit_dhs_royal.json
@@ -3,8 +3,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemDHS",
-                "TEHeatgen: -5%",
-                "HeatEfficiency: 5%",
+                "TEHeatgen: -8%",
                 "HeatPerTurn: -6"
             ]
         },
@@ -62,32 +61,6 @@
     "DisallowedLocations": "All",
     "CriticalComponent": false,
     "statusEffects": [
-	 {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "StatusEffect-Heat_Max-FB",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Has a Flame Breath.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.05",
-                "modType": "System.Single"
-            }
-        },
         {
             "durationData": {
                 "duration": -1,
@@ -110,7 +83,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.95",
+                "modValue": "0.92",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }

--- a/RogueModuleTech/Quirks/Heatsink/emod_kit_dhs_widowmaker.json
+++ b/RogueModuleTech/Quirks/Heatsink/emod_kit_dhs_widowmaker.json
@@ -3,8 +3,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemDHS",
-                "TEHeatgen: -10%",
-                "HeatEfficiency: 5%",
+                "TEHeatgen: -13%",
                 "HeatPerTurn: -10"
             ]
         },
@@ -65,32 +64,6 @@
         {
             "durationData": {
                 "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "StatusEffect-Heat_Max-FB",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Has a Flame Breath.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.05",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
                 "stackLimit": 1
             },
             "targetingData": {
@@ -110,7 +83,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.9",
+                "modValue": "0.87",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }

--- a/RogueModuleTech/Quirks/PositiveQuirks/Special_OmniStealth.json
+++ b/RogueModuleTech/Quirks/PositiveQuirks/Special_OmniStealth.json
@@ -16,14 +16,15 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"WeightedQuirk: 50%",
-				"Stealth",
-				"StealthSensors: 40%, 3, 1, 2, 3",
-				"MimeticStealth: 40%, 3, 3",
+		"WeightedQuirk: 50%",
+		"Stealth",
+		"StealthSensors: 40%, 3, 1, 2, 3",
+		"MimeticStealth: 40%, 3, 3",
                 "Visibility: -30%",
                 "Signature: -30%",
-                "ActiveHeatEfficiency: -8%",
-				"LocalEcm: 3"
+                "TEHeatgen: +10%",
+                "HeatPerTurn: +10",
+		"LocalEcm: 3"
             ]
         },
 		"MechConfiguration" : {
@@ -245,10 +246,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.92",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.1",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-10",
+                        "modType": "System.Int32"
                     }
                 }
     ],

--- a/RogueModuleTech/Quirks/Upgrade/Gear_Queen_Carapace.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_Queen_Carapace.json
@@ -80,8 +80,9 @@
                 "Jammer: 1, 280",
                 "ArmorFactor: -10%",
                 "StealthSensors: 30%, 3, 2, 3, 4",
-				"MimeticStealth: 30%, 3, 4",
-				"ActiveHeatEfficiency: -12%",
+		"MimeticStealth: 30%, 3, 4",
+                "TEHeatgen: +5%",
+                "HeatPerTurn: +5",
                 "StealthReserved: 6",
                 "Visibility: -30%",
                 "Signature: -30%",
@@ -477,10 +478,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.88",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.05",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-5",
+                        "modType": "System.Int32"
                     }
                 }
     ],

--- a/RogueModuleTech/Quirks/Upgrade/Gear_Reactive_Plating_mirax.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_Reactive_Plating_mirax.json
@@ -20,7 +20,7 @@
             "Bonuses": [
                 "KineticProtection: 25%",
                 "EnergyProtection: -10%",
-                "HeatEfficiency: 10%",
+                "HeatPerTurn: -5",
                 "ArmorTPCost: 10%",
                 "ArmorCBCost: 15%"
             ]
@@ -165,10 +165,10 @@
             },
             "nature": "Buff",
             "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.1",
-                "modType": "System.Single"
+                        "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "5",
+                        "modType": "System.Int32"
             }
         }
     ],

--- a/RogueModuleTech/Quirks/Upgrade/Gear_quirk_ChameleonLightPolarizationShield.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_quirk_ChameleonLightPolarizationShield.json
@@ -25,11 +25,12 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CLPS",
-				"StealthSensors: 50%, 4, 2, 4, 6",
-				"MimeticStealth: 50%, 4, 5",
+		"StealthSensors: 50%, 4, 2, 4, 6",
+		"MimeticStealth: 50%, 4, 5",
                 "ActiveVisibility: -50%",
                 "ActiveSignature: -50%",
-                "ActiveHeatEfficiency: -18%",
+                "TEHeatgen: +15%",
+                "HeatPerTurn: +15",
                 "ReqECM",
                 "ArmorTPCost: 50%",
                 "ArmorCBCost: 50%"
@@ -182,10 +183,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.82",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.15",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-15",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Quirks/Upgrade/Gear_quirk_Hardened_CLPS.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_quirk_Hardened_CLPS.json
@@ -31,15 +31,16 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CLPS",
-				"StealthSensors: 50%, 4, 2, 4, 6",
-				"MimeticStealth: 50%, 4, 5",
+		"StealthSensors: 50%, 4, 2, 4, 6",
+		"MimeticStealth: 50%, 4, 5",
                 "ActiveVisibility: -50%",
                 "ActiveSignature: -50%",
-                "ActiveHeatEfficiency: -20%",
-				"ArmorProtection: x2",
-				"ArmorFactor: x2",
-				"TACImmune",
-				"WalkSpeed: -20%",
+                "TEHeatgen: +15%",
+                "HeatPerTurn: +15",
+		"ArmorProtection: x2",
+		"ArmorFactor: x2",
+		"TACImmune",
+		"WalkSpeed: -20%",
                 "ReqECM",
                 "ArmorTPCost: X2",
                 "ArmorCBCost: X2"
@@ -192,10 +193,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.8",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.15",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "15",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Quirks/Upgrade/Linked_GhostArmor.json
+++ b/RogueModuleTech/Quirks/Upgrade/Linked_GhostArmor.json
@@ -8,8 +8,8 @@
         }],
         "Flags": {
             "flags": [
-				"default",
-				"not_broken",
+		"default",
+		"not_broken",
                 "no_salvage",
                 "autorepair"
             ]
@@ -22,14 +22,15 @@
             "Bonuses": [
                "ArmorFactor: -12%",
                 "Stealth",
-				"StealthSensors: 20%, 2, 1, 2, 3",
-				"MimeticStealth: 25%, 3, 4",
+		"StealthSensors: 20%, 2, 1, 2, 3",
+		"MimeticStealth: 25%, 3, 4",
                 "StealthReserved: 1",
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-                "ActiveHeatEfficiency: -12%",
-				"StealthReserved: 1",
-				"ReqECM",
+                "TEHeatgen: +10%",
+                "HeatPerTurn: +10",
+		"StealthReserved: 1",
+		"ReqECM",
                 "ArmorTPCost: 70%",
                 "ArmorCBCost: 125%",
                 "CASE"

--- a/RogueModuleTech/Quirks/Upgrade/Linked_HeavyVoid.json
+++ b/RogueModuleTech/Quirks/Upgrade/Linked_HeavyVoid.json
@@ -20,15 +20,16 @@
 				"ErrorMessage": "Stealth Armor requires a ECM!",
 		"BonusDescriptions": {
             "Bonuses": [
-                  "ArmorFactor: -20%",
+                "ArmorFactor: -20%",
                 "Stealth",
-				"StealthSensors: 25%, 2, 1, 2, 4",
-				"MimeticStealth: 65%, 5, 5",
+		"StealthSensors: 25%, 2, 1, 2, 4",
+		"MimeticStealth: 65%, 5, 5",
                 "StealthReserved: 2",
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-                "ActiveHeatEfficiency: -15%",
-				"ReqECM",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +10",
+		"ReqECM",
                 "ArmorTPCost: 80%",
                 "ArmorCBCost: 135%"
             ]

--- a/RogueModuleTech/Quirks/Upgrade/Linked_LAM_stealth.json
+++ b/RogueModuleTech/Quirks/Upgrade/Linked_LAM_stealth.json
@@ -26,14 +26,15 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 50%, 4, 2, 3, 4",
+		"StealthSensors: 50%, 4, 2, 3, 4",
                 "ActiveVisibility: -15%",
                 "ActiveSignature: -25%",
-				"JumpDistance: 10%",
+		"JumpDistance: 10%",
                 "ArmorFactor: +10%",
                 "StealthReserved: 1",
-                "ActiveHeatEfficiency: -15%",
-				"CASEDArmor: 10",
+                "TEHeatgen: +10%",
+                "HeatPerTurn: +9",
+		"CASEDArmor: 10",
                 "ReqECM",
                 "ArmorTPCost: 35%",
                 "ArmorCBCost: 65%"

--- a/RogueModuleTech/Quirks/Upgrade/Linked_Queen_Carapace.json
+++ b/RogueModuleTech/Quirks/Upgrade/Linked_Queen_Carapace.json
@@ -22,7 +22,7 @@
                 },
         "BonusDescriptions": {
             "Bonuses": [
-				"Carapace",
+		"Carapace",
                 "HaarJel",
                 "HaarJelTurn",
                 "HaarJelArmor: 12",
@@ -32,8 +32,9 @@
                 "Jammer: 1, 280",
                 "ArmorFactor: -10%",
                 "StealthSensors: 30%, 3, 2, 3, 4",
-				"MimeticStealth: 30%, 3, 4",
-				"ActiveHeatEfficiency: -12%",
+		"MimeticStealth: 30%, 3, 4",
+                "TEHeatgen: +5%",
+                "HeatPerTurn: +5",
                 "StealthReserved: 6",
                 "Visibility: -30%",
                 "Signature: -30%",

--- a/RogueModuleTech/Quirks/Upgrade/Quirk_LAM_stealth.json
+++ b/RogueModuleTech/Quirks/Upgrade/Quirk_LAM_stealth.json
@@ -67,14 +67,15 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 50%, 4, 2, 3, 4",
+		"StealthSensors: 50%, 4, 2, 3, 4",
                 "ActiveVisibility: -15%",
                 "ActiveSignature: -25%",
-				"JumpDistance: 10%",
+		"JumpDistance: 10%",
                 "ArmorFactor: +10%",
                 "StealthReserved: 1",
-                "ActiveHeatEfficiency: -15%",
-				"CASEDArmor: 10",
+                "TEHeatgen: +10%",
+                "HeatPerTurn: +9",
+		"CASEDArmor: 10",
                 "ReqECM",
                 "ArmorTPCost: 35%",
                 "ArmorCBCost: 65%"
@@ -204,10 +205,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                       "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.85",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.1",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-9",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Quirks/Upgrade/emod_armorslots_Basilisk.json
+++ b/RogueModuleTech/Quirks/Upgrade/emod_armorslots_Basilisk.json
@@ -38,8 +38,7 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-                "HeatEfficiency: 20%",
-                "TEHeatgen: -10%",
+                "TEHeatgen: -20%",
                 "ArmorFactor: -12%",
                 "Reserved: 8",
                 "ArmorTPCost: 10%",
@@ -90,32 +89,6 @@
             },
             "effectType": "StatisticEffect",
             "Description": {
-                "Id": "StatusEffect-Heat_Max-FB",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Has a Flame Breath.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.2",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
                 "Id": "StatusEffect-Heat_Armor3",
                 "Name": "HEAT GENERATION DECREASED",
                 "Details": "Heat generation reduced by 20%.",
@@ -125,7 +98,7 @@
             "statisticData": {
                 "statName": "HeatGenerated",
                 "operation": "Float_Multiply",
-                "modValue": "0.9",
+                "modValue": "0.8",
                 "modType": "System.Single",
                 "targetCollection": "Weapon"
             }

--- a/RogueModuleTech/Quirks/Upgrade/emod_armorslots_FreemanStealth.json
+++ b/RogueModuleTech/Quirks/Upgrade/emod_armorslots_FreemanStealth.json
@@ -37,12 +37,13 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "Stealth",
-				"StealthSensors: 35%, 3, 1, 2, 3",
-				"MimeticStealth: 15%, 2, 4",
+		"StealthSensors: 35%, 3, 1, 2, 3",
+		"MimeticStealth: 15%, 2, 4",
                 "Reserved: 6",
                 "ActiveVisibility: -30%",
                 "ActiveSignature: -50%",
-                "ActiveHeatEfficiency: +12%",
+                "TEHeatgen: +5%",
+                "HeatPerTurn: +5",
                 "ReqECM",
                 "ArmorTPCost: 50%",
                 "ArmorCBCost: 50%"
@@ -209,10 +210,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.88",
-                "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.05",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-5",
+                        "modType": "System.Int32"
                     }
                 }
             ],

--- a/RogueModuleTech/Quirks/Upgrade/emod_armorslots_Ghost.json
+++ b/RogueModuleTech/Quirks/Upgrade/emod_armorslots_Ghost.json
@@ -71,14 +71,15 @@
             "Bonuses": [
                 "ArmorFactor: -12%",
                 "CLPS",
-				"StealthSensors: 20%, 2, 1, 2, 3",
-				"MimeticStealth: 25%, 3, 4",
+		"StealthSensors: 20%, 2, 1, 2, 3",
+		"MimeticStealth: 25%, 3, 4",
                 "StealthReserved: 1",
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-                "ActiveHeatEfficiency: -12%",
-				"StealthReserved: 1",
-				"ReqECM",
+                "TEHeatgen: +10%",
+                "HeatPerTurn: +10",
+		"StealthReserved: 1",
+		"ReqECM",
                 "ArmorTPCost: 70%",
                 "ArmorCBCost: 125%",
                 "CASE"
@@ -244,11 +245,38 @@
                 "Icon": "uixSvgIcon_equipment_ThermalExchanger"
             },
             "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.88",
-                "modType": "System.Single"
+                    "statisticData": {
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.1",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-10",
+                        "modType": "System.Int32"
             }
         }
       ],

--- a/RogueModuleTech/Quirks/Upgrade/emod_armorslots_HeavyVoid.json
+++ b/RogueModuleTech/Quirks/Upgrade/emod_armorslots_HeavyVoid.json
@@ -68,13 +68,14 @@
             "Bonuses": [
                 "ArmorFactor: -20%",
                 "CLPS",
-				"StealthSensors: 25%, 2, 1, 2, 4",
-				"MimeticStealth: 65%, 5, 5",
+		"StealthSensors: 25%, 2, 1, 2, 4",
+		"MimeticStealth: 65%, 5, 5",
                 "StealthReserved: 2",
                 "ActiveVisibility: -70%",
                 "ActiveSignature: -15%",
-                "ActiveHeatEfficiency: -15%",
-				"ReqECM",
+                "ActiveTEHeatgen: +10%",
+                "ActiveHeatPerTurn: +10",
+		"ReqECM",
                 "ArmorTPCost: 80%",
                 "ArmorCBCost: 135%"
             ]
@@ -239,11 +240,38 @@
                 "Icon": "uixSvgIcon_equipment_ThermalExchanger"
             },
             "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "0.85",
-                "modType": "System.Single"
+                    "statisticData": {
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.1",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-10",
+                        "modType": "System.Int32"
             }
         }
       ],

--- a/RogueModuleTech/Quirks/Weapon/Weapon_Flamer_Dragonbreath.json
+++ b/RogueModuleTech/Quirks/Weapon/Weapon_Flamer_Dragonbreath.json
@@ -15,11 +15,11 @@
                 "PIRATEFLAMERDEBUFF: 25%",
                 "VariableDmg: 10",
                 "PipsIgnored: 1",
-                "HeatEfficiency: 5%",
+                "HeatPerTurn: -3",
                 "OHDamage: 40%",
-				"DmgFallOff: 30%",
+		"DmgFallOff: 30%",
                 "Initiative: +1",
-				"NoAA"
+		"NoAA"
             ]
         },
         "InventorySorter": {
@@ -170,10 +170,10 @@
             },
             "nature": "Buff",
             "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.05",
-                "modType": "System.Single"
+                        "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "3",
+                        "modType": "System.Int32"
             }
         }
     ],

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant.json
@@ -14,15 +14,14 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 0",
+		"EmergencyCoolant: 0",
                 "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -10",
-				"ActiveHeatEfficiency: +10%",
-				"FailChance: 10%",
-				"FailChanceTurn: 5%",
-				"FailCritSelf",
-				"FailReducPilot",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -20",
+		"FailChance: 10%",
+		"FailChanceTurn: 5%",
+		"FailCritSelf",
+		"FailReducPilot",
                 "CPBoom: 10"
             ]
         },
@@ -65,36 +64,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "10",
+                "modValue": "20",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_15_APPDHSKit",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.1",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_1.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_1.json
@@ -14,15 +14,14 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 1",
+		"EmergencyCoolant: 1",
                 "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -15",
-				"ActiveHeatEfficiency: +15%",
-				"FailChance: 5%",
-				"FailChanceTurn: 15%",
-				"FailCritSelf",
-				"FailReducPilot",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -25",
+		"FailChance: 5%",
+		"FailChanceTurn: 15%",
+		"FailCritSelf",
+		"FailReducPilot",
                 "CPBoom: 15"
             ]
         },
@@ -80,32 +79,6 @@
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.15",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_2.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_2.json
@@ -14,15 +14,14 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 1",
+		"EmergencyCoolant: 1",
                 "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -20",
-				"ActiveHeatEfficiency: +20%",
-				"FailChance: 5%",
-				"FailChanceTurn: 20%",
-				"FailCritSelf",
-				"FailReducPilot",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -30",
+		"FailChance: 5%",
+		"FailChanceTurn: 20%",
+		"FailCritSelf",
+		"FailReducPilot",
                 "CPBoom: 20"
             ]
         },
@@ -65,36 +64,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "20",
+                "modValue": "30",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.2",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_3.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_3.json
@@ -14,15 +14,14 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 3",
+		"EmergencyCoolant: 3",
                 "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -25",
-				"ActiveHeatEfficiency: +25%",
-				"FailChance: 5%",
-				"FailChanceTurn: 25%",
-				"FailCritSelf",
-				"FailReducPilot",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -35",
+		"FailChance: 5%",
+		"FailChanceTurn: 25%",
+		"FailCritSelf",
+		"FailReducPilot",
                 "CPBoom: 25"
             ]
         },
@@ -65,36 +64,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "25",
+                "modValue": "35",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.25",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_4.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_4.json
@@ -14,15 +14,14 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 4",
+		"EmergencyCoolant: 4",
                 "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -30",
-				"ActiveHeatEfficiency: +30%",
-				"FailChance: 5%",
-				"FailChanceTurn: 30%",
-				"FailCritSelf",
-				"FailReducPilot",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -40",
+		"FailChance: 5%",
+		"FailChanceTurn: 30%",
+		"FailCritSelf",
+		"FailReducPilot",
                 "CPBoom: 30"
             ]
         },
@@ -65,36 +64,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "30",
+                "modValue": "40",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.3",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_5.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_5.json
@@ -14,15 +14,14 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 5",
-                "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -35",
-				"ActiveHeatEfficiency: +35%",
-				"FailChance: 5%",
-				"FailChanceTurn: 35%",
-				"FailCritSelf",
-				"FailReducPilot",
+		"EmergencyCoolant: 5",
+	        "ActivateHeatLevel: 120%",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -45",
+		"FailChance: 5%",
+		"FailChanceTurn: 35%",
+		"FailCritSelf",
+		"FailReducPilot",
                 "CPBoom: 35"
             ]
         },
@@ -65,36 +64,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "35",
+                "modValue": "45",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.35",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_6.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_6.json
@@ -14,15 +14,14 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 6",
+		"EmergencyCoolant: 6",
                 "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -40",
-				"ActiveHeatEfficiency: +40%",
-				"FailChance: 5%",
-				"FailChanceTurn: 40%",
-				"FailCritSelf",
-				"FailReducPilot",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -50",
+		"FailChance: 5%",
+		"FailChanceTurn: 40%",
+		"FailCritSelf",
+		"FailReducPilot",
                 "CPBoom: 40"
             ]
         },
@@ -65,36 +64,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "40",
+                "modValue": "50",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.4",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_RISC.json
+++ b/RogueModuleTech/RISC/Engines/Gear_EmergencyCoolant_RISC.json
@@ -14,11 +14,10 @@
         },
         "BonusDescriptions": {
             "Bonuses": [
-				"EmergencyCoolant: 0",
+		"EmergencyCoolant: 0",
                 "ActivateHeatLevel: 120%",
-				"DeActivateHeatLevel: 40%",
-                "ActiveHeatPerTurn: -15",
-				"ActiveHeatEfficiency: +15%",
+		"DeActivateHeatLevel: 40%",
+                "ActiveHeatPerTurn: -25",
 				"FailChance: 5%",
 				"FailChanceTurn: 5%",
 				"FailCritSelf",
@@ -65,36 +64,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "15",
+                "modValue": "25",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.15",
-                "modType": "System.Single"
-            }
         }
 			]
 		},

--- a/RogueModuleTech/RISC/Engines/emod_kit_dhs_RISC.json
+++ b/RogueModuleTech/RISC/Engines/emod_kit_dhs_RISC.json
@@ -8,13 +8,12 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemDHS",
-				"ActivateHeatLevel: 90%",
-				"DeActivateHeatLevel: 50%",
-                "ActiveHeatPerTurn: -15",
-				"ActiveHeatEfficiency: +15%",
-				"FailChance: 5%",
-				"FailChanceTurn: 10%",
-				"FailCritSelf",
+		"ActivateHeatLevel: 90%",
+		"DeActivateHeatLevel: 50%",
+	        "ActiveHeatPerTurn: -25",
+		"FailChance: 5%",
+		"FailChanceTurn: 10%",
+		"FailCritSelf",
                 "CPBoom: 10"
             ]
         },
@@ -79,36 +78,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "15",
+                "modValue": "25",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.15",
-                "modType": "System.Single"
-            }
         }
 			]
 		},

--- a/RogueModuleTech/RISC/Engines/lootable_kit_dhs_RISC.json
+++ b/RogueModuleTech/RISC/Engines/lootable_kit_dhs_RISC.json
@@ -8,13 +8,12 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemDHS",
-				"ActivateHeatLevel: 90%",
-				"DeActivateHeatLevel: 30%",
-                "ActiveHeatPerTurn: -10",
-				"ActiveHeatEfficiency: +10%",
-				"FailChance: 5%",
-				"FailChanceTurn: 10%",
-				"FailCritSelf",
+		"ActivateHeatLevel: 90%",
+		"DeActivateHeatLevel: 30%",
+                "ActiveHeatPerTurn: -20",
+		"FailChance: 5%",
+		"FailChanceTurn: 10%",
+		"FailCritSelf",
                 "CPBoom: 10"
             ]
         },
@@ -74,36 +73,10 @@
             "statisticData": {
                 "statName": "HeatSinkCapacity",
                 "operation": "Int_Add",
-                "modValue": "10",
+                "modValue": "20",
                 "modType": "System.Int32"
             },
             "nature": "Buff"
-        },
-		{
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10_RDHS",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.1",
-                "modType": "System.Single"
-            }
         }
 			]
 		}

--- a/RogueModuleTech/RISC/Engines/radical_kit_chs.json
+++ b/RogueModuleTech/RISC/Engines/radical_kit_chs.json
@@ -8,13 +8,12 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "CoolingSystemCHS",
-				"ActivateHeatLevel: 90%",
-				"DeActivateHeatLevel: 50%",
+		"ActivateHeatLevel: 90%",
+		"DeActivateHeatLevel: 50%",
                 "ActiveHeatPerTurn: -20",
-				"ActiveHeatEfficiency: +10%",
-				"FailChance: 5%",
-				"FailChanceTurn: 10%",
-				"FailCritSelf",
+		"FailChance: 5%",
+		"FailChanceTurn: 10%",
+		"FailCritSelf",
                 "CPBoom: 20"
             ]
         },

--- a/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Bulk-Bank.json
+++ b/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Bulk-Bank.json
@@ -17,22 +17,72 @@
             "HandHeldFactor": 0.6
         },
         "ComponentExplosion": {
-            "HeatDamage": 10,
-            "ExplosionDamage": 10,
-            "StabilityDamage": 10
+            "HeatDamage": 70,
+            "ExplosionDamage": 35,
+            "StabilityDamage": 35
         },
         "BonusDescriptions": {
             "Bonuses": [
                 "Special: 40%",
-                "HeatEfficiency: 20%",
+                "EmergencyCoolant: 0",
+                "ActivateHeatLevel: 150%",
+                "DeActivateHeatLevel: 120%",
+                "ActiveHeatPerTurn: -80",
+                "FailChance: 0%",
+                "FailChanceTurn: 50%",
+                "FailCritSelf",
+                "FailReducPilot",
                 "HeatPerTurn: -3",
-                "BankBoom: 10",
+                "BankBoom: 70",
                 "Visibility: +3%",
                 "Signature: +3%"
             ]
         },
         "InventorySorter": {
             "SortKey": "00017"
+        },
+       "ActivatableComponent": {
+            "ButtonName": "Emergency Coolant",
+            "AutoActivateOnOverheatLevel": 1.5,
+            "AutoDeactivateOverheatLevel": 1.2,
+            "FailFlatChance": 0,
+            "FailRoundsStart": 2,
+            "FailChancePerTurn": 0.5,
+            "SelfCrit": true,
+            "FailPilotingBase": 5,
+            "FailPilotingMult": 0.1,
+            "ActivationMessage": "ACTIVE",
+            "DeactivationMessage": "Nominal",
+            "CanNotBeActivatedManualy": true,
+            "NoUniqueCheck": true,
+            "statusEffects": [
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "EmergencyCooling",
+                        "Name": "Emergency Coolant System",
+                        "Details": "Emergency Coolant System drastically improves the mechs cooling",
+                        "Icon": "uixSvgIcon_action_evasivemove"
+                    },
+                    "statisticData": {
+                        "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "80",
+                        "modType": "System.Int32"
+                    },
+                    "nature": "Buff"
+                }
+            ]
         }
     },
     "DissipationCapacity": 3,

--- a/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Clan-Bank.json
+++ b/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Clan-Bank.json
@@ -17,22 +17,72 @@
             "HandHeldFactor": 0.65
         },
         "ComponentExplosion": {
-            "HeatDamage": 10,
-            "ExplosionDamage": 10,
-            "StabilityDamage": 10
+            "HeatDamage": 100,
+            "ExplosionDamage": 50,
+            "StabilityDamage": 50
         },
         "BonusDescriptions": {
             "Bonuses": [
                 "Special: 35%",
-                "HeatEfficiency: 17%",
+                "EmergencyCoolant: 0",
+                "ActivateHeatLevel: 130%",
+                "DeActivateHeatLevel: 120%",
+                "ActiveHeatPerTurn: -60",
+                "FailChance: 0%",
+                "FailChanceTurn: 50%",
+                "FailCritSelf",
+                "FailReducPilot",
                 "HeatPerTurn: -3",
-                "BankBoom: 10",
+                "BankBoom: 100",
                 "Visibility: +3%",
                 "Signature: +3%"
             ]
         },
         "InventorySorter": {
             "SortKey": "00017"
+        },
+       "ActivatableComponent": {
+            "ButtonName": "Emergency Coolant",
+            "AutoActivateOnOverheatLevel": 1.5,
+            "AutoDeactivateOverheatLevel": 1.2,
+            "FailFlatChance": 0,
+            "FailRoundsStart": 2,
+            "FailChancePerTurn": 0.5,
+            "SelfCrit": true,
+            "FailPilotingBase": 5,
+            "FailPilotingMult": 0.1,
+            "ActivationMessage": "ACTIVE",
+            "DeactivationMessage": "Nominal",
+            "CanNotBeActivatedManualy": true,
+            "NoUniqueCheck": true,
+            "statusEffects": [
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "EmergencyCooling",
+                        "Name": "Emergency Coolant System",
+                        "Details": "Emergency Coolant System drastically improves the mechs cooling",
+                        "Icon": "uixSvgIcon_action_evasivemove"
+                    },
+                    "statisticData": {
+                        "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "60",
+                        "modType": "System.Int32"
+                    },
+                    "nature": "Buff"
+                }
+            ]
         }
     },
     "DissipationCapacity": 3,

--- a/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Improved-Bank.json
+++ b/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Improved-Bank.json
@@ -17,22 +17,72 @@
             "HandHeldFactor": 0.7
         },
         "ComponentExplosion": {
-            "HeatDamage": 6,
-            "ExplosionDamage": 6,
-            "StabilityDamage": 6
+            "HeatDamage": 50,
+            "ExplosionDamage": 25,
+            "StabilityDamage": 25
         },
         "BonusDescriptions": {
             "Bonuses": [
                 "Special: 30%",
-                "HeatEfficiency: 15%",
+                "EmergencyCoolant: 0",
+                "ActivateHeatLevel: 150%",
+                "DeActivateHeatLevel: 120%",
+                "ActiveHeatPerTurn: -60",
+                "FailChance: 0%",
+                "FailChanceTurn: 50%",
+                "FailCritSelf",
+                "FailReducPilot",
                 "HeatPerTurn: -2",
-                "BankBoom: 6",
+                "BankBoom: 50",
                 "Visibility: +1%",
                 "Signature: +1%"
             ]
         },
         "InventorySorter": {
             "SortKey": "00017"
+        },
+       "ActivatableComponent": {
+            "ButtonName": "Emergency Coolant",
+            "AutoActivateOnOverheatLevel": 1.5,
+            "AutoDeactivateOverheatLevel": 1.2,
+            "FailFlatChance": 0,
+            "FailRoundsStart": 2,
+            "FailChancePerTurn": 0.5,
+            "SelfCrit": true,
+            "FailPilotingBase": 5,
+            "FailPilotingMult": 0.1,
+            "ActivationMessage": "ACTIVE",
+            "DeactivationMessage": "Nominal",
+            "CanNotBeActivatedManualy": true,
+            "NoUniqueCheck": true,
+            "statusEffects": [
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "EmergencyCooling",
+                        "Name": "Emergency Coolant System",
+                        "Details": "Emergency Coolant System drastically improves the mechs cooling",
+                        "Icon": "uixSvgIcon_action_evasivemove"
+                    },
+                    "statisticData": {
+                        "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "60",
+                        "modType": "System.Int32"
+                    },
+                    "nature": "Buff"
+                }
+            ]
         }
     },
     "DissipationCapacity": 2,

--- a/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Standard-Bank.json
+++ b/RogueModuleTech/Widget/Cooling/Gear_HeatSink_Generic_Standard-Bank.json
@@ -17,22 +17,72 @@
             "HandHeldFactor": 0.8
         },
         "ComponentExplosion": {
-            "HeatDamage": 2,
-            "ExplosionDamage": 2,
-            "StabilityDamage": 2
+            "HeatDamage": 30,
+            "ExplosionDamage": 15,
+            "StabilityDamage": 15
         },
         "BonusDescriptions": {
             "Bonuses": [
                 "Special: 20%",
-                "HeatEfficiency: 10%",
+                "EmergencyCoolant: 0",
+                "ActivateHeatLevel: 150%",
+                "DeActivateHeatLevel: 120%",
+                "ActiveHeatPerTurn: -40",
+                "FailChance: 0%",
+                "FailChanceTurn: 50%",
+                "FailCritSelf",
+                "FailReducPilot",
                 "HeatPerTurn: -1",
-                "BankBoom: 2",
+                "BankBoom: 30",
                 "Visibility: +1%",
                 "Signature: +1%"
             ]
         },
         "InventorySorter": {
             "SortKey": "00017"
+        },
+        "ActivatableComponent": {
+            "ButtonName": "Emergency Coolant",
+            "AutoActivateOnOverheatLevel": 1.5,
+            "AutoDeactivateOverheatLevel": 1.2,
+            "FailFlatChance": 0,
+            "FailRoundsStart": 2,
+            "FailChancePerTurn": 0.5,
+            "SelfCrit": true,
+            "FailPilotingBase": 5,
+            "FailPilotingMult": 0.1,
+            "ActivationMessage": "ACTIVE",
+            "DeactivationMessage": "Nominal",
+            "CanNotBeActivatedManualy": true,
+            "NoUniqueCheck": true,
+            "statusEffects": [
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "EmergencyCooling",
+                        "Name": "Emergency Coolant System",
+                        "Details": "Emergency Coolant System drastically improves the mechs cooling",
+                        "Icon": "uixSvgIcon_action_evasivemove"
+                    },
+                    "statisticData": {
+                        "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "40",
+                        "modType": "System.Int32"
+                    },
+                    "nature": "Buff"
+                }
+            ]
         }
     },
     "DissipationCapacity": 1,
@@ -109,32 +159,6 @@
                 "statName": "SpottingVisibilityMultiplier",
                 "operation": "Float_Multiply",
                 "modValue": "1.01",
-                "modType": "System.Single"
-            }
-        },
-        {
-            "durationData": {
-                "duration": -1,
-                "stackLimit": -1
-            },
-            "targetingData": {
-                "effectTriggerType": "Passive",
-                "effectTargetType": "Creator",
-                "showInTargetPreview": false,
-                "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "Description": {
-                "Id": "HeatSinkEfficiency_10",
-                "Name": "MAX HEAT INCREASED",
-                "Details": "Improves Heat 15Max/10Threshhold.",
-                "Icon": "uixSvgIcon_equipment_HeatBank"
-            },
-            "nature": "Buff",
-            "statisticData": {
-                "statName": "HeatSinkCapacity",
-                "operation": "Int_Multiply_Float",
-                "modValue": "1.1",
                 "modType": "System.Single"
             }
         }

--- a/RogueModuleTech/Widget/Cooling/Special_CoolShot.json
+++ b/RogueModuleTech/Widget/Cooling/Special_CoolShot.json
@@ -27,8 +27,7 @@
                 "EmergencyCoolant: 0",
                 "ActivateHeatLevel: 80%",
                 "DeActivateHeatLevel: 50%",
-                "ActiveHeatPerTurn: -25",
-                "ActiveHeatEfficiency: +25%",
+                "ActiveHeatPerTurn: -35",
                 "FailChance: 10%",
                 "FailChanceTurn: 10%",
                 "FailCritSelf",
@@ -77,7 +76,7 @@
                     "statisticData": {
                         "statName": "HeatSinkCapacity",
                         "operation": "Int_Add",
-                        "modValue": "25",
+                        "modValue": "35",
                         "modType": "System.Int32"
                     },
                     "nature": "Buff"

--- a/RogueModuleTech/Widget/Specials/Special_Aftermarket_Stealth.json
+++ b/RogueModuleTech/Widget/Specials/Special_Aftermarket_Stealth.json
@@ -52,7 +52,8 @@
                 "StealthSensors: 80%, 1, 1, 2, 3",
                 "ActiveSignature: -10%",
                 "Dynamic: 6",
-                "ActiveHeatEfficiency: -10%",
+                "TEHeatgen: +6%",
+                "HeatPerTurn: +6",
                 "ReqECM",
                 "ArmorTPCost: 20%",
                 "ArmorCBCost: 30%"
@@ -158,10 +159,37 @@
                     },
                     "nature": "Buff",
                     "statisticData": {
-                        "statName": "HeatSinkCapacity",
-                        "operation": "Int_Multiply_Float",
-                        "modValue": "0.9",
-                        "modType": "System.Single"
+                        "statName": "HeatGenerated",
+                        "operation": "Float_Multiply",
+                        "modValue": "1.06",
+                        "modType": "System.Single",
+                        "targetCollection": "Weapon"
+                    }
+                },
+                {
+                    "durationData": {
+                        "duration": -1,
+                        "stackLimit": -1
+                    },
+                    "targetingData": {
+                        "effectTriggerType": "Passive",
+                        "effectTargetType": "Creator",
+                        "showInTargetPreview": false,
+                        "showInStatusPanel": false
+                    },
+                    "effectType": "StatisticEffect",
+                    "Description": {
+                        "Id": "Stealth_Heat_Capacity_Stealth",
+                        "Name": "Decreased Heat Capacity",
+                        "Details": "Heat Capacity Penalty",
+                        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+                    },
+                    "nature": "Debuff",
+                     "statisticData": {
+                         "statName": "HeatSinkCapacity",
+                        "operation": "Int_Add",
+                        "modValue": "-6",
+                        "modType": "System.Int32"
                     }
                 }
             ],


### PR DESCRIPTION
Heatbanks - > SuperEmergency
For heatdissipating armor, fcs etc hsefficienty converted to heatgen
Emergencey and Stealth reverted to values they had before
Emergency and stealth were buffed, some very significally, when convering to hsefficienty (Notably high tier Emergency Coolants and all variants of CLPS). If this was intended, the values need to be adjusted

