### PR TITLE
Extending Clan Scouts to 5 mechs per lance

### DIFF
--- a/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_1_simpleBattle.json
+++ b/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_1_simpleBattle.json
@@ -1,0 +1,29 @@
+{
+  "ID": "c_fp_clanscouts_1_simpleBattle",
+  "RandomSpawns": {
+    "Enable": false
+  },
+  "HotDropProtection": {
+    "Enable": true
+  },
+  "AdditionalLances": {
+    "Enable": false,
+    "EnemyLanceCount": 1,
+    "AllyLanceCount": 1
+  },
+  "ExtendedLances": {
+    "Enable": true,
+    "EnemyLanceSize": 5,
+    "AllyLanceSize": 6
+  },
+  "ExtendedBoundaries": {
+    "Enable": true,
+    "IncreaseBoundarySizeByPercentage": 0.5
+  },
+  "DynamicWithdraw": {
+    "Enable": true
+  },
+  "AdditionalPlayerMechs": {
+    "Enable": false
+  }
+}

--- a/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_2_captureBase.json
+++ b/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_2_captureBase.json
@@ -1,0 +1,29 @@
+{
+  "ID": "c_fp_clanscouts_2_captureBase",
+  "RandomSpawns": {
+    "Enable": false
+  },
+  "HotDropProtection": {
+    "Enable": true
+  },
+  "AdditionalLances": {
+    "Enable": false,
+    "EnemyLanceCount": 1,
+    "AllyLanceCount": 1
+  },
+  "ExtendedLances": {
+    "Enable": true,
+    "EnemyLanceSize": 5,
+    "AllyLanceSize": 6
+  },
+  "ExtendedBoundaries": {
+    "Enable": true,
+    "IncreaseBoundarySizeByPercentage": 0.5
+  },
+  "DynamicWithdraw": {
+    "Enable": true
+  },
+  "AdditionalPlayerMechs": {
+    "Enable": false
+  }
+}

--- a/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_a1_simpleBattle.json
+++ b/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_a1_simpleBattle.json
@@ -1,0 +1,29 @@
+{
+  "ID": "c_fp_clanscouts_a1_simpleBattle",
+  "RandomSpawns": {
+    "Enable": false
+  },
+  "HotDropProtection": {
+    "Enable": true
+  },
+  "AdditionalLances": {
+    "Enable": false,
+    "EnemyLanceCount": 1,
+    "AllyLanceCount": 1
+  },
+  "ExtendedLances": {
+    "Enable": false,
+    "EnemyLanceSize": 5,
+    "AllyLanceSize": 6
+  },
+  "ExtendedBoundaries": {
+    "Enable": true,
+    "IncreaseBoundarySizeByPercentage": 0.5
+  },
+  "DynamicWithdraw": {
+    "Enable": true
+  },
+  "AdditionalPlayerMechs": {
+    "Enable": false
+  }
+}

--- a/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_b1_simpleBattle.json
+++ b/MissionControl/config/Contracts/RogueFlashPointModule/contract/clanscouts/c_fp_clanscouts_b1_simpleBattle.json
@@ -1,0 +1,29 @@
+{
+  "ID": "c_fp_clanscouts_b1_simpleBattle",
+  "RandomSpawns": {
+    "Enable": false
+  },
+  "HotDropProtection": {
+    "Enable": true
+  },
+  "AdditionalLances": {
+    "Enable": true,
+    "EnemyLanceCount": 1,
+    "AllyLanceCount": 0
+  },
+  "ExtendedLances": {
+    "Enable": true,
+    "EnemyLanceSize": 5,
+    "AllyLanceSize": 6
+  },
+  "ExtendedBoundaries": {
+    "Enable": true,
+    "IncreaseBoundarySizeByPercentage": 0.5
+  },
+  "DynamicWithdraw": {
+    "Enable": true
+  },
+  "AdditionalPlayerMechs": {
+    "Enable": false
+  }
+}


### PR DESCRIPTION
Reduces lance difficutly by 2 but increases number of mechs by 1 per lance