### PR TITLE
Tank Movement distance fix

### DIFF
--- a/RogueTech Core/tankmovement/movedef_10-15cv.json
+++ b/RogueTech Core/tankmovement/movedef_10-15cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 350.0,
-    "MaxSprintDistance": 525.0,
+    "MaxWalkDistance": 300.0,
+    "MaxSprintDistance": 450.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_11-17cv.json
+++ b/RogueTech Core/tankmovement/movedef_11-17cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 385.0,
-    "MaxSprintDistance": 595.0,
+    "MaxWalkDistance": 330.0,
+    "MaxSprintDistance": 510.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_12-18cv.json
+++ b/RogueTech Core/tankmovement/movedef_12-18cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 420.0,
-    "MaxSprintDistance": 630.0,
+    "MaxWalkDistance": 360.0,
+    "MaxSprintDistance": 540.0,
     "WalkVelocity": 50.0,
     "RunVelocity": 58.0,
     "SprintVelocity": 61.0,

--- a/RogueTech Core/tankmovement/movedef_13-20cv.json
+++ b/RogueTech Core/tankmovement/movedef_13-20cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 455.0,
-    "MaxSprintDistance": 700.0,
+    "MaxWalkDistance": 390.0,
+    "MaxSprintDistance": 600.0,
     "WalkVelocity": 50.0,
     "RunVelocity": 58.0,
     "SprintVelocity": 61.0,

--- a/RogueTech Core/tankmovement/movedef_14-21cv.json
+++ b/RogueTech Core/tankmovement/movedef_14-21cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 490.0,
-    "MaxSprintDistance": 735.0,
+    "MaxWalkDistance": 420.0,
+    "MaxSprintDistance": 630.0,
     "WalkVelocity": 50.0,
     "RunVelocity": 58.0,
     "SprintVelocity": 61.0,

--- a/RogueTech Core/tankmovement/movedef_15-23cv.json
+++ b/RogueTech Core/tankmovement/movedef_15-23cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 525.0,
-    "MaxSprintDistance": 805.0,
+    "MaxWalkDistance": 450.0,
+    "MaxSprintDistance": 690.0,
     "WalkVelocity": 50.0,
     "RunVelocity": 58.0,
     "SprintVelocity": 61.0,

--- a/RogueTech Core/tankmovement/movedef_16-24cv.json
+++ b/RogueTech Core/tankmovement/movedef_16-24cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 525.0,
-    "MaxSprintDistance": 805.0,
+    "MaxWalkDistance": 480.0,
+    "MaxSprintDistance": 720.0,
     "WalkVelocity": 50.0,
     "RunVelocity": 58.0,
     "SprintVelocity": 61.0,

--- a/RogueTech Core/tankmovement/movedef_17-26cv.json
+++ b/RogueTech Core/tankmovement/movedef_17-26cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 595.0,
-    "MaxSprintDistance": 910.0,
+    "MaxWalkDistance": 510.0,
+    "MaxSprintDistance": 780.0,
     "WalkVelocity": 50.0,
     "RunVelocity": 58.0,
     "SprintVelocity": 61.0,

--- a/RogueTech Core/tankmovement/movedef_2-3cv.json
+++ b/RogueTech Core/tankmovement/movedef_2-3cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 70.0,
-    "MaxSprintDistance": 105.0,
+    "MaxWalkDistance": 60.0,
+    "MaxSprintDistance": 90.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_3-5cv.json
+++ b/RogueTech Core/tankmovement/movedef_3-5cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 105.0,
-    "MaxSprintDistance": 175.0,
+    "MaxWalkDistance": 90.0,
+    "MaxSprintDistance": 120.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_4-6cv.json
+++ b/RogueTech Core/tankmovement/movedef_4-6cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 140.0,
-    "MaxSprintDistance": 210.0,
+    "MaxWalkDistance": 120.0,
+    "MaxSprintDistance": 180.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_5-8cv.json
+++ b/RogueTech Core/tankmovement/movedef_5-8cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 175.0,
-    "MaxSprintDistance": 315.0,
+    "MaxWalkDistance": 150.0,
+    "MaxSprintDistance": 240.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_6-9cv.json
+++ b/RogueTech Core/tankmovement/movedef_6-9cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 210.0,
-    "MaxSprintDistance": 315.0,
+    "MaxWalkDistance": 180.0,
+    "MaxSprintDistance": 270.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_7-11cv.json
+++ b/RogueTech Core/tankmovement/movedef_7-11cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 245.0,
-    "MaxSprintDistance": 385.0,
+    "MaxWalkDistance": 210.0,
+    "MaxSprintDistance": 330.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_8-12cv.json
+++ b/RogueTech Core/tankmovement/movedef_8-12cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 280.0,
-    "MaxSprintDistance": 420.0,
+    "MaxWalkDistance": 240.0,
+    "MaxSprintDistance": 360.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,

--- a/RogueTech Core/tankmovement/movedef_9-14cv.json
+++ b/RogueTech Core/tankmovement/movedef_9-14cv.json
@@ -5,8 +5,8 @@
         "Details": "",
         "Icon": ""
     },
-    "MaxWalkDistance": 315.0,
-    "MaxSprintDistance": 490.0,
+    "MaxWalkDistance": 270.0,
+    "MaxSprintDistance": 420.0,
     "WalkVelocity": 40.0,
     "RunVelocity": 48.0,
     "SprintVelocity": 51.0,


### PR DESCRIPTION
From 35 to 30 meter hex basis. More closely matches intended movement based on testing with player controled tanks.