### PR TITLE
Remove a bunch of legacy fluff text

### DIFF
--- a/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB10_Deadfire_Quicsell.json
+++ b/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB10_Deadfire_Quicsell.json
@@ -45,7 +45,7 @@
         "UIName": "Ammo TBM 10 Deadfire QS",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB10_Deadfire_Quicsell",
         "Name": "Thunderbolt 10 Ammo",
-        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB15_Deadfire_Quicsell.json
+++ b/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB15_Deadfire_Quicsell.json
@@ -45,7 +45,7 @@
         "UIName": "Ammo TBM 15 Deadfire QS",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB15_Deadfire_Quicsell",
         "Name": "Thunderbolt 15 Ammo",
-        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB20_Deadfire_Quicsell.json
+++ b/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB20_Deadfire_Quicsell.json
@@ -45,7 +45,7 @@
         "UIName": "Ammo TBM 20 Deadfire QS",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB20_Deadfire_Quicsell",
         "Name": "Thunderbolt 20 Ammo",
-        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB5_Deadfire_Quicsell.json
+++ b/Quicsell Module/AmmunitionBox/Ammo_AmmunitionBox_Thunderbolt_TB5_Deadfire_Quicsell.json
@@ -45,7 +45,7 @@
         "UIName": "Ammo TBM 5 Deadfire QS",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB5_Deadfire_Quicsell",
         "Name": "Thunderbolt 5 Ammo",
-        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Why waste space on rarely used rocket fuel, when you can have more booms? Try Quicsell exclusive Deadfire Thunderbolt ammo today! Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueModuleTech/ProtoMech/Ammo/Ammo_AmmunitionBox_Generic_MG_20shot.json
+++ b/RogueModuleTech/ProtoMech/Ammo/Ammo_AmmunitionBox_Generic_MG_20shot.json
@@ -18,10 +18,10 @@
 				"MGAmmo: 20",
          "AmmoCost: 10"
             ]
-        },		
+        },
 		"AmmoCost" : {
       "PerUnitCost" : 10
-		},		
+		},
         "InventorySorter": {
             "SortKey": "000032"
         }
@@ -37,7 +37,7 @@
         "UIName": "Ammo MG (20 rounds)",
         "Id": "Ammo_AmmunitionBox_Generic_MG_20shot",
         "Name": "MG Ammo (20 rounds)",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "MachineGun"
     },
     "BonusValueA": "",

--- a/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile.json
+++ b/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile.json
@@ -17,7 +17,7 @@
 				"AMSAmmo: 200",
 				"AmmoCost: 5"
             ]
-        },		
+        },
 		"AmmoCost" : {
       "PerUnitCost" : 5
 		},
@@ -36,7 +36,7 @@
         "UIName": "Ammo AMS",
         "Id": "Ammo_AmmunitionBox_AntiMissile",
         "Name": "AMS Ammo",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "AMS"
     },
     "BonusValueA": "",

--- a/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_Caseless.json
+++ b/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_Caseless.json
@@ -23,7 +23,7 @@
 				"VolatileAmmo",
 				"AmmoCost: 6"
             ]
-        },		
+        },
 		"AmmoCost" : {
       "PerUnitCost" : 6
 		},
@@ -42,7 +42,7 @@
         "UIName": "Ammo AMS [CL]",
         "Id": "Ammo_AmmunitionBox_AntiMissile_Caseless",
         "Name": "AMS Ammo",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "AMS"
     },
     "BonusValueA": "",

--- a/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_HE.json
+++ b/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_HE.json
@@ -22,7 +22,7 @@
 				"VolatileAmmo",
 				"AmmoCost: 10"
             ]
-        },		
+        },
 		"AmmoCost" : {
       "PerUnitCost" : 10
 		},
@@ -41,7 +41,7 @@
         "UIName": "Ammo AMS HE",
         "Id": "Ammo_AmmunitionBox_AntiMissile_HE",
         "Name": "AMS Ammo",
-        "Details": "HE AMS Shells are an adaption of old time flak shells, firing time delayed explosive into the path of incoming Missiles. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "HE AMS Shells are an adaption of old time flak shells, firing time delayed explosive into the path of incoming Missiles. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "AMS"
     },
     "BonusValueA": "",

--- a/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_double.json
+++ b/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_double.json
@@ -37,7 +37,7 @@
         "UIName": "Ammo AMS [DBL]",
         "Id": "Ammo_AmmunitionBox_AntiMissile_double",
         "Name": "AMS Ammo",
-        "Details": "Doubled Ammo Bins replace one ammo bins feeding and storing mechanism to 25% more shots into one location. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Doubled Ammo Bins replace one ammo bins feeding and storing mechanism to 25% more shots into one location. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "AMS"
     },
     "BonusValueA": "",

--- a/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_half.json
+++ b/RogueMunitions/AMS/Ammo_AmmunitionBox_AntiMissile_half.json
@@ -20,7 +20,7 @@
         },
 "AmmoCost" : {
       "PerUnitCost" : 5
-		},		
+		},
         "InventorySorter": {
             "SortKey": "000032"
         }
@@ -36,7 +36,7 @@
         "UIName": "Ammo AMS [Half]",
         "Id": "Ammo_AmmunitionBox_AntiMissile_half",
         "Name": "AMS Ammo Half Load",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "AMS"
     },
     "BonusValueA": "",

--- a/RogueMunitions/MG/Ammo_AmmunitionBox_Generic_MG.json
+++ b/RogueMunitions/MG/Ammo_AmmunitionBox_Generic_MG.json
@@ -22,7 +22,7 @@
     },
 	"AmmoCost" : {
       "PerUnitCost" : 10
-    },	
+    },
         "InventorySorter": {
             "SortKey": "000032"
         }
@@ -38,7 +38,7 @@
         "UIName": "Ammo MG",
         "Id": "Ammo_AmmunitionBox_Generic_MG",
         "Name": "MG Ammo",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "MachineGun"
     },
     "BonusValueA": "",

--- a/RogueMunitions/MG/Ammo_AmmunitionBox_Generic_MG_double.json
+++ b/RogueMunitions/MG/Ammo_AmmunitionBox_Generic_MG_double.json
@@ -23,7 +23,7 @@
     },
 	"AmmoCost" : {
       "PerUnitCost" : 10
-    },	
+    },
         "InventorySorter": {
             "SortKey": "000032"
         }
@@ -39,7 +39,7 @@
         "UIName": "Ammo MG [DBL]",
         "Id": "Ammo_AmmunitionBox_Generic_MG_double",
         "Name": "MG Ammo",
-        "Details": "Doubled Ammo Bins replace one ammo bins feeding and storing mechanism to 25% more shots into one location. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Doubled Ammo Bins replace one ammo bins feeding and storing mechanism to 25% more shots into one location. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "MachineGun"
     },
     "BonusValueA": "",

--- a/RogueMunitions/MG/Ammo_AmmunitionBox_Generic_MG_half.json
+++ b/RogueMunitions/MG/Ammo_AmmunitionBox_Generic_MG_half.json
@@ -38,7 +38,7 @@
         "UIName": "Ammo MG [Half]",
         "Id": "Ammo_AmmunitionBox_Generic_MG_half",
         "Name": "MG Ammo Half Load",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "MachineGun"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10.json
@@ -39,7 +39,7 @@
         "UIName": "Ammo TBM 10",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB10",
         "Name": "Thunderbolt 10 Ammo",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_Feint.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_Feint.json
@@ -41,7 +41,7 @@
         "UIName": "Ammo TBM10 Feint",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB10_Feint",
         "Name": "Thunderbolt 10 Ammo",
-        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_Kinetic.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB10_Kinetic.json
@@ -46,7 +46,7 @@
         "UIName": "Ammo TBM 10 Kinetic Kill",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB10_Kinetic",
         "Name": "Thunderbolt 10 Ammo",
-        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_Feint.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_Feint.json
@@ -41,7 +41,7 @@
         "UIName": "Ammo TBM 15 Feint",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB15_Feint",
         "Name": "Thunderbolt 15 Ammo",
-        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments on just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments on just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_Kinetic.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB15_Kinetic.json
@@ -46,7 +46,7 @@
         "UIName": "Ammo TBM 15 Kinetic Kill",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB15_Kinetic",
         "Name": "Thunderbolt 15 Ammo",
-        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_Feint.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_Feint.json
@@ -41,7 +41,7 @@
         "UIName": "Ammo TBM 20 Feint",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB20_Feint",
         "Name": "Thunderbolt 20 Ammo",
-        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_Kinetic.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB20_Kinetic.json
@@ -46,7 +46,7 @@
         "UIName": "Ammo TBM 20 Kinetic Kill",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB20_Kinetic",
         "Name": "Thunderbolt 20 Ammo",
-        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5.json
@@ -39,7 +39,7 @@
         "UIName": "Ammo TBM 5",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB5",
         "Name": "Thunderbolt 5 Ammo",
-        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. ",
+        "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. ",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_Feint.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_Feint.json
@@ -41,7 +41,7 @@
         "UIName": "Ammo TBM5 Feint",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB5_Feint",
         "Name": "Thunderbolt 5 Ammo",
-        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments on just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "''Feint'' missiles have internal chaff dispensers and go ''dumb'' and coast on inertia for a large percentage of their flight arc to fool AMS systems. They wake up and make final trajectory adjustments on just before impact. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_Kinetic.json
+++ b/RogueMunitions/Thunderbolt/Ammo_AmmunitionBox_Thunderbolt_TB5_Kinetic.json
@@ -46,7 +46,7 @@
         "UIName": "Ammo TBM 5 Kinetic Kill",
         "Id": "Ammo_AmmunitionBox_Thunderbolt_TB5_Kinetic",
         "Name": "Thunderbolt 5 Ammo",
-        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Because there is no high explosive warhead this ammo type deals reduced damage to user if the magazine is detonated. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.",
+        "Details": "Kinetic Kill missiles use huge rocket motors to accelerate a heavy metal dart to high velocity. They penetrate armor well, but require time to reach full velocity. Damage increases at longer range. Because there is no high explosive warhead this ammo type deals reduced damage to user if the magazine is detonated. Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.",
         "Icon": "thunderbolt"
     },
     "BonusValueA": "",

--- a/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB10X.json
+++ b/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB10X.json
@@ -17,7 +17,7 @@
     "UIName": "LB 10-X Ammo",
     "Id": "Ammo_AmmunitionBox_Generic_LB10X",
     "Name": "LB 10-X Ammo",
-    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.\n\nLB 10-X Ammo Bins each contain 8 rounds and may feed multiple weapons.",
+    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.\n\nLB 10-X Ammo Bins each contain 8 rounds and may feed multiple weapons.",
     "Icon": "uixSvgIcon_ammoBox_Ballistic"
   },
   "BonusValueA": "",

--- a/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB20X.json
+++ b/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB20X.json
@@ -17,7 +17,7 @@
     "UIName": "LB 20-X Ammo",
     "Id": "Ammo_AmmunitionBox_Generic_LB20X",
     "Name": "LB 20-X Ammo",
-    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.\n\nLB 20-X Ammo Bins each contain 5 rounds and may feed multiple weapons.",
+    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.\n\nLB 20-X Ammo Bins each contain 5 rounds and may feed multiple weapons.",
     "Icon": "uixSvgIcon_ammoBox_Ballistic"
   },
   "BonusValueA": "",

--- a/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB2X.json
+++ b/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB2X.json
@@ -17,7 +17,7 @@
     "UIName": "LB 2-X Ammo",
     "Id": "Ammo_AmmunitionBox_Generic_LB2X",
     "Name": "LB 2-X Ammo",
-    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.\n\nLB 2-X Ammo Bins each contain 25 rounds and may feed multiple weapons.",
+    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.\n\nLB 2-X Ammo Bins each contain 25 rounds and may feed multiple weapons.",
     "Icon": "uixSvgIcon_ammoBox_Ballistic"
   },
   "BonusValueA": "",

--- a/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB5X.json
+++ b/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_LB5X.json
@@ -17,7 +17,7 @@
     "UIName": "LB 5-X Ammo",
     "Id": "Ammo_AmmunitionBox_Generic_LB5X",
     "Name": "LB 5-X Ammo",
-    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.\n\nLB 5-X Ammo Bins each contain 15 rounds and may feed multiple weapons.",
+    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.\n\nLB 5-X Ammo Bins each contain 15 rounds and may feed multiple weapons.",
     "Icon": "uixSvgIcon_ammoBox_Ballistic"
   },
   "BonusValueA": "",

--- a/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_Narc.json
+++ b/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_Narc.json
@@ -17,7 +17,7 @@
     "UIName": "Narc Ammo",
     "Id": "Ammo_AmmunitionBox_Generic_Narc",
     "Name": "Narc Beacon Ammo",
-    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit.\n\nNarc Beacon Ammo Bins each contain 6 rounds and may feed multiple weapons.",
+    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E.\n\nNarc Beacon Ammo Bins each contain 6 rounds and may feed multiple weapons.",
     "Icon": "uixSvgIcon_ammoBox_Missile"
   },
   "BonusValueA": "",

--- a/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_SRMInferno.json
+++ b/RogueMunitions/hmfix/ammunitionBox/Ammo_AmmunitionBox_Generic_SRMInferno.json
@@ -17,7 +17,7 @@
     "UIName": "Inferno Ammo",
     "Id": "Ammo_AmmunitionBox_Generic_SRMInferno",
     "Name": "Inferno Ammo",
-    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Ammo Bins will explode and destroy their installed location when they receive a Critical Hit. Inferno Ammo Bins each contain 16 rounds and may feed multiple weapons.",
+    "Details": "Ammo Bins contain the rounds needed for projectile-based weaponry, with at least one bin required per weapon type. Upon receiving a Critical Hit, any remaining ammunition stored inside an Ammo Bin will explode dealing damage to the install location. Risk can be mitigated with the use of C.A.S.E. Inferno Ammo Bins each contain 16 rounds and may feed multiple weapons.",
     "Icon": "uixSvgIcon_ammoBox_Missile"
   },
   "BonusValueA": "",


### PR DESCRIPTION
Removes "Ammo Bins will explode and destroy their installed location when they receive a Critical Hit." from ammoboxes