### PR TITLE
Event edits

### DIFF
--- a/RogueModulePilots/events/event_co_HastyExit.json
+++ b/RogueModulePilots/events/event_co_HastyExit.json
@@ -18,8 +18,8 @@
         "ExclusionTags": {
             "tagSetSourceFile": "Tags/CompanyTags",
             "items": [
-                "event_co_HastyExit1",
-                "event_co_HastyExit1a"
+                "event_co_HastyExit_nohire",
+                "event_co_HastyExit_Hired"
             ]
         },
         "RequirementComparisons": [
@@ -80,7 +80,7 @@
                             "AddedTags": {
                                 "tagSetSourceFile": "Tags/CompanyTags",
                                 "items": [
-                                    "event_co_HastyExit1"
+                                    "event_co_HastyExit_nohire"
                                 ]
                             },
                             "RemovedTags": {
@@ -133,7 +133,7 @@
                             "AddedTags": {
                                 "tagSetSourceFile": "",
                                 "items": [
-                                    "event_co_HastyExit1a"
+                                    "event_co_HastyExit_Hired"
                                 ]
                             },
                             "RemovedTags": {

--- a/RogueModulePilots/events/event_mw_Magpie_Stash.json
+++ b/RogueModulePilots/events/event_mw_Magpie_Stash.json
@@ -26,13 +26,13 @@
             "Scope": "Company",
             "RequirementTags": {
                 "tagSetSourceFile": "",
-                "items": []
+                "items": [
+                    "event_co_HastyExit_Hired"
+                ]
             },
             "ExclusionTags": {
                 "tagSetSourceFile": "",
-                "items": [
-                    "event_co_HastyExit1c"
-                ]
+                "items": []
             },
             "RequirementComparisons": []
         },
@@ -49,89 +49,26 @@
             "RequirementComparisons": []
         }
     ],
-    "AdditionalObjects": [
-        {
-            "Scope": "SecondaryMechWarrior",
-            "Requirements": {
-                "Scope": "SecondaryMechWarrior",
-                "RequirementTags": {
-                    "tagSetSourceFile": "",
-                    "items": []
-                },
-                "ExclusionTags": {
-                    "tagSetSourceFile": "Tags/PilotTags",
-                    "items": []
-                },
-                "RequirementComparisons": []
-            }
-        }
-    ],
+    "AdditionalObjects": [],
     "Options": [
         {
             "Description": {
                 "Id": "outcome_0",
                 "Name": "Open the pod.",
-                "Details": "Open the pod",
-                "Icon": null
+                "Details": "Order the pod opened",
+                "Icon": ""
             },
-            "RequirementList": [
-                {
-                    "Scope": "Company",
-                    "RequirementTags": {
-                        "tagSetSourceFile": "",
-                        "items": []
-                    },
-                    "ExclusionTags": {
-                        "tagSetSourceFile": "",
-                        "items": []
-                    },
-                    "RequirementComparisons": []
-                }
-            ],
+            "RequirementList": [],
             "ResultSets": [
                 {
                     "Description": {
                         "Id": "outcome_0_0",
-                        "Name": "Open Cargo Pod.",
-                        "Details": "You look at [[TGT_MW,{TGT_MW.Callsign}]]. \"What’s in this pod? \"Magpie frowns and leans over to check the sensor readings. \"Honestly Commander, your guess is as good as mine. I never asked what my clients were hiding away and I don't plan on asking now.\"\r\n\r\n Darius starts to frown and starts paging through the sensors readings. \"I’m not sure what to make of it Commander. Sensors are picking up what could be an inactive Fusion Core. The pod doesn't look dangerous but I'd recommend opening outside. Just in case anything happens.\"\r\n\r\nMagpie nods in agreement. \"It's probably the safest course of action. My client liked to hide stuff in the middle of nowhere for good reason. It's probably safe, but I wouldn't want to bet on it.\"\r\n\r\nThe Argo backs off and Magpie approaches the pod in an EVA suit.",
-                        "Icon": null
+                        "Name": "Send Magpie out to open the pod.",
+                        "Details": "You look at [[TGT_MW,{TGT_MW.Callsign}]]. \"What’s in this pod? \"Magpie frowns and leans over to check the sensor readings. \"Honestly Commander, your guess is as good as mine. I never asked what my clients were hiding away and I don't plan on asking now.\"\r\n\r\n Darius starts to frown and starts paging through the sensors readings. \"I’m not sure what to make of it Commander. Sensors are picking up what could be an inactive Fusion Core. The pod doesn't look dangerous but I'd recommend opening it outside. Just in case anything happens.\"\r\n\r\nMagpie nods in agreement. \"It's probably the safest course of action. My client liked to hide stuff in the middle of nowhere for good reason. It's probably safe, but I wouldn't want to bet on it.\"\r\n\r\nThe Argo backs off and Magpie approaches the pod in an EVA suit.",
+                        "Icon": ""
                     },
-                    "Weight": 100,
+                    "Weight": 50,
                     "Results": [
-                        {
-                            "Scope": "SecondaryMechWarrior",
-                            "Requirements": null,
-                            "AddedTags": {
-                                "tagSetSourceFile": "",
-                                "items": []
-                            },
-                            "RemovedTags": {
-                                "tagSetSourceFile": "",
-                                "items": []
-                            },
-                            "Stats": null,
-                            "Actions": null,
-                            "ForceEvents": null,
-                            "TemporaryResult": false,
-                            "ResultDuration": 0
-                        },
-                        {
-                            "Scope": "MechWarrior",
-                            "Requirements": null,
-                            "AddedTags": {
-                                "tagSetSourceFile": "",
-                                "items": []
-                            },
-                            "RemovedTags": {
-                                "tagSetSourceFile": "",
-                                "items": []
-                            },
-                            "Stats": null,
-                            "Actions": null,
-                            "ForceEvents": null,
-                            "TemporaryResult": false,
-                            "ResultDuration": 0
-                        },
                         {
                             "Scope": "Company",
                             "Requirements": null,
@@ -158,17 +95,71 @@
                             "ResultDuration": 0
                         }
                     ]
+                },
+                {
+                    "Description": {
+                        "Id": "outcome_0_1",
+                        "Name": "Disaster",
+                        "Details": "You look at [[TGT_MW,{TGT_MW.Callsign}]]. \"What’s in this pod? \"Magpie frowns and leans over to check the sensor readings. \"Honestly Commander, your guess is as good as mine. I never asked what my clients were hiding away and I don't plan on asking now.\"\r\n\r\n Darius starts to frown and starts paging through the sensors readings. \"I’m not sure what to make of it Commander. Sensors are picking up what could be an inactive Fusion Core. The pod doesn't look dangerous but I'd recommend opening it outside. Just in case anything happens.\"\r\n\r\nMagpie nods in agreement. \"It's probably the safest course of action. My client liked to hide stuff in the middle of nowhere for good reason. It's probably safe, but I wouldn't want to bet on it.\"\r\n\r\nThe Argo backs off and Magpie approaches the pod in an EVA suit.",
+                        "Icon": ""
+                    },
+                    "Weight": 50,
+                    "Results": [
+                        {
+                            "Scope": "MechWarrior",
+                            "Requirements": null,
+                            "AddedTags": {
+                                "tagSetSourceFile": "",
+                                "items": []
+                            },
+                            "RemovedTags": {
+                                "tagSetSourceFile": "",
+                                "items": []
+                            },
+                            "Stats": [
+                                {
+                                    "typeString": "System.Int32",
+                                    "name": "Injuries",
+                                    "value": "1",
+                                    "set": false,
+                                    "valueConstant": null
+                                }
+                            ],
+                            "Actions": null,
+                            "ForceEvents": null,
+                            "TemporaryResult": false,
+                            "ResultDuration": 0
+                        },
+                        {
+                            "Scope": "Company",
+                            "Requirements": null,
+                            "AddedTags": {
+                                "tagSetSourceFile": "",
+                                "items": [
+                                    "event_co_HastyExit1c"
+                                ]
+                            },
+                            "RemovedTags": {
+                                "tagSetSourceFile": "",
+                                "items": []
+                            },
+                            "Actions": null,
+                            "ForceEvents": null,
+                            "TemporaryResult": false,
+                            "ResultDuration": 0
+                        }
+                    ]
                 }
             ],
             "Requirements": {
                 "Scope": "Company",
                 "RequirementTags": {
-                    "tagSetSourceFile": "",
-                    "items": []
+                    "items": [],
+                    "tagSetSourceFile": ""
                 },
                 "ExclusionTags": {
-                    "tagSetSourceFile": "",
-                    "items": []
+                    "items": [],
+                    "tagSetSourceFile": ""
                 },
                 "RequirementComparisons": []
             }

--- a/RogueTech Core/events/event_co_smugglingOnAccident.json
+++ b/RogueTech Core/events/event_co_smugglingOnAccident.json
@@ -14,7 +14,9 @@
             "tagSetSourceFile": ""
         },
         "ExclusionTags": {
-            "items": [],
+            "items": [
+                "event_co_HastyExit_Prep"
+            ],
             "tagSetSourceFile": ""
         },
         "RequirementComparisons": [


### PR DESCRIPTION
Added the tag used to roll magpies event to the exclusions for the preceding event. Should prevent it from respawning/restarting the chain if the correct options are picked.  Added a requirement tag to the final event so it won't spawn if Magpie is in party at start of game. Added a 50/50 choice to the last event so opening the pod can give 1 wound instead of loot. Events still need an edit/writing pass (coming soonish)