### PR TITLE
Added 63 missing mech affinities, minor change to LNC25-01

### DIFF
--- a/Base 3061/chassis/chassisdef_lancelot_LNC25-01.json
+++ b/Base 3061/chassis/chassisdef_lancelot_LNC25-01.json
@@ -123,6 +123,10 @@
     {
       "Location": "CenterTorso",
       "Hardpoints": [
+		{
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
         {
           "WeaponMount": "AntiPersonnel",
           "Omni": false

--- a/Base 3061/mech/mechdef_lancelot_LNC25-01.json
+++ b/Base 3061/mech/mechdef_lancelot_LNC25-01.json
@@ -51,73 +51,73 @@
   "Locations": [
     {
       "Location": "Head",
-      "CurrentArmor": 45,
+      "CurrentArmor": 35,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 16,
-      "AssignedArmor": 45,
+      "AssignedArmor": 35,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 80,
+      "CurrentArmor": 70,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 80,
+      "AssignedArmor": 70,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 90,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 50,
       "CurrentInternalStructure": 70,
-      "AssignedArmor": 90,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 115,
+      "CurrentArmor": 105,
       "CurrentRearArmor": 80,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 105,
       "AssignedRearArmor": 80,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 90,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 50,
       "CurrentInternalStructure": 70,
-      "AssignedArmor": 90,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 80,
+      "CurrentArmor": 70,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 80,
+      "AssignedArmor": 70,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 70,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 70,
-      "AssignedArmor": 80,
+      "AssignedArmor": 70,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 70,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 70,
-      "AssignedArmor": 80,
+      "AssignedArmor": 70,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -384,28 +384,18 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_HandHeld_Slot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "SimGameUID": "",
-      "GUID": null,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_HandHeld_Slot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "SimGameUID": "",
-      "GUID": null,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_LargeLaser_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "SimGameUID": "",
+      "GUID": null,
+      "hasPrefabName": false,
+      "DamageLevel": "Functional"
+    },
+	{
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaser_1-ExoStar",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/MechAffinity/settings.json
+++ b/MechAffinity/settings.json
@@ -8229,6 +8229,8 @@
         "bearcub_25",
         "Gojira_200",
         "Gojira_100"
+        "Gojira_100",
+		"CGR-QS_80"
       ],
       "affinityLevels": [
         {
@@ -8796,7 +8798,11 @@
         "gargoyle_80",
         "septicemia_55",
         "Sojourner_60",
-        "Swordsman_40"
+        "Swordsman_40",
+		"BL-QS_75",
+		"BLR-QS_85",
+		"crockett_85",
+		"rifleman3m_60"
       ],
       "affinityLevels": [
         {
@@ -8906,7 +8912,9 @@
         "Jinggau_65",
         "Stag II_45",
         "Stag_45",
-        "Koshi_25"
+        "Koshi_25",
+		"TBT-QS_50",
+		"hellhound_50"
       ],
       "affinityLevels": [
         {
@@ -9001,7 +9009,15 @@
         "phoenixhawklam_55",
         "screamer_55",
         "pwwka_30",
-        "Gunsmith_25"
+        "Gunsmith_25",
+		"CLNT-QS_40",
+		"PNT-QS_35",
+		"WSP-QS_20",
+		"cyclone_30",
+		"phantom_40",
+		"PhoenixHawkLAM_45",
+		"PhoenixHawkLAM_50",
+		"valkyrielam_30"
       ],
       "affinityLevels": [
         {
@@ -9104,7 +9120,12 @@
         "rifleman_50",
         "rifleman_60",
         "wolfman_55",
-        "Mhacha_60"
+        "Mhacha_60",
+		"Lynx_55",
+		"Perseus_75",
+		"doloire_80",
+		"riflemanii_90",
+		"riflemaniia_80"		
       ],
       "affinityLevels": [
         {
@@ -9203,7 +9224,12 @@
         "Penetrator_75",
         "summoner_200",
         "Deimos_85",
-        "scarecrow_40"
+        "scarecrow_40",
+		"BNC-QS_95",
+		"GHR-QS_70",
+		"QKD-QS_60",
+		"dragonfireiic_75",
+		"sorcerer_95"
       ],
       "affinityLevels": [
         {
@@ -9307,7 +9333,13 @@
         "omega_150",
         "omega_200",
         "Flashman_75",
-        "Sunder_90"
+        "Sunder_90",
+		"TDR-QS_65",
+		"VultureMkIV_60",
+		"Mothball_150",
+		"pulverizer_90",
+		"valkyrieiilam_60",
+		"ajaxlam_55"
       ],
       "affinityLevels": [
         {
@@ -9403,7 +9435,11 @@
         "UrbanMech_30",
         "UrbanMech_35",
         "UrbanmechIIC_30",
-        "urbanlord_70"
+        "urbanlord_70",
+		"helios_60",
+		"phoenix_50",
+		"visionquest_60",
+		"thunder_70"
       ],
       "affinityLevels": [
         {
@@ -9533,7 +9569,8 @@
         "AssassinII_40",
         "Menshen_55",
         "Anubis_30",
-        "cephalus_25"
+        "cephalus_25",
+		"shayu_40"
       ],
       "affinityLevels": [
         {
@@ -9673,7 +9710,12 @@
         "Ostscout_35",
         "Gun_20",
         "Vulcan II_40",
-        "NightHawk_35"
+        "NightHawk_35",
+		"COM-QS_25",
+		"VLK-QS_30",
+		"blackheart_70",
+		"hecatoncheires_65",
+		"hermes_30"		
       ],
       "affinityLevels": [
         {
@@ -9947,6 +9989,116 @@
         }
       ]
     },
+	    {
+      "chassisNames": [
+        "anvil_60"
+      ],
+      "affinityLevels": [
+        {
+          "missionsRequired": 20,
+          "levelName": "All Out",
+          "decription": "+1 ALL Torso Accuracy",
+          "effectData": [
+            {
+              "Description": {
+                "Details": "Pilot has Mastered the Chassis.",
+                "Icon": "UixSvgIcon_specialEquip_System",
+                "Id": "Affinity_HeavyGunner_RTA",
+                "Name": "BattleMechAffinity"
+              },
+              "durationData": {
+                "duration": -1,
+                "stackLimit": -1
+              },
+              "effectType": "StatisticEffect",
+              "nature": "Buff",
+              "statisticData": {
+                "statName": "LeftTorso.Accuracy",
+                "operation": "Float_Add",
+                "modValue": "-1",
+                "modType": "System.Single",
+                "targetAmmoCategory": "NotSet",
+                "targetCollection": "NotSet",
+                "targetWeaponCategory": "NotSet",
+                "targetWeaponSubType": "NotSet",
+                "targetWeaponType": "NotSet"
+              },
+              "targetingData": {
+                "effectTargetType": "Creator",
+                "effectTriggerType": "Passive",
+                "hideApplicationFloatie": true,
+                "showInStatusPanel": false,
+                "showInTargetPreview": false
+              }
+            },
+			{
+              "Description": {
+                "Details": "Pilot has Mastered the Chassis.",
+                "Icon": "UixSvgIcon_specialEquip_System",
+                "Id": "Affinity_HeavyGunner_RTA",
+                "Name": "BattleMechAffinity"
+              },
+              "durationData": {
+                "duration": -1,
+                "stackLimit": -1
+              },
+              "effectType": "StatisticEffect",
+              "nature": "Buff",
+              "statisticData": {
+                "statName": "RightTorso.Accuracy",
+                "operation": "Float_Add",
+                "modValue": "-1",
+                "modType": "System.Single",
+                "targetAmmoCategory": "NotSet",
+                "targetCollection": "NotSet",
+                "targetWeaponCategory": "NotSet",
+                "targetWeaponSubType": "NotSet",
+                "targetWeaponType": "NotSet"
+              },
+              "targetingData": {
+                "effectTargetType": "Creator",
+                "effectTriggerType": "Passive",
+                "hideApplicationFloatie": true,
+                "showInStatusPanel": false,
+                "showInTargetPreview": false
+              }
+            },
+			{
+              "Description": {
+                "Details": "Pilot has Mastered the Chassis.",
+                "Icon": "UixSvgIcon_specialEquip_System",
+                "Id": "Affinity_HeavyGunner_RTA",
+                "Name": "BattleMechAffinity"
+              },
+              "durationData": {
+                "duration": -1,
+                "stackLimit": -1
+              },
+              "effectType": "StatisticEffect",
+              "nature": "Buff",
+              "statisticData": {
+                "statName": "CenterTorso.Accuracy",
+                "operation": "Float_Add",
+                "modValue": "-1",
+                "modType": "System.Single",
+                "targetAmmoCategory": "NotSet",
+                "targetCollection": "NotSet",
+                "targetWeaponCategory": "NotSet",
+                "targetWeaponSubType": "NotSet",
+                "targetWeaponType": "NotSet"
+              },
+              "targetingData": {
+                "effectTargetType": "Creator",
+                "effectTriggerType": "Passive",
+                "hideApplicationFloatie": true,
+                "showInStatusPanel": false,
+                "showInTargetPreview": false
+              }
+            }
+          ]
+        }
+      ]
+    },
     {
       "chassisNames": [
         "thug_80",
@@ -9972,7 +10124,10 @@
         "Anand_75",
         "Razorback_30",
         "hector_70",
-        "StormGiant_100"
+        "StormGiant_100",
+		"dragonfire_75",
+		"fafnirII_100",
+		"onager_90"
       ],
       "affinityLevels": [
         {
@@ -10096,7 +10251,10 @@
         "shrike_95",
         "spider_45",
         "Eyrie_35",
-        "Scyla_100"
+        "Scyla_100",
+		"guillotine_70",
+		"shadowcat_60",
+		"starslayer_50"
       ],
       "affinityLevels": [
         {
@@ -10170,7 +10328,9 @@
         "Moozilla_150",
         "PirateWasp_20",
         "Crosscut_30",
-        "bushranger_45"
+        "bushranger_45",
+		"bushranger_75",
+		"Mantis_30"
       ],
       "affinityLevels": [
         {
@@ -10314,7 +10474,10 @@
         "warhammer_70",
         "defiance_75",
         "Hammertime_70",
-        "BattleAxe_70"
+        "BattleAxe_70",
+		"HGN-QS_90",
+		"rifleman_70",
+		"lancelot_60"
       ],
       "affinityLevels": [
         {
@@ -10374,7 +10537,9 @@
         "novacat_70",
         "viper_40",
         "blackpython_75",
-        "prometheus_75"
+        "prometheus_75",
+		"MadCatLam_75",
+		"bellerophon_60"
       ],
       "affinityLevels": [
         {
@@ -10553,7 +10718,8 @@
         "CaveLion_75",
         "bombardier_65",
         "devastator_100",
-        "hazard_45"
+        "hazard_45",
+		"WVR-QS_55"
       ],
       "affinityLevels": [
         {
@@ -10604,7 +10770,8 @@
         "viking_90",
         "ionraptor_70",
         "wyvernIIC_45",
-        "wyvern_45"
+        "wyvern_45",
+		"VND-QS_45"
       ],
       "affinityLevels": [
         {
@@ -10710,7 +10877,10 @@
         "firebee_35",
         "RabidCoyote_55",
         "pendragon_95",
-        "Sling_25"
+        "Sling_25",
+		"Naja_55",
+		"naga_80",
+		"salamander_80"
       ],
       "affinityLevels": [
         {
@@ -11124,7 +11294,8 @@
         "carronade_70",
         "quickdraw_60",
         "Cazador_35",
-        "Reptar_35"
+        "Reptar_35",
+		"neanderthal_80"
       ],
       "affinityLevels": [
         {
@@ -11235,7 +11406,9 @@
         "stalker_75",
         "stalkerii_85",
         "orochi_90",
-        "talon_35"
+        "talon_35",
+		"thunderhawk_100",
+		"grandtitan_100"
       ],
       "affinityLevels": [
         {

--- a/MechAffinity/settings.json
+++ b/MechAffinity/settings.json
@@ -8227,9 +8227,8 @@
         "atlasiii_100",
         "kodiak_100",
         "bearcub_25",
-        "Gojira_200",
-        "Gojira_100"
-        "Gojira_100",
+		"Gojira_200",
+		"Gojira_100",
 		"CGR-QS_80"
       ],
       "affinityLevels": [


### PR DESCRIPTION
BL-QS_75 - (Scrapper)
BLR-QS_85 - (Scrapper)
BNC-QS_95 - (Gunboat)
CGR-QS_80 - (Brute)
CLNT-QS_40 - (Evasive)
COM-QS_25 - (Scout)
GHR-QS_70 - (Gunboat)
HGN-QS_90 - (High-pressure-cooling)
Lynx_55 - (Focus Fire)
MadCatLam_75 - (Supercooled)
Mantis_30 - (Storm Trooper) 
Naja_55 - (Missile Boat) 
PNT-QS_35 - (Evasive)
Perseus_75 - (Focus Fire)
PhoenixHawkLAM_45 - (Evasive)
PhoenixHawkLAM_50 - (Evasive)
QKD-QS_60 - (Gunboat)
TBT-QS_50 - (Agile) 
TDR-QS_65 - (Dreadnought)
VLK-QS_30 - (Scout) 
VND-QS_45 - (Reactive Plates)
VultureMkIV_60 - (Dreadnought)
WSP-QS_20 - (Evasive) 
WVR-QS_55 - (Reflective Coating)
ajaxlam_55 - (dreadnought)
anvil_60 - (All out)
bellerophon_60 - (Supercooled)
blackheart_70 - (Scout)
bushranger_75 - (Stormtrooper)
cyclone_30 - (Evasive)
Mothball_150 - (Dreadnought)
crockett_85 - (Scrapper) 
doloire_80 - (Focus Fire) 
dragonfire_75 - (Gunslinger)
dragonfireiic_75 - (Gunboat)
fafnirII_100 - (Gunslinger)
grandtitan_100 - (Sniper)
guillotine_70 - (Jump Trooper)
hecatoncheires_65 - (Scout) 
helios_60 - (Shocktrooper)
hellhound_50 - (Agile)
hermes_30 - (Scout)
lancelot_60 - (High-Pressure Cooling)
naga_80 - (Missile Boat)
neanderthal_80 - (Brawler)
onager_90 - (Gunslinger) 
phantom_40 - (Evasive) 
phoenix_50 - (Shocktrooper)
pulverizer_90 - (Dreadnought)
rifleman3m_60 - (Scrapper)
rifleman_70 (High-Pressure Cooling)
riflemanii_90 - (Focus Fire)
riflemaniia_80 - (Focus Fire) 
salamander_80 - (Missile Boat)
shadowcat_60 - (Jump Trooper) 
shayu_40 - (Ambusher)
sorcerer_95 - (Gunboat)
starslayer_50 - (Jump Trooper)
thunder_70 - (Shocktrooper)
thunderhawk_100 - (Sniper) 
valkyrieiilam_60 (Dreadnought)
valkyrielam_30 - (Evasive)
visionquest_60 - (Shock Trooper)

Added missing medium laser to LNC25-01.