### PR TITLE
Added missile hardpoint to Sling 1H so quirk is useful.

### DIFF
--- a/Base 3061/chassis/chassisdef_sling_SL-1H.json
+++ b/Base 3061/chassis/chassisdef_sling_SL-1H.json
@@ -123,10 +123,6 @@
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
           "WeaponMountID": "Special",
           "Omni": false
         },
@@ -151,7 +147,12 @@
     },
     {
       "Location": "RightTorso",
-      "Hardpoints": [],
+      "Hardpoints": [
+	    {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+	  ],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 60,


### PR DESCRIPTION
Sling 1H had chassis quirk for accurate missiles but no missile hardpoints.

Added a missile hardpoint to the chassis to allow it to use chassis quirk and removed CT antipersonnel hardpoint to get under HP limit.