### PR TITLE
7 new tanks

### DIFF
--- a/Base 3061/vehicle/heavy/vehicledef_TYPHOON_TRACKED.json
+++ b/Base 3061/vehicle/heavy/vehicledef_TYPHOON_TRACKED.json
@@ -1,0 +1,287 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-2.12",
+            "unit_vehicle",
+            "unit_heavy",
+            "unit_tracks",
+            "unit_release",
+            "unit_bracket_high",
+            "unit_lance_tank",
+            "unit_advanced",
+            "unit_predator",
+            "unit_solaris",
+            "Republic",
+            "davion",
+            "steiner",
+            "locals",
+            "auriganmercenaries",
+            "LocalsBrockwayRefugees",
+            "MasonsMarauders",
+            "SteelBeast",
+            "KellHounds",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "RedHareRegiment",
+            "SecuritySolutionsInc",
+            "PaladinProtectionLLC",
+            "BlackWidowCompany",
+            "BaumannGroup",
+            "BountyHunterAssociates",
+            "Solaris7"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_TYPHOON_TRACKED",
+    "Description": {
+        "Cost": 6381243,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Typhoon Urban Combat Vehicle",
+        "Id": "vehicledef_TYPHOON_TRACKED",
+        "Name": "Typhoon Urban Combat Vehicle",
+        "Details": "Slower than the Medium Tank, but possessing heavier armor and fire power, the Heavy Tank is a fearsome combatant. Trading speed or weapons for armor, the Heavy Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       236     35\n<b>Left</b>         200     35\n<b>Right</b>       200     35\n<b>Rear</b>        160     35\n<b>Turret</b>      220     35\n\n<b>Total</b>      1016    175\n",
+        "Icon": "Typhoon"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 236,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 236,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 200,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 200,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 200,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 200,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 160,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 160,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 220,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 220,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Weapon_Laser_SmallLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Autocannon_AC20_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM2_STREAK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM6_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC20",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_BeagleActiveProbe",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_ferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_190",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_TYPHOON_TRACKED.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_TYPHOON_TRACKED.json
@@ -1,0 +1,156 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Typhoon",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "Description": {
+    "Cost": 6381243,
+    "Rarity": 0,
+    "Purchasable": false,
+    "UIName": "Typhoon Urban Combat Vehicle",
+    "Id": "vehiclechassisdef_TYPHOON_TRACKED",
+    "Name": "Typhoon",
+    "Details": "Slower than the Medium Tank, but possessing heavier armor and fire power, the Heavy Tank is a fearsome combatant. Trading speed or weapons for armor, the Heavy Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       236     35\n<b>Left</b>         200     35\n<b>Right</b>       200     35\n<b>Rear</b>        160     35\n<b>Turret</b>      220     35\n\n<b>Total</b>      1016    175\n",
+    "Icon": "Typhoon"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_3-5cv",
+  "movementType": "Tracked",
+  "PathingCapDefID": "pathingdef_heavy_tracked",
+  "HardpointDataDefID": "hardpointdatadef_chevalier",
+  "PrefabIdentifier": "chrprfvhcl_chevalier",
+  "PrefabBase": "chevalier",
+  "Tonnage": 70,
+  "weightClass": "HEAVY",
+  "BattleValue": 993,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 4,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "z": 3
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "z": 3
+    },
+    {
+      "x": -3,
+      "y": 1.5,
+      "z": 0
+    },
+    {
+      "x": 3,
+      "y": 1.5,
+      "z": 0
+    },
+    {
+      "x": 0,
+      "y": 3,
+      "z": -4
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 236,
+      "InternalStructure": 35
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 200,
+      "InternalStructure": 35
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 200,
+      "InternalStructure": 35
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 160,
+      "InternalStructure": 35
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 220,
+      "InternalStructure": 35
+    }
+  ]
+}

--- a/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA.json
+++ b/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA.json
@@ -9,6 +9,7 @@
       "unit_bracket_low",
       "unit_advanced",
       "unit_noconvoy",
+      "unit_predator",
       "WordOfBlake",
       "Republic",
       "comstar",

--- a/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA_LRM.json
+++ b/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA_LRM.json
@@ -1,0 +1,183 @@
+{
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_support",
+            "unit_bracket_low",
+            "unit_generic",
+            "unit_noconvoy",
+            "unit_indirectfire",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "aurigandirectorate",
+            "auriganpirates",
+            "auriganrestoration",
+            "castile",
+            "circinus",
+            "elysia",
+            "hanse",
+            "illyrian",
+            "locals",
+            "LocalsBrockwayRefugees",
+            "lothian",
+            "marian",
+            "magistracyofcanopus",
+            "magistracycentrella",
+            "oberon",
+            "outworld",
+            "SelfEmployed",
+            "taurianconcordat",
+            "tortuga",
+            "valkyrate",
+            "nautilus",
+            "auriganmercenaries",
+            "mercenaryreviewboard",
+            "MajestyMetals",
+            "Marauders",
+            "MasonsMarauders",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "KellHounds",
+            "SteelBeast",
+            "FlakJackals",
+            "Solaris7"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_ROTUNDA_LRM",
+    "Description": {
+        "Cost": 246033,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Rotunda Recon Vehicle (LRM)",
+        "Id": "vehicledef_ROTUNDA_LRM",
+        "Name": "Rotunda Recon Vehicle (LRM)",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Carrying an array of ranged weapons, the Light Tank is designed to support allied units from range.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        45     10\n<b>Left</b>          35     10\n<b>Right</b>        35     10\n<b>Rear</b>         11     10\n<b>Turret</b>       35     10\n\n<b>Total</b>      161     50\n",
+        "Icon": "Rotunda"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 45,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 45,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 45,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 45,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 45,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 45,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 25,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 25,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_ferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_140",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA_RL.json
+++ b/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA_RL.json
@@ -112,21 +112,21 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Weapon_LRM_ROCKETTANDEM15",
+      "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 3,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_LRM_INFERNOLAUNCHER15",
+      "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 2,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_LRM_ROCKETTANDEM15",
+      "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 4,
       "DamageLevel": "Functional"

--- a/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA_SRM.json
+++ b/Base UrbanWarfare/vehicle/vehicledef_ROTUNDA_SRM.json
@@ -1,0 +1,197 @@
+{
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_release",
+            "unit_lance_support",
+            "unit_bracket_low",
+            "unit_generic",
+            "unit_noconvoy",
+            "unit_indirectfire",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "aurigandirectorate",
+            "auriganpirates",
+            "auriganrestoration",
+            "castile",
+            "circinus",
+            "elysia",
+            "hanse",
+            "illyrian",
+            "locals",
+            "LocalsBrockwayRefugees",
+            "lothian",
+            "marian",
+            "magistracyofcanopus",
+            "magistracycentrella",
+            "oberon",
+            "outworld",
+            "SelfEmployed",
+            "taurianconcordat",
+            "tortuga",
+            "valkyrate",
+            "nautilus",
+            "auriganmercenaries",
+            "mercenaryreviewboard",
+            "MajestyMetals",
+            "Marauders",
+            "MasonsMarauders",
+            "RazorbackMercs",
+            "HostileMercenaries",
+            "KellHounds",
+            "SteelBeast",
+            "FlakJackals",
+            "Solaris7"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_ROTUNDA_SRM",
+    "Description": {
+        "Cost": 246033,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Rotunda Recon Vehicle (SRM)",
+        "Id": "vehicledef_ROTUNDA_SRM",
+        "Name": "Rotunda Recon Vehicle (SRM)",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Carrying an array of ranged weapons, the Light Tank is designed to support allied units from range.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        45     10\n<b>Left</b>          35     10\n<b>Right</b>        35     10\n<b>Rear</b>         11     10\n<b>Turret</b>       35     10\n\n<b>Total</b>      161     50\n",
+        "Icon": "Rotunda"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 45,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 45,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 45,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 45,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 45,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 45,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 25,
+            "CurrentInternalStructure": 10,
+            "AssignedArmor": 25,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_ferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_140",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base UrbanWarfare/vehicleChassis/vehiclechassisdef_ROTUNDA_LRM.json
+++ b/Base UrbanWarfare/vehicleChassis/vehiclechassisdef_ROTUNDA_LRM.json
@@ -1,0 +1,118 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Rotunda",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "Description": {
+        "Cost": 246033,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Rotunda Recon Vehicle (LRM)",
+        "Id": "vehiclechassisdef_ROTUNDA_LRM",
+        "Name": "Rotunda",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Carrying an array of ranged weapons, the Light Tank is designed to support allied units from range.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        45     10\n<b>Left</b>          35     10\n<b>Right</b>        35     10\n<b>Rear</b>         11     10\n<b>Turret</b>       35     10\n\n<b>Total</b>      161     50\n",
+        "Icon": "Rotunda"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_8-12cv",
+    "movementType": "Wheeled",
+    "PathingCapDefID": "pathingdef_light_wheeled",
+    "HardpointDataDefID": "hardpointdatadef_rotunda",
+    "PrefabIdentifier": "chrPrfVhcl_rotunda",
+    "PrefabBase": "rotunda",
+    "Tonnage": 20,
+    "weightClass": "LIGHT",
+    "BattleValue": 564,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 3,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3.5
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3.5
+        },
+        {
+            "x": -1.5,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 1.5,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 2.25,
+            "z": -2.75
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 45,
+            "InternalStructure": 10
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 35,
+            "InternalStructure": 10
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 35,
+            "InternalStructure": 10
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 25,
+            "InternalStructure": 10
+        }
+    ]
+}

--- a/Base UrbanWarfare/vehicleChassis/vehiclechassisdef_ROTUNDA_SRM.json
+++ b/Base UrbanWarfare/vehicleChassis/vehiclechassisdef_ROTUNDA_SRM.json
@@ -1,0 +1,126 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Rotunda",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "Description": {
+        "Cost": 246033,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Rotunda Recon Vehicle (SRM)",
+        "Id": "vehiclechassisdef_ROTUNDA_SRM",
+        "Name": "Rotunda",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Carrying an array of ranged weapons, the Light Tank is designed to support allied units from range.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        45     10\n<b>Left</b>          35     10\n<b>Right</b>        35     10\n<b>Rear</b>         11     10\n<b>Turret</b>       35     10\n\n<b>Total</b>      161     50\n",
+        "Icon": "Rotunda"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_8-12cv",
+    "movementType": "Wheeled",
+    "PathingCapDefID": "pathingdef_light_wheeled",
+    "HardpointDataDefID": "hardpointdatadef_rotunda",
+    "PrefabIdentifier": "chrPrfVhcl_rotunda",
+    "PrefabBase": "rotunda",
+    "Tonnage": 20,
+    "weightClass": "LIGHT",
+    "BattleValue": 564,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 3,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3.5
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3.5
+        },
+        {
+            "x": -1.5,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 1.5,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 2.25,
+            "z": -2.75
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 45,
+            "InternalStructure": 10
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 35,
+            "InternalStructure": 10
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 35,
+            "InternalStructure": 10
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 25,
+            "InternalStructure": 10
+        }
+    ]
+}

--- a/DynamicShops/data/RT_Davion_AlliedTanks.csv
+++ b/DynamicShops/data/RT_Davion_AlliedTanks.csv
@@ -29,6 +29,7 @@ vehicledef_MANTICORE_3055,Mech,1,4
 vehicledef_MANTICORE_LBX,Mech,1,4
 vehicledef_CHALLENGER_X,Mech,1,2
 vehicledef_TYPHOON,Mech,1,4
+vehicledef_TYPHOON_TRACKED,Mech,1,4
 vehicledef_FULCRUM_1,Mech,1,7
 vehicledef_PARTISAN_AAA,Mech,1,2
 vehicledef_PARTISAN_AAA_XL,Mech,1,2

--- a/DynamicShops/data/RT_Steiner_AlliedTanks.csv
+++ b/DynamicShops/data/RT_Steiner_AlliedTanks.csv
@@ -29,6 +29,7 @@ vehicledef_MANTICORE_3055,Mech,1,4
 vehicledef_MANTICORE_LBX,Mech,1,4
 vehicledef_CHALLENGER_X,Mech,1,2
 vehicledef_TYPHOON,Mech,1,4
+vehicledef_TYPHOON_TRACKED,Mech,1,4
 vehicledef_FULCRUM_1,Mech,1,7
 vehicledef_PARTISAN_AAA,Mech,1,2
 vehicledef_PEGASUS_3058,Mech,1,7

--- a/Jihad 3068-3080/vehicle/vehicledef_AJAX_D.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_AJAX_D.json
@@ -1,0 +1,281 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.59",
+            "unit_vehicle",
+            "omni_tank",
+            "unit_assault",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_assassin",
+            "unit_indirectfire",
+            "unit_lance_support",
+            "unit_arrow",
+            "unit_advanced",
+            "unit_bracket_high",
+            "Republic",
+            "comstar",
+            "davion"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_AJAX_D",
+    "Description": {
+        "Cost": 27263813,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Ajax D",
+        "Id": "vehicledef_AJAX_D",
+        "Name": "Ajax D",
+        "Details": "A monster of a unit, these heavily armed vehicles are the epitome of the Tank.  Line breakers and fire support platforms, these are usually found in the front of an attack. Trading speed or weapons for armor, the Assault Tank is almost impossible to kill.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       362     45\n<b>Left</b>         300     45\n<b>Right</b>       300     45\n<b>Rear</b>        220     45\n<b>Turret</b>      350     45\n\n<b>Total</b>      1532    225\n",
+        "Icon": "Ajax"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 380,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 380,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 300,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 300,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 300,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 300,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 200,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 200,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 340,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 340,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_MachineGun_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 3,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Weapon_MachineGun_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Weapon_MachineGun_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Weapon_MachineGun_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Artillery_ArrowIV",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LMG_half",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_ArrowIV",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_ArrowIV",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Guided_ArrowIV",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_CargoCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_FCS_ARTIV",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_Tank_DroneController",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CommunicationsEquipment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_CASE",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_270",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_xl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_AJAX_SEALED.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_AJAX_SEALED.json
@@ -1,0 +1,307 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.59",
+            "unit_vehicle",
+            "omni_tank",
+            "unit_assault",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_tank",
+            "unit_lance_assassin",
+            "unit_predator",
+            "unit_advanced",
+            "unit_bracket_high",
+            "Republic",
+            "davion"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_SEALED",
+    "Description": {
+        "Cost": 27263813,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Ajax (Sealed)",
+        "Id": "vehicledef_AJAX_SEALED",
+        "Name": "Ajax (Sealed)",
+        "Details": "A monster of a unit, these heavily armed vehicles are the epitome of the Tank.  Line breakers and fire support platforms, these are usually found in the front of an attack. Trading speed or weapons for armor, the Assault Tank is almost impossible to kill.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       362     45\n<b>Left</b>         300     45\n<b>Right</b>       300     45\n<b>Rear</b>        220     45\n<b>Turret</b>      350     45\n\n<b>Total</b>      1532    225\n",
+        "Icon": "Ajax"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 380,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 380,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 300,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 300,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 300,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 300,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 200,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 200,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 340,
+            "CurrentInternalStructure": 45,
+            "AssignedArmor": 340,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM6_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_MML_9",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_LargeLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM_double",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_EnviroSealing",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_C3",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_CASE",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_270",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_xl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicle/vehicledef_MANTICORE_HPPC.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_MANTICORE_HPPC.json
@@ -1,0 +1,257 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_heavy",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_tank",
+            "unit_lance_assassin",
+            "unit_advanced",
+            "unit_bracket_med",
+            "Republic",
+            "kurita",
+            "davion"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_MANTICORE_HPPC",
+    "Description": {
+        "Cost": 2780800,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Manticore Heavy Tank (HPPC)",
+        "Id": "vehicledef_MANTICORE_HPPC",
+        "Name": "Manticore Heavy Tank (HPPC)",
+        "Details": "Slower than the Medium Tank, but possessing heavier armor and fire power, the Heavy Tank is a fearsome combatant. Trading speed or weapons for armor, the Heavy Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       230     30\n<b>Left</b>         165     30\n<b>Right</b>       165     30\n<b>Rear</b>        130     30\n<b>Turret</b>      210     30\n\n<b>Total</b>      900    150\n",
+        "Icon": "Manticore"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 215,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 215,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 170,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 170,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 170,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 170,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 130,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 130,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 210,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 210,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_AMS",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_HEAVY",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_MML_7",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_AntiMissile",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_RCA_InstaTrac-XII",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Hartford_S2000",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_FCS_AdvancedTC",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_240",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_light_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_AJAX_D.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_AJAX_D.json
@@ -1,0 +1,160 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Ajax",
+            "Exclude": false,
+            "Include": true
+        },
+        "CustomWeights": [
+            {
+                "ComponentDefID": "Tank_InfantryCompartment",
+                "Tonnage": 4
+            },
+            {
+                "ComponentDefID": "Tank_CargoCompartment",
+                "Tonnage": 7
+            }
+        ]
+    },
+    "Description": {
+        "Cost": 27263813,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Ajax Assault Tank - D",
+        "Id": "vehiclechassisdef_AJAX_D",
+        "Name": "Ajax",
+        "Details": "A monster of a unit, these heavily armed vehicles are the epitome of the Tank.  Line breakers and fire support platforms, these are usually found in the front of an attack. Trading speed or weapons for armor, the Assault Tank is almost impossible to kill.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       362     45\n<b>Left</b>         300     45\n<b>Right</b>       300     45\n<b>Rear</b>        220     45\n<b>Turret</b>      350     45\n\n<b>Total</b>      1532    225\n",
+        "Icon": "Ajax"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_3-5cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_assault_tracked",
+    "HardpointDataDefID": "hardpointdatadef_challenger",
+    "PrefabIdentifier": "chrprfvhcl_challengerbase",
+    "PrefabBase": "challenger",
+    "Tonnage": 90,
+    "weightClass": "ASSAULT",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        },
+        {
+            "x": -3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 3,
+            "z": -4
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Ballistic",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 362,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Ballistic",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 300,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Ballistic",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 300,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Ballistic",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 220,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 350,
+            "InternalStructure": 45
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_AJAX_SEALED.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_AJAX_SEALED.json
@@ -1,0 +1,138 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Ajax",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "Description": {
+        "Cost": 27263813,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Ajax Assault Tank (Sealed)",
+        "Id": "vehiclechassisdef_AJAX_SEALED",
+        "Name": "Ajax",
+        "Details": "A monster of a unit, these heavily armed vehicles are the epitome of the Tank.  Line breakers and fire support platforms, these are usually found in the front of an attack. Trading speed or weapons for armor, the Assault Tank is almost impossible to kill.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       362     45\n<b>Left</b>         300     45\n<b>Right</b>       300     45\n<b>Rear</b>        220     45\n<b>Turret</b>      350     45\n\n<b>Total</b>      1532    225\n",
+        "Icon": "Ajax"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_3-5cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_assault_tracked",
+    "HardpointDataDefID": "hardpointdatadef_challenger",
+    "PrefabIdentifier": "chrprfvhcl_challengerbase",
+    "PrefabBase": "challenger",
+    "Tonnage": 90,
+    "weightClass": "ASSAULT",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        },
+        {
+            "x": -3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 3,
+            "z": -4
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 362,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 300,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 300,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 220,
+            "InternalStructure": 45
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 350,
+            "InternalStructure": 45
+        }
+    ]
+}

--- a/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_MANTICORE_HPPC.json
+++ b/Jihad 3068-3080/vehicleChassis/vehiclechassisdef_MANTICORE_HPPC.json
@@ -1,0 +1,130 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Manticore",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "Description": {
+        "Cost": 2780800,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Manticore Heavy Tank (HPPC)",
+        "Id": "vehiclechassisdef_MANTICORE_HPPC",
+        "Name": "Manticore",
+        "Details": "Slower than the Medium Tank, but possessing heavier armor and fire power, the Heavy Tank is a fearsome combatant. Trading speed or weapons for armor, the Heavy Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       230     30\n<b>Left</b>         165     30\n<b>Right</b>       165     30\n<b>Rear</b>        130     30\n<b>Turret</b>      210     30\n\n<b>Total</b>      900    150\n",
+        "Icon": "Manticore"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_4-6cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_heavy_tracked",
+    "HardpointDataDefID": "hardpointdatadef_manticore",
+    "PrefabIdentifier": "chrPrfVhcl_manticore",
+    "PrefabBase": "manticore",
+    "Tonnage": 60,
+    "weightClass": "HEAVY",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        },
+        {
+            "x": -3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 3,
+            "z": -4
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 230,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 165,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 165,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 130,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "AntiPersonnel",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 210,
+            "InternalStructure": 30
+        }
+    ]
+}

--- a/Jihad Unique/vehicle/vehicledef_SCHREK_II-X.json
+++ b/Jihad Unique/vehicle/vehicledef_SCHREK_II-X.json
@@ -1,0 +1,486 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_assault",
+            "unit_tracks",
+            "unit_lance_support",
+            "unit_lance_assassin",
+            "unit_advanced",
+            "unit_bracket_high",
+            "unit_legendary",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_SCHREK_II-X",
+    "Description": {
+        "Cost": 18788250,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Schrek II-X",
+        "Id": "vehicledef_SCHREK_II-X",
+        "Name": "Schrek II-X",
+        "Details": "Developed by the New Earth Trading Company in 2587, the Alacorn has developed a reputation as an effective and dependable tank. The design is popular with mercenary units and minor powers who can't afford BattleMechs, because of its heavy offensive weaponry and thirteen tons of armor; however, this payload is only possible through the use of an expensive and fragile 285 XL Engine. The three turret-mounted  Gauss Rifles allow the Alacorn to unleash devastating barrages at range, with five tons of reloads offering excellent endurance in combat.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       270     50\n<b>Left</b>         205     50\n<b>Right</b>       205     50\n<b>Rear</b>        140     50\n<b>Turret</b>      260     50\n\n<b>Total</b>      1080    250\n",
+        "Icon": "Schrek"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 175,
+            "CurrentInternalStructure": 50,
+            "AssignedArmor": 175,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 170,
+            "CurrentInternalStructure": 50,
+            "AssignedArmor": 170,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 170,
+            "CurrentInternalStructure": 50,
+            "AssignedArmor": 170,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 165,
+            "CurrentInternalStructure": 50,
+            "AssignedArmor": 165,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 160,
+            "CurrentInternalStructure": 50,
+            "AssignedArmor": 160,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_LIGHT",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_PPC_Capacitator",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Gunnery",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_RCA_InstaTrac-XII",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_LongRange",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_MedRange",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_CargoCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_FCS_AdvancedTC",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_heavyferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_285",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "emod_engineslots_size6",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "emod_engineslots_size6",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_xxl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Jihad Unique/vehicleChassis/vehiclechassisdef_SCHREK_II-X.json
+++ b/Jihad Unique/vehicleChassis/vehiclechassisdef_SCHREK_II-X.json
@@ -1,0 +1,148 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "SchrekII",
+            "Exclude": false,
+            "Include": true
+        },
+        "CustomWeights": [
+            {
+                "ComponentDefID": "Tank_CargoCompartment",
+                "Tonnage": 2
+            }
+        ]
+    },
+    "Description": {
+        "Cost": 18788250,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Schrek II-X",
+        "Id": "vehiclechassisdef_SCHREK_II-X",
+        "Name": "Schrek",
+        "Details": "Developed by the New Earth Trading Company in 2587, the Alacorn has developed a reputation as an effective and dependable tank. The design is popular with mercenary units and minor powers who can't afford BattleMechs, because of its heavy offensive weaponry and thirteen tons of armor; however, this payload is only possible through the use of an expensive and fragile 285 XL Engine. The three turret-mounted  Gauss Rifles allow the Alacorn to unleash devastating barrages at range, with five tons of reloads offering excellent endurance in combat.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       270     50\n<b>Left</b>         205     50\n<b>Right</b>       205     50\n<b>Rear</b>        140     50\n<b>Turret</b>      260     50\n\n<b>Total</b>      1080    250\n",
+        "Icon": "Schrek"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_3-5cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_assault_tracked",
+    "HardpointDataDefID": "hardpointdatadef_schreck",
+    "PrefabIdentifier": "chrPrfVhcl_schreck",
+    "PrefabBase": "schreck",
+    "Tonnage": 95,
+    "weightClass": "ASSAULT",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": 4
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": 4
+        },
+        {
+            "x": -2,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 2,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": -4.5
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 270,
+            "InternalStructure": 50
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 205,
+            "InternalStructure": 50
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 205,
+            "InternalStructure": 50
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 140,
+            "InternalStructure": 50
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 260,
+            "InternalStructure": 50
+        }
+    ]
+}


### PR DESCRIPTION
Added 7 new tanks from various eras of BT. Added Typhoon (Tracked), 2 Rotunda variants, 2 Ajax variants, a Manticore variant and the Schrek II-X