### PR TITLE
Quicsell Turrets

### DIFF
--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_AntiAir_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_AntiAir_Quicsell.json
@@ -1,0 +1,217 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Assault_AntiAir_Quicsell",
+      "Name": "Hardened Anti-Air Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Assault_AntiAir_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_assault",
+         "mr-resize-0.75",
+         "steiner",
+         "marik",
+         "kurita",
+         "davion",
+         "liao",
+         "locals"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 480,
+   "CurrentInternalStructure": 250,
+   "AssignedArmor": 480,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Laser_LBXLargeLaser_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_PPC_LBXPPC_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_400",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	  {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "emod_engineslots_std_center",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_Command_Quicsell.json
@@ -1,0 +1,191 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Assault_Command_Quicsell",
+    "Name": "Hardened Command Bunker",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Assault_Command_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_assault",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 500,
+  "CurrentInternalStructure": 250,
+  "AssignedArmor": 500,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Gear_C3_Master",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_ProbeKing_Quicsell",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Aftermarket_EWS",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Cockpit_CommandConsole",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Weapon_REMOTE_SENSOR",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_FLARELAUNCHER5",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_FLARELAUNCHER_AMS",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_SRM_SRM10_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_AMS_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_MagPulse_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM10_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM10_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_AugmentedThunder_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Sensors_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Chaff_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Narc_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_400",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Aftermarket_Stealth",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_Gauss_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_Gauss_Quicsell.json
@@ -1,0 +1,120 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Assault_Gauss_Quicsell",
+    "Name": "Hardened Gauss Emplacement",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Assault_Gauss_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_assault",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 480,
+  "CurrentInternalStructure": 250,
+  "AssignedArmor": 480,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Gauss_Gauss_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Gauss_Gauss_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammunition_AC2_Precision",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammunition_AC2_Flak",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_400",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_LRM_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_LRM_Quicsell.json
@@ -1,0 +1,174 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Assault_LRM_Quicsell",
+      "Name": "Hardened Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Assault_LRM_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_assault",
+         "mr-resize-0.75",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 480,
+   "CurrentInternalStructure": 250,
+   "AssignedArmor": 480,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_SAM_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Ammo_AmmunitionBox_Swarmi_LRM",
+        "ComponentDefType": "AmmunitionBox",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_400",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	  {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_PointDefense_Quicsell.json
@@ -1,0 +1,259 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Assault_PointDefense_Quicsell",
+    "Name": "Hardened Point Defense",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Assault_PointDefense_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_assault",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 480,
+  "CurrentInternalStructure": 250,
+  "AssignedArmor": 480,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Aftermarket_EWS",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_400",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Assault",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_Quad_Quicsell.json
@@ -1,0 +1,173 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Assault_Quad_Quicsell",
+      "Name": "Hardened Quad Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Assault_Quad_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_assault",
+         "mr-resize-0.75",
+         "davion",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 480,
+   "CurrentInternalStructure": 250,
+   "AssignedArmor": 480,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+        "ComponentDefID": "Weapon_Double_Autocannon_5_Quicsell",
+        "ComponentDefType": "Weapon",
+        "HardpointSlot": 0,
+        "DamageLevel": "Functional",
+        "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+        "hasPrefabName": true
+      },
+      {
+        "ComponentDefID": "Weapon_Double_Autocannon_5_Quicsell",
+        "ComponentDefType": "Weapon",
+        "HardpointSlot": 0,
+        "DamageLevel": "Functional",
+        "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+        "hasPrefabName": true
+      },
+      {
+        "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+        "ComponentDefType": "Weapon",
+        "HardpointSlot": 0,
+        "DamageLevel": "Functional",
+        "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+        "hasPrefabName": true
+      },
+      {
+        "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+        "ComponentDefType": "Weapon",
+        "HardpointSlot": 0,
+        "DamageLevel": "Functional",
+        "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+        "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammunition_AC2_Precision",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammunition_AC2_Precision",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC5",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammunition_AC5_Precision",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammunition_AC5_Precision",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_400",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	   {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_Quicsell.json
@@ -1,0 +1,221 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Assault_Quicsell",
+      "Name": "Hardened Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Assault_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_assault",
+         "mr-resize-0.75",
+         "steiner",
+         "marik",
+         "kurita",
+         "davion",
+         "liao",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 480,
+   "CurrentInternalStructure": 250,
+   "AssignedArmor": 480,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Laser_LargeLaserREX_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_Laser_LargeLaserREX_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_400",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	  {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_Shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_Shredder_Quicsell.json
@@ -1,0 +1,149 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Assault_Shredder_Quicsell",
+      "Name": "Hardened Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Assault_Shredder_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_assault",
+         "mr-resize-0.75",
+         "steiner",
+         "marik",
+         "kurita",
+         "davion",
+         "liao",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 480,
+   "CurrentInternalStructure": 250,
+   "AssignedArmor": 480,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Double_Autocannon_20_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_Double_Autocannon_20_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Quicsell_AC20_double",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Quicsell_AC20_double",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_400",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	  {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Assault_Sniper_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Assault_Sniper_Quicsell.json
@@ -1,0 +1,169 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Assault_Sniper_Quicsell",
+      "Name": "Hardened Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Assault_Sniper_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_assault",
+         "mr-resize-0.75",
+         "steiner",
+         "marik",
+         "kurita",
+         "davion",
+         "liao",
+         "locals"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 480,
+   "CurrentInternalStructure": 250,
+   "AssignedArmor": 480,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+        "ComponentDefID": "Weapon_PPC_HEAVY_Quicsell",
+        "ComponentDefType": "Weapon",
+        "HardpointSlot": 3,
+        "DamageLevel": "Functional",
+        "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+        "hasPrefabName": true
+      },
+      {
+        "ComponentDefID": "Weapon_PPC_HEAVY_Quicsell",
+        "ComponentDefType": "Weapon",
+        "HardpointSlot": 3,
+        "DamageLevel": "Functional",
+        "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+        "hasPrefabName": true
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": -1,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_400",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	  {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Assault",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_AntiAir_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_AntiAir_Quicsell.json
@@ -1,0 +1,183 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Heavy_AntiAir_Quicsell",
+    "Name": "Heavy Anti-Air Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Heavy_AntiAir_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_heavy",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 360,
+  "CurrentInternalStructure": 200,
+  "AssignedArmor": 360,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_PPC_LBXPPC_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM10_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_SAM_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_ListenKill_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_Command_Quicsell.json
@@ -1,0 +1,183 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Heavy_Command_Quicsell",
+    "Name": "Heavy Command Bunker",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Heavy_Command_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_heavy",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 400,
+  "CurrentInternalStructure": 200,
+  "AssignedArmor": 400,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Gear_C3_Master",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_ProbeKing_Quicsell",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Aftermarket_EWS",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Cockpit_CommandConsole",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Weapon_REMOTE_SENSOR",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_FLARELAUNCHER_AMS",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_SRM_SRM10_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_AMS_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_MagPulse_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_AugmentedThunder_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Sensors_LRM_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Chaff_LRM_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Narc_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Aftermarket_Stealth",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_LRM_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_LRM_Quicsell.json
@@ -1,0 +1,164 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Heavy_LRM_Quicsell",
+    "Name": "Heavy LRM Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Heavy_lrm_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_heavy",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 400,
+  "CurrentInternalStructure": 200,
+  "AssignedArmor": 400,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_SAM_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Swarmi_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_Laser_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_Laser_Quicsell.json
@@ -1,0 +1,212 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Heavy_Laser_Quicsell",
+    "Name": "Heavy Laser Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Heavy_laser_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_heavy",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 320,
+  "CurrentInternalStructure": 200,
+  "AssignedArmor": 320,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_HeavyLargeLaser_Chemical_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Large",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Large",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Large",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_HeavyMediumLaser_Chemical_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_HeavySmallLaser_Chemical_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Small",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_PointDefense_Quicsell.json
@@ -1,0 +1,213 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Heavy_PointDefense_Quicsell",
+    "Name": "Heavy Point Defense",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Heavy_PointDefense_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_heavy",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 320,
+  "CurrentInternalStructure": 200,
+  "AssignedArmor": 320,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Aftermarket_EWS",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_Quad_Quicsell.json
@@ -1,0 +1,143 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Heavy_Quad_Quicsell",
+    "Name": "Heavy Quad Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Heavy_Quad_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_heavy",
+      "mr-resize-0.75",
+      "davion",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 400,
+  "CurrentInternalStructure": 200,
+  "AssignedArmor": 400,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Quicsell_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_Quicsell.json
@@ -1,0 +1,199 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Heavy_Quicsell",
+      "Name": "Heavy Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Heavy_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_heavy",
+         "mr-resize-0.75",
+         "steiner",
+         "marik",
+         "kurita",
+         "davion",
+         "liao",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 400,
+   "CurrentInternalStructure": 200,
+   "AssignedArmor": 400,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Laser_LargeLaserREX_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_Laser_MediumLaserREX_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_MachineGun_HEAVY_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+	   {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_300",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Heavy",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Heavy",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Heavy_Shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Heavy_Shredder_Quicsell.json
@@ -1,0 +1,219 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Heavy_Shredder_Quicsell",
+    "Name": "Heavy Shredder Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Heavy_shredder_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_heavy",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 400,
+  "CurrentInternalStructure": 200,
+  "AssignedArmor": 400,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_SRM_SRM4_STREAK_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Deadfire_SRM_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Heavy",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_Command_Quicsell.json
@@ -1,0 +1,109 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Light_Command_Quicsell",
+    "Name": "Light Command Bunker",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Light_Command_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_light",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 200,
+  "CurrentInternalStructure": 100,
+  "AssignedArmor": 200,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Gear_C3_Master",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_ProbeKing_Quicsell",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Aftermarket_EWS",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_FLARELAUNCHER5",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_MachineGun_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Aftermarket_Stealth",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_LRM_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_LRM_Quicsell.json
@@ -1,0 +1,130 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Light_LRM_Quicsell",
+    "Name": "Light LRM Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Light_lrm_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_light",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 200,
+  "CurrentInternalStructure": 100,
+  "AssignedArmor": 200,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Quicsell_LRM_double",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Swarm_LRM_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_Laser_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_Laser_Quicsell.json
@@ -1,0 +1,132 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Light_Laser_Quicsell",
+    "Name": "Light Laser Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Light_laser_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_light",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 160,
+  "CurrentInternalStructure": 100,
+  "AssignedArmor": 160,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_HeavyMediumLaser_Chemical_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_HeavySmallLaser_Chemical_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Small",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_PointDefense_Quicsell.json
@@ -1,0 +1,115 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Light_PointDefense_Quicsell",
+    "Name": "Light Point Defense",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Light_PointDefense_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_light",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 160,
+  "CurrentInternalStructure": 100,
+  "AssignedArmor": 160,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_Quad_Quicsell.json
@@ -1,0 +1,119 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Light_Quad_Quicsell",
+    "Name": "Light Quad Gun",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Light_Quad_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_light",
+      "mr-resize-0.75",
+      "davion",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 200,
+  "CurrentInternalStructure": 100,
+  "AssignedArmor": 200,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_MachineGun_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_MachineGun_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_MachineGun_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Quicsell_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_Quicsell.json
@@ -1,0 +1,123 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Light_Quicsell",
+      "Name": "Light Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Light_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_light",
+         "mr-resize-0.75",
+         "steiner",
+         "marik",
+         "kurita",
+         "davion",
+         "liao",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 200,
+   "CurrentInternalStructure": 100,
+   "AssignedArmor": 200,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Laser_MediumLaserREX_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_100",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Light",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Light",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_Shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_Shredder_Quicsell.json
@@ -1,0 +1,139 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Light_Shredder_Quicsell",
+    "Name": "Light Shredder Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Light_shredder_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_light",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 160,
+  "CurrentInternalStructure": 100,
+  "AssignedArmor": 160,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_MachineGun_HEAVY_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Light_Sniper_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Light_Sniper_Quicsell.json
@@ -1,0 +1,100 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Light_Sniper_Quicsell",
+    "Name": "Light Sniper Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Light_sniper_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_light",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 80,
+  "CurrentInternalStructure": 100,
+  "AssignedArmor": 80,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Double_Autocannon_5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Precision_AC5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Quicsell_AC5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Light",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_AntiAir_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_AntiAir_Quicsell.json
@@ -1,0 +1,159 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_AntiAir_Quicsell",
+    "Name": "Anti-Air Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_AntiAir_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 280,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 280,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_LBXLargeLaser_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM5_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_SAM_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_ListenKill_LRM_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_Command_Quicsell.json
@@ -1,0 +1,131 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_Command_Quicsell",
+    "Name": "Command Bunker",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_Command_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 300,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 300,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Gear_C3_Master",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_ProbeKing_Quicsell",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Aftermarket_EWS",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Cockpit_CommandConsole",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Weapon_REMOTE_SENSOR",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_FLARELAUNCHER_AMS",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_FLARELAUNCHER5",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Aftermarket_Stealth",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_Gauss_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_Gauss_Quicsell.json
@@ -1,0 +1,100 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_Gauss_Quicsell",
+    "Name": "Gauss Emplacement",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_Gauss_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 240,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 240,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Gauss_Gauss_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_LRM_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_LRM_Quicsell.json
@@ -1,0 +1,138 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_LRM_Quicsell",
+    "Name": "Standard LRM Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_LRM_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 280,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 280,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_LRM_LRM20_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunder_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_SAM_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Swarmi_LRM_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_Laser_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_Laser_Quicsell.json
@@ -1,0 +1,154 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_Laser_Quicsell",
+    "Name": "Light Standard Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_laser_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 240,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 240,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_HeavyLargeLaser_Chemical_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Large",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Large",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_PointDefense_Quicsell.json
@@ -1,0 +1,161 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_PointDefense_Quicsell",
+    "Name": "Point Defense",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_PointDefense_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 300,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 300,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_AMS_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_Quad_Quicsell.json
@@ -1,0 +1,119 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Standard_Quad_Quicsell",
+      "Name": "Standard Quad Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Standard_Quad_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_medium",
+         "mr-resize-0.75",
+         "davion",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 200,
+   "CurrentInternalStructure": 150,
+   "AssignedArmor": 200,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Weapon_Double_Autocannon_2_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 0,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+        "ComponentDefID": "Weapon_MachineGun_LIGHT_Quicsell",
+        "ComponentDefType": "Weapon",
+        "HardpointSlot": 0,
+        "DamageLevel": "Functional",
+        "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+        "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Ammo_AmmunitionBox_Quicsell_AC2_double",
+         "ComponentDefType": "AmmunitionBox",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_200",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	  {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Standard",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Standard",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_Quicsell.json
@@ -1,0 +1,153 @@
+{
+   "Version": 1,
+   "Description": {
+      "Id": "turretdef_Standard_Quicsell",
+      "Name": "Standard Turret",
+      "Details": "",
+      "Icon": "",
+      "Cost": 993,
+      "Rarity": 0,
+      "Purchasable": false
+   },
+   "ChassisID": "turretchassisdef_Standard_Quicsell",
+   "TurretTags": {
+      "items": [
+         "unit_turret",
+         "unit_medium",
+         "mr-resize-0.75",
+         "steiner",
+         "marik",
+         "kurita",
+         "davion",
+         "liao",
+         "locals",
+         "magistracyofcanopus",
+         "marian",
+         "taurianconcordat",
+         "outworld",
+         "oberon",
+         "castile",
+         "valkyrate",
+         "tortuga",
+         "circinus",
+         "illyrian",
+         "lothian",
+         "elysia",
+         "jarnfolk",
+         "hanse",
+         "aurigandirectorate",
+         "auriganrestoration"
+      ],
+      "tagSetSourceFile": ""
+   },
+   "CurrentArmor": 240,
+   "CurrentInternalStructure": 150,
+   "AssignedArmor": 240,
+   "DamageLevel": "Functional",
+   "inventory": [
+      {
+         "ComponentDefID": "Weapon_Laser_LargeLaserREX_Quicsell",
+         "ComponentDefType": "Weapon",
+         "HardpointSlot": 3,
+         "DamageLevel": "Functional",
+         "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+         "hasPrefabName": true
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": -1,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Gear_Engine_200",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+	   {
+         "ComponentDefID": "Turret_Coolant_System",
+         "ComponentDefType": "HeatSink",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+        "ComponentDefID": "emod_engineslots_std_center",
+        "ComponentDefType": "HeatSink",
+        "HardpointSlot": 2,
+        "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Tank_CrewBunker_Standard",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Turret_Systems_Standard",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+      },
+      {
+         "ComponentDefID": "Special_Stable_Weapons",
+         "ComponentDefType": "Upgrade",
+         "HardpointSlot": 2,
+         "DamageLevel": "Functional"
+     }
+   ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_Shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_Shredder_Quicsell.json
@@ -1,0 +1,165 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_Shredder_Quicsell",
+    "Name": "Standard Shredder Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_shredder_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals",
+      "magistracyofcanopus",
+      "marian",
+      "taurianconcordat",
+      "outworld",
+      "oberon",
+      "castile",
+      "valkyrate",
+      "tortuga",
+      "circinus",
+      "illyrian",
+      "lothian",
+      "elysia",
+      "jarnfolk",
+      "hanse",
+      "aurigandirectorate",
+      "auriganrestoration"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 240,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 240,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_Laser_SmallLaserREX_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Weapon_SRM_SRM4_STREAK_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Ammo_AmmunitionBox_Inferno_SRM_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/Turret/turretdef_Standard_Sniper_Quicsell.json
+++ b/Quicsell Module/Turrets/Turret/turretdef_Standard_Sniper_Quicsell.json
@@ -1,0 +1,119 @@
+{
+  "Version": 1,
+  "Description": {
+    "Id": "turretdef_Standard_Sniper_Quicsell",
+    "Name": "Sniper Turret",
+    "Details": "",
+    "Icon": "",
+    "Cost": 993,
+    "Rarity": 0,
+    "Purchasable": false
+  },
+  "ChassisID": "turretchassisdef_Standard_sniper_Quicsell",
+  "TurretTags": {
+    "items": [
+      "unit_turret",
+      "unit_medium",
+      "mr-resize-0.75",
+      "steiner",
+      "marik",
+      "kurita",
+      "davion",
+      "liao",
+      "locals"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "CurrentArmor": 240,
+  "CurrentInternalStructure": 150,
+  "AssignedArmor": 240,
+  "DamageLevel": "Functional",
+  "inventory": [
+    {
+      "ComponentDefID": "Weapon_PPC_HEAVY_Quicsell",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "DamageLevel": "Functional",
+      "prefabName": "chrPrfWeap_apc_turret_generic_eh1",
+      "hasPrefabName": true
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Gear_Engine_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Turret_Systems_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Tank_CrewBunker_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    },
+    {
+      "ComponentDefID": "Special_Stable_Weapons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 2,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_AntiAir_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_AntiAir_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_AntiAir_Quicsell",
+		"Name": "Hardened AA Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Command_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_Command_Quicsell",
+		"Name": "Hardened Command Bunker",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Gauss_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Gauss_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_Gauss_Quicsell",
+		"Name": "Hardened Gauss Emplacement",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_gaussturret",
+	"PrefabIdentifier": "chrprftrt_gaussturret",
+	"PrefabBase": "gaussturret",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_LRM_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_LRM_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_LRM_Quicsell",
+		"Name": "Hardened Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_PointDefense_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_PointDefense_Quicsell",
+		"Name": "Hardened Point Defenses",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_ams2turret",
+	"PrefabIdentifier": "chrprftrt_ams2turret",
+	"PrefabBase": "ams2turret",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Quad_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_Quad_Quicsell",
+		"Name": "Hardened Quad Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_Quicsell",
+		"Name": "Hardened Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Shredder_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_Shredder_Quicsell",
+		"Name": "Hardened Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Sniper_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Assault_Sniper_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Assault_Sniper_Quicsell",
+		"Name": "Hardened Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "ASSAULT",
+	"Tonnage": 100,
+	"InventorySlots": 20,
+	"MaxArmor": 500,
+	"MaxInternalStructure": 250,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_AntiAir_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_AntiAir_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_AntiAir_Quicsell",
+		"Name": "Heavy AA Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_Command_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_Command_Quicsell", 
+		"Name": "Heavy Command Bunker",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_PointDefense_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_PointDefense_Quicsell",
+		"Name": "Heavy Point Defense",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_ams1turret",
+	"PrefabIdentifier": "chrprftrt_ams1turret",
+	"PrefabBase": "ams1turret",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_Quad_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_Quad_Quicsell",
+		"Name": "Heavy Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_Quicsell",
+		"Name": "Heavy Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavysniper",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavySniper",
+	"PrefabBase": "turretHeavySniper",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_laser_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_laser_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_laser_Quicsell",
+		"Name": "Heavy Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavylaser",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavyLaser",
+	"PrefabBase": "turretHeavyLaser",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_lrm_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_lrm_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_lrm_Quicsell",
+		"Name": "Heavy Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavylrm",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavyLRM",
+	"PrefabBase": "turretHeavyLRM",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Heavy_shredder_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Heavy_shredder_Quicsell",
+		"Name": "Heavy Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretheavyshredder",
+	"PrefabIdentifier": "chrPrfTrt_turretHeavyShredder",
+	"PrefabBase": "turretHeavyShredder",
+	"weightClass": "HEAVY",
+	"Tonnage": 75,
+	"InventorySlots": 20,
+	"MaxArmor": 400,
+	"MaxInternalStructure": 200,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 4,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -3
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 3
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_Command_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_Command_Quicsell",
+		"Name": "Light Command Bunker",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlightlaser",
+	"PrefabIdentifier": "chrPrfTrt_turretLightLaser",
+	"PrefabBase": "turretLightLaser",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_PointDefense_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_PointDefense_Quicsell",
+		"Name": "Light Point Defense",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_mgturret",
+	"PrefabIdentifier": "chrprftrt_mgturret",
+	"PrefabBase": "mgturret",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_Quad_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_Quad_Quicsell",
+		"Name": "Light Quad Gun",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_quadturret",
+	"PrefabIdentifier": "chrprftrt_quadturret",
+	"PrefabBase": "quadturret",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_Quicsell",
+		"Name": "Light Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlightlaser",
+	"PrefabIdentifier": "chrPrfTrt_turretLightLaser",
+	"PrefabBase": "turretLightLaser",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_laser_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_laser_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_laser_Quicsell",
+		"Name": "Light Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlightlaser",
+	"PrefabIdentifier": "chrPrfTrt_turretLightLaser",
+	"PrefabBase": "turretLightLaser",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_lrm_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_lrm_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_lrm_Quicsell",
+		"Name": "Light Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlightlrm",
+	"PrefabIdentifier": "chrPrfTrt_turretLightLRM",
+	"PrefabBase": "turretLightLRM",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_shredder_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_shredder_Quicsell",
+		"Name": "Light Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlightshredder",
+	"PrefabIdentifier": "chrPrfTrt_turretLightShredder",
+	"PrefabBase": "turretLightShredder",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_sniper_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Light_sniper_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Light_sniper_Quicsell",
+		"Name": "Light Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlightsniper",
+	"PrefabIdentifier": "chrPrfTrt_turretLightSniper",
+	"PrefabBase": "turretLightSniper",
+	"weightClass": "LIGHT",
+	"Tonnage": 35,
+	"InventorySlots": 20,
+	"MaxArmor": 200,
+	"MaxInternalStructure": 100,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 8,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": -2
+		},
+		{
+			"x": 0,
+			"y": 8,
+			"z": 2
+		},
+		{
+			"x": 0.0,
+			"y": 4,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_AntiAir_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_AntiAir_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_AntiAir_Quicsell",
+		"Name": "Standard AA Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretsniper",
+	"PrefabIdentifier": "chrPrfTrt_turretsniper",
+	"PrefabBase": "turretsniper",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Command_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Command_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_Command_Quicsell",  
+		"Name": "Standard Command Bunker",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretsniper",
+	"PrefabIdentifier": "chrPrfTrt_turretsniper",
+	"PrefabBase": "turretsniper",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Gauss_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Gauss_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_Gauss_Quicsell",
+		"Name": "Gauss Emplacement",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_gaussturret",
+	"PrefabIdentifier": "chrprftrt_gaussturret",
+	"PrefabBase": "gaussturret",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_LRM_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_LRM_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_LRM_Quicsell",
+		"Name": "Standard Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlrm",
+	"PrefabIdentifier": "chrPrfTrt_turretlrm",
+	"PrefabBase": "turretlrm",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_PointDefense_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_PointDefense_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_PointDefense_Quicsell",
+		"Name": "Standard Point Defense",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_ams1turret",
+	"PrefabIdentifier": "chrprftrt_ams1turret",
+	"PrefabBase": "ams1turret",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Quad_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Quad_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_Quad_Quicsell",
+		"Name": "Standard Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretsniper",
+	"PrefabIdentifier": "chrPrfTrt_turretsniper",
+	"PrefabBase": "turretsniper",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_Quicsell",
+		"Name": "Standard Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretsniper",
+	"PrefabIdentifier": "chrPrfTrt_turretsniper",
+	"PrefabBase": "turretsniper",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_laser_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_laser_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_laser_Quicsell",
+		"Name": "Standard Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretlaser",
+	"PrefabIdentifier": "chrPrfTrt_turretlaser",
+	"PrefabBase": "turretlaser",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_shredder_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_shredder_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_shredder_Quicsell",
+		"Name": "Standard Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretshredder",
+	"PrefabIdentifier": "chrPrfTrt_turretshredder",
+	"PrefabBase": "turretshredder",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_sniper_Quicsell.json
+++ b/Quicsell Module/Turrets/TurretChassis/turretchassisdef_Standard_sniper_Quicsell.json
@@ -1,0 +1,157 @@
+{
+	"Description": {
+		"Id": "turretchassisdef_Standard_sniper_Quicsell",
+		"Name": "Standard Turret Chassis",
+		"Details": "",
+		"Icon": "TURRET",
+		"Cost": 993,
+		"Rarity": 0,
+		"Purchasable": false
+	},
+	"MovementCapDefID": "",
+	"PathingCapDefID": "",
+	"HardpointDataDefID": "hardpointdatadef_turretsniper",
+	"PrefabIdentifier": "chrPrfTrt_turretsniper",
+	"PrefabBase": "turretsniper",
+	"weightClass": "MEDIUM",
+	"Tonnage": 55,
+	"InventorySlots": 20,
+	"MaxArmor": 300,
+	"MaxInternalStructure": 150,
+	"BattleValue": 100,
+	"SpotterDistanceMultiplier": 1,
+	"VisibilityMultiplier": 1,
+	"SensorRangeMultiplier": 1,
+	"Signature": 0,
+	"Radius": 4,
+	"FiringArcDegrees": 360,
+	"Hardpoints": [
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Energy",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Ballistic",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "Missile",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		},
+		{
+			"WeaponMount": "AntiPersonnel",
+			"Omni": false
+		}
+	],
+	"LOSSourcePositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		}
+	],
+	"LOSTargetPositions": [
+		{
+			"x": -2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 2,
+			"y": 9,
+			"z": 0
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": -2.5
+		},
+		{
+			"x": 0,
+			"y": 9,
+			"z": 2.5
+		},
+		{
+			"x": 0.0,
+			"y": 4.5,
+			"z": 0
+		}
+	]
+}

--- a/Quicsell Module/mod.json
+++ b/Quicsell Module/mod.json
@@ -77,6 +77,14 @@
 			"Type": "ItemCollectionDef",
 			"Path": "Shop",
 			"ShouldAppendText": true
-		}
+		},
+		{
+            "Type": "TurretChassisDef",
+            "Path": "Turrets/TurretChassis"
+        },
+        {
+            "Type": "TurretDef",
+            "Path": "Turrets/Turret"
+        }
 ]
 }


### PR DESCRIPTION
Added new turrets, split between higher tech (House and locals tags) and lower tech (periphery and locals tags).