### PR TITLE
Added 9 new Adder mech variants and made modifications to 5 existing …

### DIFF
--- a/Base 3061/chassis/chassisdef_adder_ADR-E.json
+++ b/Base 3061/chassis/chassisdef_adder_ADR-E.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-E",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The E configuration has two ATM-9 launchers which can fire ammunition specialized for long, medium, and short ranges. For close combat, the 'Mech has an additional four Micro Pulse Lasers.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-E",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The E configuration has two ATM-9 launchers which can fire ammunition specialized for long, medium, and short ranges. For close combat, the 'Mech has an additional four Micro Pulse Lasers.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Base 3061/chassis/chassisdef_adder_ADR-H.json
+++ b/Base 3061/chassis/chassisdef_adder_ADR-H.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-H",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The only true brawling configuration of the Adder, the Adder H has two highly destructive Heavy Large Lasers as its primary weapons backed up only by the fixed Flamer. To help dissipate the 'Mech's heat, it has six additional double heat sinks.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-H",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Brawler",
+  "YangsThoughts": "The only true brawling configuration of the Adder, the Adder H has two highly destructive Heavy Large Lasers as its primary weapons backed up only by the fixed Flamer. To help dissipate the 'Mech's heat, it has six additional double heat sinks.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Base 3061/chassis/chassisdef_adder_ADR-Prime.json
+++ b/Base 3061/chassis/chassisdef_adder_ADR-Prime.json
@@ -101,7 +101,7 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
+  "StockRole": "Sniper",
   "YangsThoughts": "Khan Marthe Pryde decided to upgrade the 'Mechs her Clan fielded. Rather than waste precious resources designing a new OmniMech from the ground up, she instructed her scientists to improve upon existing designs. The design the scientists chose to modify was the Adder. Though the two 'Mechs are visually similar and share the same weight, the Cougar is slower and better armed. ",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",

--- a/Base 3061/mech/mechdef_adder_ADR-A.json
+++ b/Base 3061/mech/mechdef_adder_ADR-A.json
@@ -159,15 +159,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -177,6 +168,42 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_hand",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -195,16 +222,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/Base 3061/mech/mechdef_adder_ADR-B.json
+++ b/Base 3061/mech/mechdef_adder_ADR-B.json
@@ -176,15 +176,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -195,6 +186,24 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/Base 3061/mech/mechdef_adder_ADR-D.json
+++ b/Base 3061/mech/mechdef_adder_ADR-D.json
@@ -134,7 +134,7 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -166,15 +166,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -185,6 +176,24 @@
     {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/Base 3061/mech/mechdef_adder_ADR-E.json
+++ b/Base 3061/mech/mechdef_adder_ADR-E.json
@@ -7,11 +7,11 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
       "unit_littlefriend",
+	  "unit_indirectfire",
       "Republic",
       "clansgeneric",
       "clanbloodspirit",
@@ -35,17 +35,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-E",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-E",
+    "Id": "mechdef_adder_ADR-E",
+    "Name": "Adder ADR-E",
+    "Details": "The E configuration has two ATM-9 launchers which can fire ammunition specialized for long, medium, and short ranges. For close combat, the 'Mech has an additional four Micro Pulse Lasers.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +135,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -303,7 +319,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_LRM_ATM9_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -311,73 +327,73 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_ATM9_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_ER_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_HE_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },

--- a/Base 3061/mech/mechdef_adder_ADR-H.json
+++ b/Base 3061/mech/mechdef_adder_ADR-H.json
@@ -7,10 +7,9 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
-      "unit_role_sniper",
+      "unit_role_brawler",
       "unit_littlefriend",
       "Republic",
       "clansgeneric",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-H",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-H",
+    "Id": "mechdef_adder_ADR-H",
+    "Name": "Adder ADR-H",
+    "Details": "The only true brawling configuration of the Adder, the Adder H has two highly destructive Heavy Large Lasers as its primary weapons backed up only by the fixed Flamer. To help dissipate the 'Mech's heat, it has six additional double heat sinks.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +134,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,6 +173,62 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_LongRange",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -177,19 +248,9 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -213,19 +274,17 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -303,97 +362,17 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_HeavyLargeLaser_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_HeavyLargeLaser_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Base 3061/mech/mechdef_adder_ADR-Prime.json
+++ b/Base 3061/mech/mechdef_adder_ADR-Prime.json
@@ -157,7 +157,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Crit",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -165,7 +165,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_MultiTrack",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -173,7 +173,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -329,7 +329,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Base Unique 3061/chassis/chassisdef_adder_ADR-CN.json
+++ b/Base Unique 3061/chassis/chassisdef_adder_ADR-CN.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-CN",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "Reportedly piloted by Dirk Radick, the Adder Hero 'Mech, the Cinder mounts an ER Large Laser in each arm supported by a Machine Gun in each side torso complimented by the head mounted Flamer. Carrying two and half tons of machine gun rounds, five extra Double Heat Sinks maintain a high rate of laser fire.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-CN",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "TReportedly piloted by Dirk Radick, the Adder Hero 'Mech, the Cinder mounts an ER Large Laser in each arm supported by a Machine Gun in each side torso complimented by the head mounted Flamer. Carrying two and half tons of machine gun rounds, five extra Double Heat Sinks maintain a high rate of laser fire.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Base Unique 3061/mech/mechdef_adder_ADR-CN.json
+++ b/Base Unique 3061/mech/mechdef_adder_ADR-CN.json
@@ -7,45 +7,28 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
       "unit_littlefriend",
-      "Republic",
-      "clansgeneric",
-      "clanbloodspirit",
-      "clanwolf",
-      "clanfiremandrill",
-      "clanstaradder",
-      "clancoyote",
-      "clanjadefalcon",
-      "clansteelviper",
-      "clanicehellion",
-      "clangoliathscorpion",
-      "clandiamondshark",
-      "clanhellshorses",
-      "clansnowraven",
-      "clanghostbear",
-      "clansmokejaguar",
-      "clancloudcobra",
-      "clannovacat",
-      "clanburrock",
-      "society"
+	  "unit_legendary",
+	  "unit_hero",
+	  "unit_totem",
+      "clanwolf"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-CN",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-CN",
+    "Id": "mechdef_adder_ADR-CN",
+    "Name": "Adder ADR-CN",
+    "Details": "Reportedly piloted by Dirk Radick, the Adder Hero 'Mech, the Cinder mounts an ER Large Laser in each arm supported by a Machine Gun in each side torso complimented by the head mounted Flamer. Carrying two and half tons of machine gun rounds, five extra Double Heat Sinks maintain a high rate of laser fire.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +109,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +119,84 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,38 +219,26 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -213,19 +262,9 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -303,7 +342,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -311,7 +350,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -319,81 +358,41 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
-    },
+    }
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserER_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/DarkAge/chassis/chassisdef_adder_ADR-I.json
+++ b/DarkAge/chassis/chassisdef_adder_ADR-I.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-I",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The Adder I config carries an Improved Heavy Medium Laser and twin ER Medium Lasers. An SRM-6 and a ton of ammunition is mounted in each side torso. To handle the heavy heat load, four extra heat sinks are installed, two in each arm.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-I",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Striker",
+  "YangsThoughts": "The Adder I config carries an Improved Heavy Medium Laser and twin ER Medium Lasers. An SRM-6 and a ton of ammunition is mounted in each side torso. To handle the heavy heat load, four extra heat sinks are installed, two in each arm.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/DarkAge/chassis/chassisdef_adder_ADR-L.json
+++ b/DarkAge/chassis/chassisdef_adder_ADR-L.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-L",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The L configuration is apparently a light striker variant. Each arm carries a pair of Streak LRM-5s and a ton of ammunition. The side torsos carry a single ER Medium Laser, while an ECM Suite provides electronic warfare support. For additional movement, six jump jets are installed for a 180 meter jump range.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-L",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Striker",
+  "YangsThoughts": "The L configuration is apparently a light striker variant. Each arm carries a pair of Streak LRM-5s and a ton of ammunition. The side torsos carry a single ER Medium Laser, while an ECM Suite provides electronic warfare support. For additional movement, six jump jets are installed for a 180 meter jump range.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/DarkAge/chassis/chassisdef_adder_ADR-T.json
+++ b/DarkAge/chassis/chassisdef_adder_ADR-T.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-T",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The T configuration carries an ER PPC with a PPC Capacitor in each arm. An extra double heat sink is in the left and right torso, but to handle heavy heat loads the right torso carries a triple Coolant Pod.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-T",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The T configuration carries an ER PPC with a PPC Capacitor in each arm. An extra double heat sink is in the left and right torso, but to handle heavy heat loads the right torso carries a triple Coolant Pod.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/DarkAge/mech/mechdef_adder_ADR-I.json
+++ b/DarkAge/mech/mechdef_adder_ADR-I.json
@@ -7,10 +7,9 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
-      "unit_role_sniper",
+      "unit_role_brawler",
       "unit_littlefriend",
       "Republic",
       "clansgeneric",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-I",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-I",
+    "Id": "mechdef_adder_ADR-I",
+    "Name": "Adder ADR-I",
+    "Details": "The Adder I config carries an Improved Heavy Medium Laser and twin ER Medium Lasers. An SRM-6 and a ton of ammunition is mounted in each side torso. To handle the heavy heat load, four extra heat sinks are installed, two in each arm.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +134,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,6 +173,30 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -177,19 +216,17 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -213,19 +250,17 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -303,99 +338,83 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_ImprovedHeavyMediumLaser_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
+      "ComponentDefID": "Weapon_Laser_ImprovedHeavyMediumLaser_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
-    }
+    }	
   ]
 }

--- a/DarkAge/mech/mechdef_adder_ADR-L.json
+++ b/DarkAge/mech/mechdef_adder_ADR-L.json
@@ -7,11 +7,11 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
       "unit_littlefriend",
+	  "unit_jumpOK",
       "Republic",
       "clansgeneric",
       "clanbloodspirit",
@@ -35,17 +35,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-L",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-L",
+    "Id": "mechdef_adder_ADR-L",
+    "Name": "Adder ADR-L",
+    "Details": "The L configuration is apparently a light striker variant. Each arm carries a pair of Streak LRM-5s and a ton of ammunition. The side torsos carry a single ER Medium Laser, while an ECM Suite provides electronic warfare support. For additional movement, six jump jets are installed for a 180 meter jump range.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +126,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +136,92 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,7 +244,47 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Guardian_ECM_CLAN",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -167,62 +293,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,97 +375,65 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Streak_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Streak_LRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/DarkAge/mech/mechdef_adder_ADR-T.json
+++ b/DarkAge/mech/mechdef_adder_ADR-T.json
@@ -7,7 +7,6 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-T",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-T",
+    "Id": "mechdef_adder_ADR-T",
+    "Name": "Adder ADR-T",
+    "Details": "The T configuration carries an ER PPC with a PPC Capacitor in each arm. An extra double heat sink is in the left and right torso, but to handle heavy heat loads the right torso carries a triple Coolant Pod.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +125,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +135,85 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_PPC_Capacitator",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,38 +236,26 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Coolantpod_Clan_X3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -205,24 +271,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,97 +351,17 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Jihad 3068-3080/chassis/chassisdef_adder_ADR-J.json
+++ b/Jihad 3068-3080/chassis/chassisdef_adder_ADR-J.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-J",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The Adder J carries the new Hyper Assault Gauss 20 as its primary weapon, giving it a powerful punch. This is backed up by four Anti-Personnel Gauss Rifles, which are capable of decimating infantry.[1][16] This variant was first observed being used by forces from Clan Hell's Horses in action on Paulus Prime.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-J",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The Adder J carries the new Hyper Assault Gauss 20 as its primary weapon, giving it a powerful punch. This is backed up by four Anti-Personnel Gauss Rifles, which are capable of decimating infantry.[1][16] This variant was first observed being used by forces from Clan Hell's Horses in action on Paulus Prime.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",
@@ -162,7 +162,23 @@
         {
           "WeaponMount": "AntiPersonnel",
           "Omni": true
-        }
+        },
+		{
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
       ],
       "Tonnage": 0,
       "InventorySlots": 12,

--- a/Jihad 3068-3080/mech/mechdef_adder_ADR-J.json
+++ b/Jihad 3068-3080/mech/mechdef_adder_ADR-J.json
@@ -7,10 +7,9 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
-      "unit_role_sniper",
+      "unit_role_brawler",
       "unit_littlefriend",
       "Republic",
       "clansgeneric",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-J",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-J",
+    "Id": "mechdef_adder_ADR-J",
+    "Name": "Adder ADR-J",
+    "Details": "The Adder J carries the new Hyper Assault Gauss 20 as its primary weapon, giving it a powerful punch. This is backed up by four Anti-Personnel Gauss Rifles, which are capable of decimating infantry.[1][16] This variant was first observed being used by forces from Clan Hell's Horses in action on Paulus Prime.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +134,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,6 +173,22 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -176,24 +207,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -205,24 +218,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,31 +298,15 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
@@ -335,65 +314,33 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 2,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Gauss_HAG20_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Hyper_GAUSS_double",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Republic 3081-3130/chassis/chassisdef_adder_ADR-K.json
+++ b/Republic 3081-3130/chassis/chassisdef_adder_ADR-K.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-K",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The K config is equipped with a Rotary AC/2 and ton of ammunition in the right arm while the left arm carries a single ER Large Pulse Laser. Additional protection comes from a Laser Anti-Missile System.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-K",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The K config is equipped with a Rotary AC/2 and ton of ammunition in the right arm while the left arm carries a single ER Large Pulse Laser. Additional protection comes from a Laser Anti-Missile System.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Republic 3081-3130/mech/mechdef_adder_ADR-K.json
+++ b/Republic 3081-3130/mech/mechdef_adder_ADR-K.json
@@ -7,7 +7,6 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-K",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-K",
+    "Id": "mechdef_adder_ADR-K",
+    "Name": "Adder ADR-K",
+    "Details": "The K config is equipped with a Rotary AC/2 and ton of ammunition in the right arm while the left arm carries a single ER Large Pulse Laser. Additional protection comes from a Laser Anti-Missile System.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +125,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +135,68 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,38 +219,10 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -205,24 +238,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,15 +318,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserERPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -319,81 +326,25 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
+      "ComponentDefID": "Weapon_Laser_AMS_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Rotary_Autocannon_2_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_Rotary_AC2",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }


### PR DESCRIPTION
…variants

Adder-Prime - Shuffled BCs to RT and moved one heatsink from RT to LT as this was backwards compared to record sheet.
Adder-A - Added omnipod hand actuator to both arms per record sheet
Adder-B - Added omnipod hand to RA per record sheet
Adder-C - Minor typo fix in description, added omnipod hands to both arms per record sheet.
Adder-D - Added omnipod hand actuator to left arm and removed FCS TC per record sheet
Adder-E- New
Adder-H - New
Adder-I - New
Adder-J - New
Adder-K - New
Adder-L - New
Adder-T - New
Adder-CN Cinder - New