### PR TITLE
Dev

### DIFF
--- a/Base 3061/chassis/chassisdef_adder_ADR-E.json
+++ b/Base 3061/chassis/chassisdef_adder_ADR-E.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-E",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The E configuration has two ATM-9 launchers which can fire ammunition specialized for long, medium, and short ranges. For close combat, the 'Mech has an additional four Micro Pulse Lasers.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-E",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The E configuration has two ATM-9 launchers which can fire ammunition specialized for long, medium, and short ranges. For close combat, the 'Mech has an additional four Micro Pulse Lasers.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Base 3061/chassis/chassisdef_adder_ADR-H.json
+++ b/Base 3061/chassis/chassisdef_adder_ADR-H.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-H",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The only true brawling configuration of the Adder, the Adder H has two highly destructive Heavy Large Lasers as its primary weapons backed up only by the fixed Flamer. To help dissipate the 'Mech's heat, it has six additional double heat sinks.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-H",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Brawler",
+  "YangsThoughts": "The only true brawling configuration of the Adder, the Adder H has two highly destructive Heavy Large Lasers as its primary weapons backed up only by the fixed Flamer. To help dissipate the 'Mech's heat, it has six additional double heat sinks.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Base 3061/chassis/chassisdef_adder_ADR-Prime.json
+++ b/Base 3061/chassis/chassisdef_adder_ADR-Prime.json
@@ -101,7 +101,7 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
+  "StockRole": "Sniper",
   "YangsThoughts": "Khan Marthe Pryde decided to upgrade the 'Mechs her Clan fielded. Rather than waste precious resources designing a new OmniMech from the ground up, she instructed her scientists to improve upon existing designs. The design the scientists chose to modify was the Adder. Though the two 'Mechs are visually similar and share the same weight, the Cougar is slower and better armed. ",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",

--- a/Base 3061/chassis/chassisdef_timber_wolf_TW-BH.json
+++ b/Base 3061/chassis/chassisdef_timber_wolf_TW-BH.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-BH",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "The first custom configuration used by the infamous Bounty Hunter of the time of the initial Clan Invasion, it mounted a Large Pulse Laser and a Medium Pulse Laser in each arm. It also had a Medium Pulse Laser in both the left and right torso with a Clan Light TAG in the center torso. A Light Active Probe, ECM suite, and a Targeting Computer provided stealth and increased accuracy. \n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-BH",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "StockRole": "Brawler",
+  "YangsThoughts": "The first custom configuration used by the infamous Bounty Hunter of the time of the initial Clan Invasion, it mounted a Large Pulse Laser and a Medium Pulse Laser in each arm. It also had a Medium Pulse Laser in both the left and right torso with a Clan Light TAG in the center torso. A Light Active Probe, ECM suite, and a Targeting Computer provided stealth and increased accuracy. ",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,16 +174,8 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -242,16 +234,8 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Base 3061/chassis/chassisdef_timber_wolf_TW-C.json
+++ b/Base 3061/chassis/chassisdef_timber_wolf_TW-C.json
@@ -82,7 +82,7 @@
     "UIName": "Timber Wolf",
     "Id": "chassisdef_timber_wolf_TW-C",
     "Name": "Timber Wolf",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A long range configuration of the Timber Wolf, the C configuration carries an assortment of long range weapons. For direct fire capabilities, the Timber Wolf C mounts two ER Large Lasers and an Ultra Autocannon/5. For indirect fire support capability, its two LRM-15 launchers provide an ample quantity of firepower. Finally, for close range protection, the C carries an ER Medium Laser and an Anti-Missile System.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "VariantName": "TW-C",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Mad Cat",
-  "YangsThoughts": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.",
+  "StockRole": "Sniper",
+  "YangsThoughts": "A long range configuration of the Timber Wolf, the C configuration carries an assortment of long range weapons. For direct fire capabilities, the Timber Wolf C mounts two ER Large Lasers and an Ultra Autocannon/5. For indirect fire support capability, its two LRM-15 launchers provide an ample quantity of firepower. Finally, for close range protection, the C carries an ER Medium Laser and an Anti-Missile System.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,8 +174,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -234,8 +242,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Base 3061/chassis/chassisdef_timber_wolf_TW-D.json
+++ b/Base 3061/chassis/chassisdef_timber_wolf_TW-D.json
@@ -82,7 +82,7 @@
     "UIName": "Timber Wolf",
     "Id": "chassisdef_timber_wolf_TW-D",
     "Name": "Timber Wolf",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "This configuration mounts a pair of ER PPCs as its primary weapons. These are supported by four Streak SRM-6 launchers with two in the left torso and two in the right torso. One Streak SRM-6 on both torsos is rear mounted. A single ER Small Laser rounds out the Timber Wolf D's arsenal.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "VariantName": "TW-D",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Mad Cat",
-  "YangsThoughts": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.",
+  "StockRole": "Skirmisher",
+  "YangsThoughts": "This configuration mounts a pair of ER PPCs as its primary weapons. These are supported by four Streak SRM-6 launchers with two in the left torso and two in the right torso. One Streak SRM-6 on both torsos is rear mounted. A single ER Small Laser rounds out the Timber Wolf D's arsenal.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,8 +174,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -234,8 +242,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Base 3061/chassis/chassisdef_timber_wolf_TW-H.json
+++ b/Base 3061/chassis/chassisdef_timber_wolf_TW-H.json
@@ -82,7 +82,7 @@
     "UIName": "Timber Wolf",
     "Id": "chassisdef_timber_wolf_TW-H",
     "Name": "Timber Wolf",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A configuration that is capable of engaging an enemy with devastating effect at any range, the H configuration carries a pair of LRM-20 launchers linked to an Artemis IV Fire Control System for long range firepower. For close combat, two Heavy Large Lasers are carried, each of which can strip a full ton of armor from an enemy 'Mech at short ranges. Finally, seemingly added almost as an afterthought, an ER Small Laser completes the H's weaponry loadout.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "VariantName": "TW-H",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Mad Cat",
-  "YangsThoughts": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.",
+  "StockRole": "Missile Boat",
+  "YangsThoughts": "A configuration that is capable of engaging an enemy with devastating effect at any range, the H configuration carries a pair of LRM-20 launchers linked to an Artemis IV Fire Control System for long range firepower. For close combat, two Heavy Large Lasers are carried, each of which can strip a full ton of armor from an enemy 'Mech at short ranges. Finally, seemingly added almost as an afterthought, an ER Small Laser completes the H's weaponry loadout.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,8 +174,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -234,8 +242,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Base 3061/chassis/chassisdef_timber_wolf_TW-N.json
+++ b/Base 3061/chassis/chassisdef_timber_wolf_TW-N.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-N",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A mix of the Prime and the D configurations, alternate configuration N mounts an ER PPC in each arm alongside an LRM-15 rack in the left and right torsos. These weapons are supported at short range by paired Machine Guns and Medium Pulse Lasers in each side torso. Two tons of LRM reloads and a half ton of machine gun rounds force a focus on the energy weapons with an extra Double Heat Sink tries to assist in managing their heat.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-N",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "StockRole": "Brawler",
+  "YangsThoughts": "A mix of the Prime and the D configurations, alternate configuration N mounts an ER PPC in each arm alongside an LRM-15 rack in the left and right torsos. These weapons are supported at short range by paired Machine Guns and Medium Pulse Lasers in each side torso. Two tons of LRM reloads and a half ton of machine gun rounds force a focus on the energy weapons with an extra Double Heat Sink tries to assist in managing their heat.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",

--- a/Base 3061/chassis/chassisdef_timber_wolf_TW-Prime.json
+++ b/Base 3061/chassis/chassisdef_timber_wolf_TW-Prime.json
@@ -82,7 +82,7 @@
     "UIName": "Timber Wolf",
     "Id": "chassisdef_timber_wolf_TW-Prime",
     "Name": "Timber Wolf",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "The default configuration of the Timber Wolf features a well blended mix of energy and missile weaponry; primarily extended-range lasers and long range missile racks that give the Timber Wolf considerable firepower at medium and long range. A pair of LRM-20 racks supplemented by two Extended Range Large Lasers make up the bulk of the Timber Wolf's firepower. The Timber Wolf also has an array of lighter, shorter ranged weaponry for use once the 'Mech draws closer to its prey: two ER Medium Lasers and a Medium Pulse Laser. Finally, it has two Machine Guns for point defense against infantry.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "VariantName": "TW-Prime",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Mad Cat",
-  "YangsThoughts": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.",
+  "StockRole": "Brawler",
+  "YangsThoughts": "The default configuration of the Timber Wolf features a well blended mix of energy and missile weaponry; primarily extended-range lasers and long range missile racks that give the Timber Wolf considerable firepower at medium and long range. A pair of LRM-20 racks supplemented by two Extended Range Large Lasers make up the bulk of the Timber Wolf's firepower. The Timber Wolf also has an array of lighter, shorter ranged weaponry for use once the 'Mech draws closer to its prey: two ER Medium Lasers and a Medium Pulse Laser. Finally, it has two Machine Guns for point defense against infantry.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,8 +174,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -234,8 +242,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Base 3061/chassis/chassisdef_timber_wolf_TW-S.json
+++ b/Base 3061/chassis/chassisdef_timber_wolf_TW-S.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-S",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A highly maneuverable urban combat configuration of the Timber Wolf, the S mounts five jump jets, allowing it to jump up to one hundred and fifty meters. To offset the inaccuracy from using jump jets, the S configuration is armed with a Large Pulse Laser backed up by two Medium Pulse Lasers. The S configuration also carries four SRM-6 launchers and two Machine Guns, making it a deadly close combat fighter. \n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-S",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "StockRole": "Urban Mad Cat",
+  "YangsThoughts": "A highly maneuverable urban combat configuration of the Timber Wolf, the S mounts five jump jets, allowing it to jump up to one hundred and fifty meters. To offset the inaccuracy from using jump jets, the S configuration is armed with a Large Pulse Laser backed up by two Medium Pulse Lasers. The S configuration also carries four SRM-6 launchers and two Machine Guns, making it a deadly close combat fighter. ",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,16 +174,8 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -242,16 +234,8 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Base 3061/mech/mechdef_adder_ADR-A.json
+++ b/Base 3061/mech/mechdef_adder_ADR-A.json
@@ -159,15 +159,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -177,6 +168,42 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_hand",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -195,16 +222,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/Base 3061/mech/mechdef_adder_ADR-B.json
+++ b/Base 3061/mech/mechdef_adder_ADR-B.json
@@ -176,15 +176,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -195,6 +186,24 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/Base 3061/mech/mechdef_adder_ADR-D.json
+++ b/Base 3061/mech/mechdef_adder_ADR-D.json
@@ -134,7 +134,7 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -166,15 +166,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -185,6 +176,24 @@
     {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/Base 3061/mech/mechdef_adder_ADR-E.json
+++ b/Base 3061/mech/mechdef_adder_ADR-E.json
@@ -7,11 +7,11 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
       "unit_littlefriend",
+	  "unit_indirectfire",
       "Republic",
       "clansgeneric",
       "clanbloodspirit",
@@ -35,17 +35,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-E",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-E",
+    "Id": "mechdef_adder_ADR-E",
+    "Name": "Adder ADR-E",
+    "Details": "The E configuration has two ATM-9 launchers which can fire ammunition specialized for long, medium, and short ranges. For close combat, the 'Mech has an additional four Micro Pulse Lasers.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +135,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -303,7 +319,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_LRM_ATM9_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -311,73 +327,73 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MicroLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_ATM9_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_ER_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_HE_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },

--- a/Base 3061/mech/mechdef_adder_ADR-H.json
+++ b/Base 3061/mech/mechdef_adder_ADR-H.json
@@ -7,10 +7,9 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
-      "unit_role_sniper",
+      "unit_role_brawler",
       "unit_littlefriend",
       "Republic",
       "clansgeneric",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-H",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-H",
+    "Id": "mechdef_adder_ADR-H",
+    "Name": "Adder ADR-H",
+    "Details": "The only true brawling configuration of the Adder, the Adder H has two highly destructive Heavy Large Lasers as its primary weapons backed up only by the fixed Flamer. To help dissipate the 'Mech's heat, it has six additional double heat sinks.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +134,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,6 +173,62 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_LongRange",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -177,19 +248,9 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -213,19 +274,17 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -303,97 +362,17 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_HeavyLargeLaser_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_HeavyLargeLaser_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Base 3061/mech/mechdef_adder_ADR-Prime.json
+++ b/Base 3061/mech/mechdef_adder_ADR-Prime.json
@@ -157,7 +157,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Crit",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -165,7 +165,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_MultiTrack",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -173,7 +173,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -329,7 +329,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Base 3061/mech/mechdef_timber_wolf_TW-BH.json
+++ b/Base 3061/mech/mechdef_timber_wolf_TW-BH.json
@@ -5,29 +5,32 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "unit_totem",
+	  "unit_legendary",
+      "unit_hero",
+      "locals",
+      "auriganpirates"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-BH",
   "Description": {
-    "Cost": 2086377,
+    "Cost": 2246868,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-BH",
+    "Id": "mechdef_timber_wolf_TW-BH",
+    "Name": "Timber Wolf TW-BH",
+    "Details": "The first custom configuration used by the infamous Bounty Hunter of the time of the initial Clan Invasion, it mounted a Large Pulse Laser and a Medium Pulse Laser in each arm. It also had a Medium Pulse Laser in both the left and right torso with a Clan Light TAG in the center torso. A Light Active Probe, ECM suite, and a Targeting Computer provided stealth and increased accuracy. \n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "simGameMechPartCost": 2086377,
+  "simGameMechPartCost": 2246868,
   "Version": 1,
   "Locations": [
     {
@@ -50,29 +53,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 75,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 75,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
@@ -86,19 +89,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -112,11 +115,90 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_AP_CLAN",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -137,7 +219,47 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Guardian_ECM_CLAN",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_RCA_InstaTrac-XII",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_LongRange",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_MedRange",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -146,7 +268,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -154,8 +276,8 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftArm",
+	{
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_omni_lower",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -164,181 +286,114 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_hip",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_hip",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_Laser_Light_TAG_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -346,31 +401,15 @@
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Base 3061/mech/mechdef_timber_wolf_TW-C.json
+++ b/Base 3061/mech/mechdef_timber_wolf_TW-C.json
@@ -43,7 +43,7 @@
     "UIName": "Timber Wolf TW-C",
     "Id": "mechdef_timber_wolf_TW-C",
     "Name": "Timber Wolf TW-C",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A long range configuration of the Timber Wolf, the C configuration carries an assortment of long range weapons. For direct fire capabilities, the Timber Wolf C mounts two ER Large Lasers and an Ultra Autocannon/5. For indirect fire support capability, its two LRM-15 launchers provide an ample quantity of firepower. Finally, for close range protection, the C carries an ER Medium Laser and an Anti-Missile System.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2086377,
@@ -298,7 +298,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_AMS_CLAN",
+      "ComponentDefID": "Weapon_AMS_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -347,6 +347,14 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Ammo_AmmunitionBox_Ultra_AC5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_AntiMissile_half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "hasPrefabName": false,

--- a/Base 3061/mech/mechdef_timber_wolf_TW-D.json
+++ b/Base 3061/mech/mechdef_timber_wolf_TW-D.json
@@ -42,7 +42,7 @@
     "UIName": "Timber Wolf TW-D",
     "Id": "mechdef_timber_wolf_TW-D",
     "Name": "Timber Wolf TW-D",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "This configuration mounts a pair of ER PPCs as its primary weapons. These are supported by four Streak SRM-6 launchers with two in the left torso and two in the right torso. One Streak SRM-6 on both torsos is rear mounted. A single ER Small Laser rounds out the Timber Wolf D's arsenal.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2086377,
@@ -335,15 +335,15 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Base 3061/mech/mechdef_timber_wolf_TW-H.json
+++ b/Base 3061/mech/mechdef_timber_wolf_TW-H.json
@@ -43,7 +43,7 @@
     "UIName": "Timber Wolf TW-H",
     "Id": "mechdef_timber_wolf_TW-H",
     "Name": "Timber Wolf TW-H",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A configuration that is capable of engaging an enemy with devastating effect at any range, the H configuration carries a pair of LRM-20 launchers linked to an Artemis IV Fire Control System for long range firepower. For close combat, two Heavy Large Lasers are carried, each of which can strip a full ton of armor from an enemy 'Mech at short ranges. Finally, seemingly added almost as an afterthought, an ER Small Laser completes the H's weaponry loadout.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2086377,

--- a/Base 3061/mech/mechdef_timber_wolf_TW-N.json
+++ b/Base 3061/mech/mechdef_timber_wolf_TW-N.json
@@ -5,29 +5,47 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+	  "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "Republic",
+      "clansgeneric",
+      "clanbloodspirit",
+      "clanwolf",
+      "clanfiremandrill",
+      "clanstaradder",
+      "clancoyote",
+      "clanjadefalcon",
+      "clansteelviper",
+      "clanicehellion",
+      "clangoliathscorpion",
+      "clandiamondshark",
+      "clanhellshorses",
+      "clansnowraven",
+      "clanghostbear",
+      "clansmokejaguar",
+      "clancloudcobra",
+      "clannovacat",
+      "clanburrock"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-N",
   "Description": {
-    "Cost": 2086377,
+    "Cost": 2246868,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-N",
+    "Id": "mechdef_timber_wolf_TW-N",
+    "Name": "Timber Wolf TW-N",
+    "Details": "A mix of the Prime and the D configurations, alternate configuration N mounts an ER PPC in each arm alongside an LRM-15 rack in the left and right torsos. These weapons are supported at short range by paired Machine Guns and Medium Pulse Lasers in each side torso. Two tons of LRM reloads and a half ton of machine gun rounds force a focus on the energy weapons with an extra Double Heat Sink tries to assist in managing their heat.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "simGameMechPartCost": 2086377,
+  "simGameMechPartCost": 2246868,
   "Version": 1,
   "Locations": [
     {
@@ -50,29 +68,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 81,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 81,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
@@ -86,19 +104,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -112,11 +130,65 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -137,7 +209,15 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "Heatsink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -146,7 +226,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -155,8 +235,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_hip",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -164,213 +244,161 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_hip",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM_double",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Base 3061/mech/mechdef_timber_wolf_TW-Prime.json
+++ b/Base 3061/mech/mechdef_timber_wolf_TW-Prime.json
@@ -43,7 +43,7 @@
     "UIName": "Timber Wolf TW-Prime",
     "Id": "mechdef_timber_wolf_TW-Prime",
     "Name": "Timber Wolf TW-Prime",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "The default configuration of the Timber Wolf features a well blended mix of energy and missile weaponry; primarily extended-range lasers and long range missile racks that give the Timber Wolf considerable firepower at medium and long range. A pair of LRM-20 racks supplemented by two Extended Range Large Lasers make up the bulk of the Timber Wolf's firepower. The Timber Wolf also has an array of lighter, shorter ranged weaponry for use once the 'Mech draws closer to its prey: two ER Medium Lasers and a Medium Pulse Laser. Finally, it has two Machine Guns for point defense against infantry.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2086377,
@@ -157,15 +157,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -175,6 +166,41 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -193,19 +219,9 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -314,7 +330,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
@@ -362,22 +378,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
       "ComponentDefType": "AmmunitionBox",
@@ -387,15 +387,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "hasPrefabName": false,

--- a/Base 3061/mech/mechdef_timber_wolf_TW-S.json
+++ b/Base 3061/mech/mechdef_timber_wolf_TW-S.json
@@ -5,29 +5,47 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+	  "unit_jumpOK",
+	  "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "clansgeneric",
+      "clanbloodspirit",
+      "clanwolf",
+      "clanfiremandrill",
+      "clanstaradder",
+      "clancoyote",
+      "clanjadefalcon",
+      "clansteelviper",
+      "clanicehellion",
+      "clangoliathscorpion",
+      "clandiamondshark",
+      "clanhellshorses",
+      "clansnowraven",
+      "clanghostbear",
+      "clansmokejaguar",
+      "clancloudcobra",
+      "clannovacat",
+      "clanburrock"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-S",
   "Description": {
-    "Cost": 2086377,
+    "Cost": 2246868,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-S",
+    "Id": "mechdef_timber_wolf_TW-S",
+    "Name": "Timber Wolf TW-S",
+    "Details": "A highly maneuverable urban combat configuration of the Timber Wolf, the S mounts five jump jets, allowing it to jump up to one hundred and fifty meters. To offset the inaccuracy from using jump jets, the S configuration is armed with a Large Pulse Laser backed up by two Medium Pulse Lasers. The S configuration also carries four SRM-6 launchers and two Machine Guns, making it a deadly close combat fighter. \n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "simGameMechPartCost": 2086377,
+  "simGameMechPartCost": 2246868,
   "Version": 1,
   "Locations": [
     {
@@ -50,29 +68,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 75,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 75,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
@@ -86,19 +104,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -112,10 +130,89 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
+      "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
@@ -137,49 +234,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
       "ComponentDefType": "JumpJet",
@@ -221,7 +275,7 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_omni_lower",
       "ComponentDefType": "Upgrade",
@@ -231,6 +285,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftLeg",
       "ComponentDefID": "emod_leg_hip",
       "ComponentDefType": "Upgrade",
@@ -306,13 +368,13 @@
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -320,57 +382,105 @@
     },
     {
       "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Base Unique 3061/chassis/chassisdef_adder_ADR-CN.json
+++ b/Base Unique 3061/chassis/chassisdef_adder_ADR-CN.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-CN",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "Reportedly piloted by Dirk Radick, the Adder Hero 'Mech, the Cinder mounts an ER Large Laser in each arm supported by a Machine Gun in each side torso complimented by the head mounted Flamer. Carrying two and half tons of machine gun rounds, five extra Double Heat Sinks maintain a high rate of laser fire.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-CN",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "TReportedly piloted by Dirk Radick, the Adder Hero 'Mech, the Cinder mounts an ER Large Laser in each arm supported by a Machine Gun in each side torso complimented by the head mounted Flamer. Carrying two and half tons of machine gun rounds, five extra Double Heat Sinks maintain a high rate of laser fire.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Base Unique 3061/chassis/chassisdef_timber_wolf_TW-Pryde.json
+++ b/Base Unique 3061/chassis/chassisdef_timber_wolf_TW-Pryde.json
@@ -94,7 +94,7 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Mad Cat",
+  "StockRole": "Missile Boat",
   "YangsThoughts": "A non-standard alternate configuration of the Timber Wolf, this configuration was famously used by Star Colonel Aidan Pryde. The primary long range weapons are a pair of ER Large Lasers which are backed up by a pair of LRM-20s for long range combat. For close combat, two ER Medium Lasers are carried as well as an ER Small Laser. The Pryde Configuration also mounts four jump jets making it highly maneuverable.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",

--- a/Base Unique 3061/chassis/chassisdef_timber_wolf_TW-Vlad.json
+++ b/Base Unique 3061/chassis/chassisdef_timber_wolf_TW-Vlad.json
@@ -175,8 +175,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -235,8 +243,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Base Unique 3061/mech/mechdef_adder_ADR-CN.json
+++ b/Base Unique 3061/mech/mechdef_adder_ADR-CN.json
@@ -7,45 +7,28 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
       "unit_littlefriend",
-      "Republic",
-      "clansgeneric",
-      "clanbloodspirit",
-      "clanwolf",
-      "clanfiremandrill",
-      "clanstaradder",
-      "clancoyote",
-      "clanjadefalcon",
-      "clansteelviper",
-      "clanicehellion",
-      "clangoliathscorpion",
-      "clandiamondshark",
-      "clanhellshorses",
-      "clansnowraven",
-      "clanghostbear",
-      "clansmokejaguar",
-      "clancloudcobra",
-      "clannovacat",
-      "clanburrock",
-      "society"
+	  "unit_legendary",
+	  "unit_hero",
+	  "unit_totem",
+      "clanwolf"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-CN",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-CN",
+    "Id": "mechdef_adder_ADR-CN",
+    "Name": "Adder ADR-CN",
+    "Details": "Reportedly piloted by Dirk Radick, the Adder Hero 'Mech, the Cinder mounts an ER Large Laser in each arm supported by a Machine Gun in each side torso complimented by the head mounted Flamer. Carrying two and half tons of machine gun rounds, five extra Double Heat Sinks maintain a high rate of laser fire.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +109,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +119,84 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,38 +219,26 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -213,19 +262,9 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -303,7 +342,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -311,7 +350,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -319,81 +358,41 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
-    },
+    }
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserER_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Base Unique 3061/mech/mechdef_timber_wolf_TW-Pryde.json
+++ b/Base Unique 3061/mech/mechdef_timber_wolf_TW-Pryde.json
@@ -8,6 +8,7 @@
       "unit_lance_support",
       "unit_role_sniper",
       "unit_advanced",
+	  "unit_jumpOK",
       "unit_bracket_high",
       "unit_legendary",
       "unit_hero",
@@ -53,29 +54,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 150,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 135,
+      "CurrentRearArmor": 60,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 150,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 135,
+      "AssignedRearArmor": 60,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 174,
-      "CurrentRearArmor": 100,
+      "CurrentArmor": 175,
+      "CurrentRearArmor": 80,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 174,
-      "AssignedRearArmor": 100,
+      "AssignedArmor": 175,
+      "AssignedRearArmor": 80,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 150,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 135,
+      "CurrentRearArmor": 60,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 150,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 135,
+      "AssignedRearArmor": 60,
       "DamageLevel": "Functional"
     },
     {
@@ -166,6 +167,23 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -177,6 +195,15 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_omni_lower",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -264,8 +291,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
@@ -273,7 +300,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
@@ -296,14 +323,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_Laser_LargeLaserER_CLAN",
       "ComponentDefType": "Weapon",
@@ -312,6 +331,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
       "ComponentDefType": "AmmunitionBox",
@@ -336,6 +363,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
       "ComponentDefType": "JumpJet",
@@ -344,15 +379,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,

--- a/DarkAge/chassis/chassisdef_adder_ADR-I.json
+++ b/DarkAge/chassis/chassisdef_adder_ADR-I.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-I",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The Adder I config carries an Improved Heavy Medium Laser and twin ER Medium Lasers. An SRM-6 and a ton of ammunition is mounted in each side torso. To handle the heavy heat load, four extra heat sinks are installed, two in each arm.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-I",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Striker",
+  "YangsThoughts": "The Adder I config carries an Improved Heavy Medium Laser and twin ER Medium Lasers. An SRM-6 and a ton of ammunition is mounted in each side torso. To handle the heavy heat load, four extra heat sinks are installed, two in each arm.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/DarkAge/chassis/chassisdef_adder_ADR-L.json
+++ b/DarkAge/chassis/chassisdef_adder_ADR-L.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-L",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The L configuration is apparently a light striker variant. Each arm carries a pair of Streak LRM-5s and a ton of ammunition. The side torsos carry a single ER Medium Laser, while an ECM Suite provides electronic warfare support. For additional movement, six jump jets are installed for a 180 meter jump range.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-L",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Striker",
+  "YangsThoughts": "The L configuration is apparently a light striker variant. Each arm carries a pair of Streak LRM-5s and a ton of ammunition. The side torsos carry a single ER Medium Laser, while an ECM Suite provides electronic warfare support. For additional movement, six jump jets are installed for a 180 meter jump range.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/DarkAge/chassis/chassisdef_adder_ADR-T.json
+++ b/DarkAge/chassis/chassisdef_adder_ADR-T.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-T",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The T configuration carries an ER PPC with a PPC Capacitor in each arm. An extra double heat sink is in the left and right torso, but to handle heavy heat loads the right torso carries a triple Coolant Pod.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-T",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The T configuration carries an ER PPC with a PPC Capacitor in each arm. An extra double heat sink is in the left and right torso, but to handle heavy heat loads the right torso carries a triple Coolant Pod.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/DarkAge/chassis/chassisdef_timber_wolf_TW-T.json
+++ b/DarkAge/chassis/chassisdef_timber_wolf_TW-T.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -18,13 +18,13 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Improved_Targeting_Medium",
+      "ComponentDefID": "Special_FCS_ARTV",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "emod_structureslots_clanendosteel",
       "ComponentDefType": "Upgrade",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-T",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A missile boat configuration, the Timber Wolf T is armed with an Artemis V FCS-enhanced LRM-20 rack in each side torso, supported by a Improved Heavy Medium Laser and ER Medium Laser in each arm and a pair of ER Small Lasers and a single ER Small Pulse Laser in the torsos. Six tons of LRM rounds and two extra double heat sinks give it good field endurance.\n\n<b><color=#e62e00>Quirk: Artemis V</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-T",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "StockRole": "Missile Boat",
+  "YangsThoughts": "A missile boat configuration, the Timber Wolf T is armed with an Artemis V FCS-enhanced LRM-20 rack in each side torso, supported by a Improved Heavy Medium Laser and ER Medium Laser in each arm and a pair of ER Small Lasers and a single ER Small Pulse Laser in the torsos. Six tons of LRM rounds and two extra double heat sinks give it good field endurance.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,14 +174,6 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
-          "Omni": true
-        },
         {
           "WeaponMount": "Ballistic",
           "Omni": true
@@ -240,14 +232,6 @@
       "Hardpoints": [
         {
           "WeaponMount": "Energy",
-          "Omni": true
-        },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Missile",
           "Omni": true
         },
         {

--- a/DarkAge/mech/mechdef_adder_ADR-I.json
+++ b/DarkAge/mech/mechdef_adder_ADR-I.json
@@ -7,10 +7,9 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
-      "unit_role_sniper",
+      "unit_role_brawler",
       "unit_littlefriend",
       "Republic",
       "clansgeneric",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-I",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-I",
+    "Id": "mechdef_adder_ADR-I",
+    "Name": "Adder ADR-I",
+    "Details": "The Adder I config carries an Improved Heavy Medium Laser and twin ER Medium Lasers. An SRM-6 and a ton of ammunition is mounted in each side torso. To handle the heavy heat load, four extra heat sinks are installed, two in each arm.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +134,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,6 +173,30 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -177,19 +216,17 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -213,19 +250,17 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -303,99 +338,83 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Laser_ImprovedHeavyMediumLaser_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_SRM_SRM6_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
+      "ComponentDefID": "Weapon_Laser_ImprovedHeavyMediumLaser_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
-    }
+    }	
   ]
 }

--- a/DarkAge/mech/mechdef_adder_ADR-L.json
+++ b/DarkAge/mech/mechdef_adder_ADR-L.json
@@ -7,11 +7,11 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
       "unit_littlefriend",
+	  "unit_jumpOK",
       "Republic",
       "clansgeneric",
       "clanbloodspirit",
@@ -35,17 +35,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-L",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-L",
+    "Id": "mechdef_adder_ADR-L",
+    "Name": "Adder ADR-L",
+    "Details": "The L configuration is apparently a light striker variant. Each arm carries a pair of Streak LRM-5s and a ton of ammunition. The side torsos carry a single ER Medium Laser, while an ECM Suite provides electronic warfare support. For additional movement, six jump jets are installed for a 180 meter jump range.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +126,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +136,92 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,7 +244,47 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Guardian_ECM_CLAN",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -167,62 +293,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,97 +375,65 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_LRM5_STREAK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Streak_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Streak_LRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/DarkAge/mech/mechdef_adder_ADR-T.json
+++ b/DarkAge/mech/mechdef_adder_ADR-T.json
@@ -7,7 +7,6 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-T",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-T",
+    "Id": "mechdef_adder_ADR-T",
+    "Name": "Adder ADR-T",
+    "Details": "The T configuration carries an ER PPC with a PPC Capacitor in each arm. An extra double heat sink is in the left and right torso, but to handle heavy heat loads the right torso carries a triple Coolant Pod.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +125,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +135,85 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_PPC_Capacitator",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,38 +236,26 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Coolantpod_Clan_X3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -205,24 +271,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,97 +351,17 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/DarkAge/mech/mechdef_timber_wolf_TW-T.json
+++ b/DarkAge/mech/mechdef_timber_wolf_TW-T.json
@@ -5,26 +5,46 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+	  "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "unit_indirectfire",
+	  "Republic",
+      "clansgeneric",
+      "clanbloodspirit",
+      "clanwolf",
+      "clanfiremandrill",
+      "clanstaradder",
+      "clancoyote",
+      "clanjadefalcon",
+      "clansteelviper",
+      "clanicehellion",
+      "clangoliathscorpion",
+      "clandiamondshark",
+      "clanhellshorses",
+      "clansnowraven",
+      "clanghostbear",
+      "clansmokejaguar",
+      "clancloudcobra",
+      "clannovacat",
+      "clanburrock",
+	  "KellHounds"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-T",
   "Description": {
     "Cost": 2086377,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-T",
+    "Id": "mechdef_timber_wolf_TW-T",
+    "Name": "Timber Wolf TW-T",
+    "Details": "A missile boat configuration, the Timber Wolf T is armed with an Artemis V FCS-enhanced LRM-20 rack in each side torso, supported by a Improved Heavy Medium Laser and ER Medium Laser in each arm and a pair of ER Small Lasers and a single ER Small Pulse Laser in the torsos. Six tons of LRM rounds and two extra double heat sinks give it good field endurance.\n\n<b><color=#e62e00>Quirk: Artemis V</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2086377,
@@ -50,29 +70,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 81,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 81,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
@@ -86,19 +106,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -121,10 +141,30 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_Heatsinks_5",
-      "ComponentDefType": "HeatSink",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -164,41 +204,25 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
+      "ComponentDefID": "Gear_Engine_Heatsinks_5",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
@@ -231,6 +255,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftLeg",
       "ComponentDefID": "emod_leg_hip",
       "ComponentDefType": "Upgrade",
@@ -304,13 +336,13 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_ImprovedHeavyMediumLaser_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
       "ComponentDefType": "Weapon",
@@ -320,37 +352,53 @@
     },
     {
       "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
+      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_ImprovedHeavyMediumLaser_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
       "ComponentDefType": "Weapon",
@@ -359,18 +407,50 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArtemisIV_LRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArtemisIV_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Jihad 3068-3080/chassis/chassisdef_adder_ADR-J.json
+++ b/Jihad 3068-3080/chassis/chassisdef_adder_ADR-J.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-J",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The Adder J carries the new Hyper Assault Gauss 20 as its primary weapon, giving it a powerful punch. This is backed up by four Anti-Personnel Gauss Rifles, which are capable of decimating infantry.[1][16] This variant was first observed being used by forces from Clan Hell's Horses in action on Paulus Prime.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-J",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The Adder J carries the new Hyper Assault Gauss 20 as its primary weapon, giving it a powerful punch. This is backed up by four Anti-Personnel Gauss Rifles, which are capable of decimating infantry.[1][16] This variant was first observed being used by forces from Clan Hell's Horses in action on Paulus Prime.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",
@@ -162,7 +162,23 @@
         {
           "WeaponMount": "AntiPersonnel",
           "Omni": true
-        }
+        },
+		{
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
       ],
       "Tonnage": 0,
       "InventorySlots": 12,

--- a/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-BH2.json
+++ b/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-BH2.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-BH2",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "The second custom configuration used by the Bounty Hunter at the start of Jihad mounted a Large Pulse Laser in the left arm and paired ER Medium Lasers in the right arm, supported by a trio of SRM-4s in the left torso and similar trio of Streak SRM-4s in the right. Rounded out by an Anti-Personnel Gauss Rifle in each side torso and a ER Small Laser in the right, the Bounty Hunter's second Mad Cat also mounted a Targeting Computer as well as a Coolant Pod and three Jump Jets to enhance its effectiveness. A single ton of reloads for each weapon type was carried.  \n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-BH2",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "StockRole": "Brawler",
+  "YangsThoughts": "The second custom configuration used by the Bounty Hunter at the start of Jihad mounted a Large Pulse Laser in the left arm and paired ER Medium Lasers in the right arm, supported by a trio of SRM-4s in the left torso and similar trio of Streak SRM-4s in the right. Rounded out by an Anti-Personnel Gauss Rifle in each side torso and a ER Small Laser in the right, the Bounty Hunter's second Mad Cat also mounted a Targeting Computer as well as a Coolant Pod and three Jump Jets to enhance its effectiveness. A single ton of reloads for each weapon type was carried. ",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,16 +174,8 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -242,16 +234,8 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
-		{
-          "WeaponMount": "Energy",
-          "Omni": true
-        },
         {
           "WeaponMount": "Missile",
-          "Omni": true
-        },
-        {
-          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-F.json
+++ b/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-F.json
@@ -82,7 +82,7 @@
     "UIName": "Timber Wolf",
     "Id": "chassisdef_timber_wolf_TW-F",
     "Name": "Timber Wolf",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.14</color></b>",
+    "Details": "This variant takes the primary configuration, downgrades the pulse laser to an ER Medium and replaces the Machine Guns with three Anti-Personnel Gauss Rifles.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.14</color></b>",
     "Icon": "Timberwolf"
   },
   "VariantName": "TW-F",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Mad Cat",
-  "YangsThoughts": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.",
+  "StockRole": "Missile Boat",
+  "YangsThoughts": "This variant takes the primary configuration, downgrades the pulse laser to an ER Medium and replaces the Machine Guns with three Anti-Personnel Gauss Rifles.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -174,8 +174,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {
@@ -234,8 +242,16 @@
           "WeaponMount": "Energy",
           "Omni": true
         },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
         {
           "WeaponMount": "Missile",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "Ballistic",
           "Omni": true
         },
         {

--- a/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-M.json
+++ b/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-M.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-M",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A brawler configuration, the Timber Wolf M mounts an ER PPC in each arm, supported by a pair of LRM-5s in each side torso, a Large Pulse Laser in the left torso and a Heavy Flamer in the center torso. A combined two tons of LRM missiles and a single ton of flamer ammo sit in the torsos alongside a single extra Double Heat Sink.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-M",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "StockRole": "Brawler",
+  "YangsThoughts": "A brawler configuration, the Timber Wolf M mounts an ER PPC in each arm, supported by a pair of LRM-5s in each side torso, a Large Pulse Laser in the left torso and a Heavy Flamer in the center torso. A combined two tons of LRM missiles and a single ton of flamer ammo sit in the torsos alongside a single extra Double Heat Sink.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",

--- a/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-Z.json
+++ b/Jihad 3068-3080/chassis/chassisdef_timber_wolf_TW-Z.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.14
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -80,12 +80,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-Z",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "Used by The Society's MechWarriors, this version of the Timber Wolf carries twin iATM 9 missile launchers with four tons of ammunition. Each arm carries an ER Large Laser and an ER Medium Pulse Laser. To maximize its battlefield utility it also carries a Nova CEWS in the center torso.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.14</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-Z",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -94,7 +94,7 @@
     "tagSetSourceFile": ""
   },
   "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "YangsThoughts": "Used by The Society's MechWarriors, this version of the Timber Wolf carries twin iATM 9 missile launchers with four tons of ammunition. Each arm carries an ER Large Laser and an ER Medium Pulse Laser. To maximize its battlefield utility it also carries a Nova CEWS in the center torso.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",

--- a/Jihad 3068-3080/mech/mechdef_adder_ADR-J.json
+++ b/Jihad 3068-3080/mech/mechdef_adder_ADR-J.json
@@ -7,10 +7,9 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
-      "unit_role_sniper",
+      "unit_role_brawler",
       "unit_littlefriend",
       "Republic",
       "clansgeneric",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-J",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-J",
+    "Id": "mechdef_adder_ADR-J",
+    "Name": "Adder ADR-J",
+    "Details": "The Adder J carries the new Hyper Assault Gauss 20 as its primary weapon, giving it a powerful punch. This is backed up by four Anti-Personnel Gauss Rifles, which are capable of decimating infantry.[1][16] This variant was first observed being used by forces from Clan Hell's Horses in action on Paulus Prime.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -135,7 +134,23 @@
     },
     {
       "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,6 +173,22 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -176,24 +207,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -205,24 +218,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,31 +298,15 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
@@ -335,65 +314,33 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 0,
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 2,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 3,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Gauss_HAG20_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Hyper_GAUSS_double",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-BH2.json
+++ b/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-BH2.json
@@ -5,29 +5,33 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "unit_totem",
+	  "unit_jumpOK",
+	  "unit_legendary",
+      "unit_hero",
+      "locals",
+	  "auriganpirates"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-BH2",
   "Description": {
-    "Cost": 2086377,
+    "Cost": 2246868,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-BH2",
+    "Id": "mechdef_timber_wolf_TW-BH2",
+    "Name": "Timber Wolf TW-BH2",
+    "Details": "The second custom configuration used by the Bounty Hunter at the start of Jihad mounted a Large Pulse Laser in the left arm and paired ER Medium Lasers in the right arm, supported by a trio of SRM-4s in the left torso and similar trio of Streak SRM-4s in the right. Rounded out by an Anti-Personnel Gauss Rifle in each side torso and a ER Small Laser in the right, the Bounty Hunter's second Mad Cat also mounted a Targeting Computer as well as a Coolant Pod and three Jump Jets to enhance its effectiveness. A single ton of reloads for each weapon type was carried.  \n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "simGameMechPartCost": 2086377,
+  "simGameMechPartCost": 2246868,
   "Version": 1,
   "Locations": [
     {
@@ -50,29 +54,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 75,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 75,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
@@ -86,19 +90,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -112,10 +116,105 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_MedRange",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Coolantpod_Clan_X3",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
@@ -137,49 +236,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
       "ComponentDefType": "JumpJet",
@@ -196,14 +252,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -221,7 +269,7 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_omni_lower",
       "ComponentDefType": "Upgrade",
@@ -306,63 +354,111 @@
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM4_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM4_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM4_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_SRM4_STREAK_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_SRM4_STREAK_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_SRM4_STREAK_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Magshot",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -370,7 +466,7 @@
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-F.json
+++ b/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-F.json
@@ -10,6 +10,7 @@
       "unit_legendary",
       "unit_bracket_high",
       "Republic",
+	  "clansgeneric",
       "clanwolf",
       "clanjadefalcon",
       "clangoliathscorpion",
@@ -33,7 +34,7 @@
     "UIName": "Timber Wolf TW-F",
     "Id": "mechdef_timber_wolf_TW-F",
     "Name": "Timber Wolf TW-F",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.14</color></b>",
+    "Details": "This variant takes the primary configuration, downgrades the pulse laser to an ER Medium and replaces the Machine Guns with three Anti-Personnel Gauss Rifles.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.14</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2086377,
@@ -138,16 +139,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Guardian_ECM_CLAN",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_Heatsinks_4",
+      "ComponentDefID": "Gear_Engine_Heatsinks_5",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -163,15 +156,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -181,6 +165,41 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -199,19 +218,9 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -313,7 +322,15 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 2,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -321,9 +338,9 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -337,17 +354,17 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
+      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_LRM_LRM20_CLAN",
+      "ComponentDefID": "Weapon_Gauss_Magshot_Clan",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -367,9 +384,9 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
+	{
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_FTL_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_MagShot",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -378,6 +395,14 @@
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_FTL_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_MagShot_half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -387,22 +412,6 @@
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Coolantflush_Clan",
-      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"

--- a/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-M.json
+++ b/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-M.json
@@ -5,29 +5,49 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+	  "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "Republic",
+      "clansgeneric",
+      "clanbloodspirit",
+      "clanwolf",
+      "clanfiremandrill",
+      "clanstaradder",
+      "clancoyote",
+      "clanjadefalcon",
+      "clansteelviper",
+      "clanicehellion",
+      "clangoliathscorpion",
+      "clandiamondshark",
+      "clanhellshorses",
+      "clansnowraven",
+      "clanghostbear",
+      "clansmokejaguar",
+      "clancloudcobra",
+      "clannovacat",
+      "clanburrock",
+	  "WordOfBlake",
+      "society"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-M",
   "Description": {
-    "Cost": 2086377,
+    "Cost": 2246868,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-M",
+    "Id": "mechdef_timber_wolf_TW-M",
+    "Name": "Timber Wolf TW-M",
+    "Details": "A brawler configuration, the Timber Wolf M mounts an ER PPC in each arm, supported by a pair of LRM-5s in each side torso, a Large Pulse Laser in the left torso and a Heavy Flamer in the center torso. A combined two tons of LRM missiles and a single ton of flamer ammo sit in the torsos alongside a single extra Double Heat Sink.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "simGameMechPartCost": 2086377,
+  "simGameMechPartCost": 2246868,
   "Version": 1,
   "Locations": [
     {
@@ -50,29 +70,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 81,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 81,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
@@ -86,19 +106,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -112,11 +132,65 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -137,7 +211,15 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "Heatsink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -146,7 +228,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -155,8 +237,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_hip",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -164,155 +246,151 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_hip",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_LRM_LRM5_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_LRM_LRM5_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_LRM_LRM5_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_MachineGun_MachineGun_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Flamer_Heavy_Clan",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_LRM_LRM5_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_LRM_LRM5_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -320,57 +398,25 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_HeavyFlamer",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-Z.json
+++ b/Jihad 3068-3080/mech/mechdef_timber_wolf_TW-Z.json
@@ -5,26 +5,26 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
-      "unit_role_brawler",
-      "unit_advanced",
+      "unit_lance_support",
+      "unit_role_sniper",
+      "unit_legendary",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+      "society",
+      "clancoyote"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-Z",
   "Description": {
     "Cost": 2086377,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-Z",
+    "Id": "mechdef_timber_wolf_TW-Z",
+    "Name": "Timber Wolf TW-Z",
+    "Details": "Used by The Society's MechWarriors, this version of the Timber Wolf carries twin iATM 9 missile launchers with four tons of ammunition. Each arm carries an ER Large Laser and an ER Medium Pulse Laser. To maximize its battlefield utility it also carries a Nova CEWS in the center torso.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.14</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2086377,
@@ -51,28 +51,28 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentRearArmor": 60,
       "CurrentInternalStructure": 80,
       "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedRearArmor": 60,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 190,
+      "CurrentRearArmor": 85,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 190,
+      "AssignedRearArmor": 85,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
       "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentRearArmor": 60,
       "CurrentInternalStructure": 80,
       "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedRearArmor": 60,
       "DamageLevel": "Functional"
     },
     {
@@ -114,7 +114,23 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefID": "Gear_Cockpit_CLAN_EI",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Society",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Society",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -122,7 +138,15 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_Heatsinks_5",
+      "ComponentDefID": "Gear_Nova_CEWS",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_Heatsinks_4",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -138,6 +162,15 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -155,7 +188,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_omni_lower",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -164,147 +197,106 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_hip",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_hip",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "emod_leg_foot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
+      "ComponentDefID": "Gear_HeatSink_Generic_Thermal-Exchanger-Clan",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_hip",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
-      "ComponentDefID": "emod_leg_foot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
@@ -312,7 +304,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefID": "Weapon_Laser_MediumLaserERPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -320,15 +312,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
+      "ComponentDefID": "Weapon_LRM_iATM9_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 2,
       "hasPrefabName": false,
@@ -336,7 +320,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
+      "ComponentDefID": "Weapon_LRM_iATM9_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
@@ -344,7 +328,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
@@ -352,7 +336,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefID": "Weapon_Laser_MediumLaserERPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -360,7 +344,15 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_iATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_HE_iATM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -368,8 +360,24 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_HE_iATM",
       "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Inferno_iATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Coolantflush_Clan",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"

--- a/Republic 3081-3130/chassis/chassisdef_adder_ADR-K.json
+++ b/Republic 3081-3130/chassis/chassisdef_adder_ADR-K.json
@@ -88,12 +88,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Adder",
-    "Id": "chassisdef_adder_ADR-C",
+    "Id": "chassisdef_adder_ADR-K",
     "Name": "Adder",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "Details": "The K config is equipped with a Rotary AC/2 and ton of ammunition in the right arm while the left arm carries a single ER Large Pulse Laser. Additional protection comes from a Laser Anti-Missile System.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
-  "VariantName": "ADR-C",
+  "VariantName": "ADR-K",
   "ChassisTags": {
     "items": [
       "ClanMech",
@@ -101,8 +101,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Support OmniMech",
-  "YangsThoughts": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament... And also an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.   ",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The K config is equipped with a Rotary AC/2 and ton of ammunition in the right arm while the left arm carries a single ER Large Pulse Laser. Additional protection comes from a Laser Anti-Missile System.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_adder",

--- a/Republic 3081-3130/chassis/chassisdef_timber_wolf_TW-BLO.json
+++ b/Republic 3081-3130/chassis/chassisdef_timber_wolf_TW-BLO.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-BLO",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A custom configuration used by the Blessed Order's revived First Division's Unending Faith III, the Mad Cat BLO carries a ER PPC in each arm supported by Streak SRM-6 rack in each side torso and a ER Small Laser in the center torso.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-BLO",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -94,7 +94,7 @@
     "tagSetSourceFile": ""
   },
   "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "YangsThoughts": "A custom configuration used by the Blessed Order's revived First Division's Unending Faith III, the Mad Cat BLO carries a ER PPC in each arm supported by Streak SRM-6 rack in each side torso and a ER Small Laser in the center torso.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",

--- a/Republic 3081-3130/chassis/chassisdef_timber_wolf_TW-W.json
+++ b/Republic 3081-3130/chassis/chassisdef_timber_wolf_TW-W.json
@@ -6,7 +6,7 @@
       "CustomDescription": "Omni Mech"
     },
     "DropCostFactor": {
-      "DropModifier": 1.12
+      "DropModifier": 1.17
     },
     "AssemblyVariant": {
       "PrefabID": "timberwolf",
@@ -74,18 +74,18 @@
     }
   ],
   "Description": {
-    "Cost": 10431887,
+    "Cost": 11234340,
     "Rarity": 6,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Timber Wolf",
-    "Id": "chassisdef_timber_wolf_TW-TC",
+    "Id": "chassisdef_timber_wolf_TW-W",
     "Name": "Timber Wolf",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "Details": "A brutal short-ranged combatant, the Timber Wolf W mounts a mammoth Ultra AC/20 in the right torso, supported by a Streak SRM-6 rack in each side torso, a ER Small Laser in the left torso, and twin ER Medium Lasers in the left arm. Carrying four tons of UAC rounds and single ton of missiles for the ammo efficient Streak launchers, a Supercharger allows the W config to close within optimum range as quickly as possible.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "VariantName": "TW-TC",
+  "VariantName": "TW-W",
   "ChassisTags": {
     "items": [
       "OmniMech",
@@ -93,8 +93,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Skirmisher",
-  "YangsThoughts": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.",
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "A brutal short-ranged combatant, the Timber Wolf W mounts a mammoth Ultra AC/20 in the right torso, supported by a Streak SRM-6 rack in each side torso, a ER Small Laser in the left torso, and twin ER Medium Lasers in the left arm. Carrying four tons of UAC rounds and single ton of missiles for the ammo efficient Streak launchers, a Supercharger allows the W config to close within optimum range as quickly as possible.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",

--- a/Republic 3081-3130/mech/mechdef_adder_ADR-K.json
+++ b/Republic 3081-3130/mech/mechdef_adder_ADR-K.json
@@ -7,7 +7,6 @@
       "unit_mech",
       "unit_light",
       "unit_ready",
-      "unit_indirectfire",
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_sniper",
@@ -35,17 +34,17 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_adder_ADR-C",
+  "ChassisID": "chassisdef_adder_ADR-K",
   "Description": {
     "Cost": 669810,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Adder ADR-C",
-    "Id": "mechdef_adder_ADR-C",
-    "Name": "Adder ADR-C",
-    "Details": "As a slightly lighter armed long range bombardment variant, the Adder-C 'only' sports two LRM-15 launchers as the main armament...but also has an additional launcher for NARC Homing Beacons. You can't hide anywhere if you have one of those stuck on your hull. For CQC and as a non ammo-dependent backup weapon, a single Medium Pulse Laser can absolutely ruin the day for ambushers who think the LRM support mech might be an easy kill.  \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
+    "UIName": "Adder ADR-K",
+    "Id": "mechdef_adder_ADR-K",
+    "Name": "Adder ADR-K",
+    "Details": "The K config is equipped with a Rotary AC/2 and ton of ammunition in the right arm while the left arm carries a single ER Large Pulse Laser. Additional protection comes from a Laser Anti-Missile System.   \n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>",
     "Icon": "adder"
   },
   "simGameMechPartCost": 669810,
@@ -126,8 +125,8 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -136,6 +135,68 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
@@ -158,38 +219,10 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -205,24 +238,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
@@ -303,15 +318,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_Laser_LargeLaserERPulse_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -319,81 +326,25 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_SRM_NARC_CLAN",
+      "ComponentDefID": "Weapon_Laser_AMS_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_LRM_LRM15_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Rotary_Autocannon_2_CLAN",
+      "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Narc_Beacon",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
+	{
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefID": "Ammo_Rotary_AC2",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Republic 3081-3130/mech/mechdef_timber_wolf_TW-BLO.json
+++ b/Republic 3081-3130/mech/mechdef_timber_wolf_TW-BLO.json
@@ -5,29 +5,29 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "unit_totem",
+      "comstar"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-BLO",
   "Description": {
-    "Cost": 2086377,
+    "Cost": 2246868,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-BLO",
+    "Id": "mechdef_timber_wolf_TW-BLO",
+    "Name": "Timber Wolf TW-BLO",
+    "Details": "A custom configuration used by the Blessed Order's revived First Division's Unending Faith III, the Mad Cat BLO carries a ER PPC in each arm supported by Streak SRM-6 rack in each side torso and a ER Small Laser in the center torso. Carrying two tons of Streak reloads, its combat effectiveness is enhanced by TAG in the right torso and a Light Active Probe and Inner Sphere Improved C3 Computer mounted in left torso.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "simGameMechPartCost": 2086377,
+  "simGameMechPartCost": 2246868,
   "Version": 1,
   "Locations": [
     {
@@ -41,64 +41,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 120,
+      "CurrentArmor": 105,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 120,
+      "AssignedArmor": 105,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
+      "CurrentArmor": 160,
       "CurrentRearArmor": 80,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
+      "AssignedArmor": 160,
       "AssignedRearArmor": 80,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 120,
+      "CurrentArmor": 105,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 120,
+      "AssignedArmor": 105,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 90,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 90,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 90,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 90,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -112,11 +112,97 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_LIGHT_AP_CLAN",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_C3i",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -137,73 +223,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -223,10 +242,17 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -304,22 +330,30 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Light_TAG_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
@@ -327,14 +361,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
       "ComponentDefType": "Weapon",
@@ -344,17 +370,9 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+      "ComponentDefID": "Weapon_PPCER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -362,7 +380,7 @@
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -370,7 +388,7 @@
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/Republic 3081-3130/mech/mechdef_timber_wolf_TW-W.json
+++ b/Republic 3081-3130/mech/mechdef_timber_wolf_TW-W.json
@@ -5,29 +5,34 @@
       "unit_mech",
       "unit_heavy",
       "unit_ready",
-      "unit_lance_vanguard",
+	  "unit_lance_vanguard",
+      "unit_lance_assassin",
       "unit_role_brawler",
       "unit_advanced",
       "unit_bracket_high",
-      "unit_totem",
-      "clanwolf"
+	  "clanjadefalcon",
+      "clannovacat",
+	  "clanwolf",
+	  "KellHounds",
+	  "rasalhague",
+	  "Republic"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_timber_wolf_TW-TC",
+  "ChassisID": "chassisdef_timber_wolf_TW-W",
   "Description": {
-    "Cost": 2086377,
+    "Cost": 2246868,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Timber Wolf TW-TC",
-    "Id": "mechdef_timber_wolf_TW-TC",
-    "Name": "Timber Wolf TW-TC",
-    "Details": "Recognised and feared throughout the Inner Sphere, the Timber Wolf is a 75 ton Clan OmniMech with a deadly blend of speed, armour and firepower. Powered by a 375 rated XL Engine, a combination of Ferro Fibrous and Endo Steel give the OmniMech 27.5 tons of Pod Space. The Timber Wolf TC is a Clan Wolf special designed for Tukayyid and the expectation of an extended campaign. Armed with a pair of Large Pulse Lasers and a pair of Streak SRM-6’s, the TC mounts a pair of ER Medium Lasers and an ER Small as secondary weapons. 5 Jump Jets enhance the TC’s mobility.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.12</color></b>",
+    "UIName": "Timber Wolf TW-W",
+    "Id": "mechdef_timber_wolf_TW-W",
+    "Name": "Timber Wolf TW-W",
+    "Details": "A brutal short-ranged combatant, the Timber Wolf W mounts a mammoth Ultra AC/20 in the right torso, supported by a Streak SRM-6 rack in each side torso, a ER Small Laser in the left torso, and twin ER Medium Lasers in the left arm. Carrying four tons of UAC rounds and single ton of missiles for the ammo efficient Streak launchers, a Supercharger allows the W config to close within optimum range as quickly as possible.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.17</color></b>",
     "Icon": "Timberwolf"
   },
-  "simGameMechPartCost": 2086377,
+  "simGameMechPartCost": 2246868,
   "Version": 1,
   "Locations": [
     {
@@ -50,29 +55,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 185,
-      "CurrentRearArmor": 80,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 81,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 185,
-      "AssignedRearArmor": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 81,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 65,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 65,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
@@ -86,19 +91,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 80,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -112,11 +117,74 @@
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
+	{
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_Cockpit_CLAN_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "SimGameUID": "",
+      "IsFixed": false,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_shoulder",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_part_upper",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "emod_arm_omni_lower",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -137,68 +205,9 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_shoulder",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_upper",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_JumpJet_Generic_Heavy",
-      "ComponentDefType": "JumpJet",
+      "ComponentDefID": "Gear_Supercharger",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
@@ -222,15 +231,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_omni_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftLeg",
       "ComponentDefID": "emod_leg_hip",
       "ComponentDefType": "Upgrade",
@@ -299,20 +299,28 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -322,15 +330,7 @@
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 2,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -338,21 +338,13 @@
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_SRM_SRM6_STREAK_CLAN",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+      "ComponentDefID": "Weapon_Ultra_Autocannon_20_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "hasPrefabName": false,
@@ -362,15 +354,23 @@
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 0,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Ultra_AC20_double",
       "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
+      "HardpointSlot": 1,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Ultra_AC20_double",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": 1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     }

--- a/RogueSociety/chassis/chassisdef_timber_wolf_TW-Z-A.json
+++ b/RogueSociety/chassis/chassisdef_timber_wolf_TW-Z-A.json
@@ -96,7 +96,7 @@
     "UIName": "Timber Wolf",
     "Id": "chassisdef_timber_wolf_TW-Z-A",
     "Name": "Timber Wolf",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. The Z-A is an advanced Society configuration that utilizes a pair of Light Ultra Gauss Rifles and a pair of iATM3s in addition to the Nova CEWS.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
+    "Details": "The Z-A is an advanced Society configuration that utilizes a pair of Light Ultra Gauss Rifles and a pair of iATM3s in addition to the Nova CEWS.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
     "Icon": "Timberwolf"
   },
   "VariantName": "TW-Z-A",
@@ -108,8 +108,8 @@
     ],
     "tagSetSourceFile": ""
   },
-  "StockRole": "Mad Cat",
-  "YangsThoughts": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact. The Z variant is used by Society MechWarriors.",
+  "StockRole": "Sniper",
+  "YangsThoughts": "The Z-A is an advanced Society configuration that utilizes a pair of Light Ultra Gauss Rifles and a pair of iATM3s in addition to the Nova CEWS.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -190,16 +190,24 @@
       "Location": "LeftTorso",
       "Hardpoints": [
         {
-          "Omni": true,
-          "WeaponMountID": "Energy"
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "Missile"
+          "WeaponMount": "Missile",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "AntiPersonnel"
+          "WeaponMount": "Ballistic",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "AntiPersonnel",
+          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -250,16 +258,24 @@
       "Location": "RightTorso",
       "Hardpoints": [
         {
-          "Omni": true,
-          "WeaponMountID": "Energy"
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "Missile"
+          "WeaponMount": "Missile",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "AntiPersonnel"
+          "WeaponMount": "Ballistic",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "AntiPersonnel",
+          "Omni": true
         }
       ],
       "Tonnage": 0,

--- a/RogueSociety/chassis/chassisdef_timber_wolf_TW-Z-B.json
+++ b/RogueSociety/chassis/chassisdef_timber_wolf_TW-Z-B.json
@@ -96,7 +96,7 @@
     "UIName": "Timber Wolf",
     "Id": "chassisdef_timber_wolf_TW-Z-B",
     "Name": "Timber Wolf",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. The Z-A is an advanced Society configuration that utilizes a pair of Society MRM45s, a pair of Medium Supra Lasers, and a pair of Small Supra Lasers.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
+    "Details": "The Z-B is an advanced Society configuration that utilizes a pair of Society MRM45s, a pair of Medium Supra Lasers, and a pair of Small Supra Lasers.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
     "Icon": "Timberwolf"
   },
   "VariantName": "TW-Z-B",
@@ -109,7 +109,7 @@
     "tagSetSourceFile": ""
   },
   "StockRole": "Mad Cat",
-  "YangsThoughts": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. Vaguely resembling a cross-over between the MAD (Marauder) and CAT (Catapult) series, the Timber Wolf was tagged with the Inner Sphere reporting name Mad Cat on first contact. The Z variant is used by Society MechWarriors.",
+  "YangsThoughts": "The Z-B is an advanced Society configuration that utilizes a pair of Society MRM45s, a pair of Medium Supra Lasers, and a pair of Small Supra Lasers.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_madcat",
@@ -190,16 +190,24 @@
       "Location": "LeftTorso",
       "Hardpoints": [
         {
-          "Omni": true,
-          "WeaponMountID": "Energy"
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "Missile"
+          "WeaponMount": "Missile",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "AntiPersonnel"
+          "WeaponMount": "Ballistic",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "AntiPersonnel",
+          "Omni": true
         }
       ],
       "Tonnage": 0,
@@ -250,16 +258,24 @@
       "Location": "RightTorso",
       "Hardpoints": [
         {
-          "Omni": true,
-          "WeaponMountID": "Energy"
+          "WeaponMount": "Energy",
+          "Omni": true
+        },
+		{
+          "WeaponMount": "Energy",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "Missile"
+          "WeaponMount": "Missile",
+          "Omni": true
         },
         {
-          "Omni": true,
-          "WeaponMountID": "AntiPersonnel"
+          "WeaponMount": "Ballistic",
+          "Omni": true
+        },
+        {
+          "WeaponMount": "AntiPersonnel",
+          "Omni": true
         }
       ],
       "Tonnage": 0,

--- a/RogueSociety/mech/mechdef_timber_wolf_TW-Z-A.json
+++ b/RogueSociety/mech/mechdef_timber_wolf_TW-Z-A.json
@@ -27,7 +27,7 @@
     "UIName": "Timber Wolf TW-Z-A",
     "Id": "mechdef_timber_wolf_TW-Z-A",
     "Name": "Timber Wolf TW-Z-A",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. The Z-A is an advanced Society configuration that utilizes a pair of Light Ultra Gauss Rifles and a pair of iATM3s in addition to the Nova CEWS.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
+    "Details": "The Z-A is an advanced Society configuration that utilizes a pair of Light Ultra Gauss Rifles and a pair of iATM3s in addition to the Nova CEWS.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2648094,

--- a/RogueSociety/mech/mechdef_timber_wolf_TW-Z-B.json
+++ b/RogueSociety/mech/mechdef_timber_wolf_TW-Z-B.json
@@ -26,7 +26,7 @@
     "UIName": "Timber Wolf TW-Z-B",
     "Id": "mechdef_timber_wolf_TW-Z-B",
     "Name": "Timber Wolf TW-Z-B",
-    "Details": "The Timber Wolf is a fast, heavy OmniMech. A signature design of the Clans' military might, it was arguably the first Clan OmniMech encountered by Inner Sphere forces on The Rock by Phelan Kell. The Z-A is an advanced Society configuration that utilizes a pair of Society MRM45s, a pair of Medium Supra Lasers, and a pair of Small Supra Lasers.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
+    "Details": "The Z-B is an advanced Society configuration that utilizes a pair of Society MRM45s, a pair of Medium Supra Lasers, and a pair of Small Supra Lasers.\n\n<b><color=#e62e00>Quirk: Improved Targeting - Medium</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.2</color></b>",
     "Icon": "Timberwolf"
   },
   "simGameMechPartCost": 2648094,


### PR DESCRIPTION
Timber Wolf-BLO - Added
Timber Wolf-W - Added
Timber Wolf-N - Added
Timber Wolf-M - Added
Timber Wolf-T - Added
Timber Wolf-S - Added
Timber Wolf-Bounty Hunter - Added
Timber Wolf-Bounty Hunter 2 - Added
Timber Wolf-A - Removed one extra heat sink per record sheet, minor adjustment to armor to balance weight difference, adjusted stock role text per MUL.
Timber Wolf-C - Swapped laser ams for normal ams with ammo per record sheet
Timber Wolf-D - Replaced one spare heat sink with an extra ton of SRM ammo per record sheet
Timber Wolf-E - Removed CASE II from both side torsos, removed ER medium lasers from both arms, added two tons of ATM ammo to reflect record sheet
Timber Wolf F - Changed engine HS from +4 to +5 and moved externals to arms, removed ECM from head, added ER medium laser to LT, removed spare two tons of LRM ammo to bring in line to record sheet.  Left in exchanger and coolant flush because mech is hot hot hot!
Timber Wolf-H - Minor text change.
Timber Wolf-Prime - Removed two half MG ammo boxes and added single ton in RT, removed one ton of LRM ammo in each side torso, added MG in CT, added DHS in each arm per record sheet.  Changed stock role text per MUL.
Timber Wolf-TC - Moved Jump Jets from legs to side torsos per record sheet.
Timber Wolf-Pryde - Moved ER medium lasers from side torsos to arms, moved one pair of JJs from legs to side torsos, added heatsink to LA and adjusted armor for the weight as it was too high anyway per record sheets.