### PR TITLE
HEP-IIC Tag/Fluff Fix and CYC add to Start Lists

### DIFF
--- a/IRTweaks/data/itemCollection_Mechs_Starting_Comstar_Light_D.csv
+++ b/IRTweaks/data/itemCollection_Mechs_Starting_Comstar_Light_D.csv
@@ -12,3 +12,4 @@ mechdef_owens_OW-1D,Mech,1,3
 mechdef_owens_OW-1E,Mech,1,3
 mechdef_spector_SPR-5F,Mech,1,1
 mechdef_venom_SDR-9K,Mech,1,3
+mechdef_cyclone_CYC-A1,Mech,1,3

--- a/IRTweaks/data/itemCollection_Mechs_Starting_Davion_Light.csv
+++ b/IRTweaks/data/itemCollection_Mechs_Starting_Davion_Light.csv
@@ -7,3 +7,4 @@ mechdef_spider_SDR-7M,Mech,1,3
 mechdef_Valkyrie_VLK-QD,Mech,1,3
 mechdef_hollander_BZK-G1,Mech,1,3
 mechdef_wolfhound_WLF-2,Mech,1,3
+mechdef_cyclone_CYC-A3,Mech,1,3

--- a/IRTweaks/data/itemCollection_Mechs_Starting_Kurita_Light.csv
+++ b/IRTweaks/data/itemCollection_Mechs_Starting_Kurita_Light.csv
@@ -7,3 +7,4 @@ mechdef_hitman_HM-2,Mech,1,3
 mechdef_spider_SDR-C,Mech,1,2
 mechdef_jenner_JR7-C,Mech,1,3
 mechdef_panther_PNT-10K,Mech,1,3
+mechdef_cyclone_CYC-A3P,Mech,1,3

--- a/IRTweaks/data/itemCollection_Mechs_Starting_Liao_Light.csv
+++ b/IRTweaks/data/itemCollection_Mechs_Starting_Liao_Light.csv
@@ -7,3 +7,4 @@ mechdef_spider_SDR-7M,Mech,1,3
 mechdef_urbanmech_UM-R63,Mech,1,3
 mechdef_firestarter_FS9-S,Mech,1,3
 mechdef_owens_OW-1A,Mech,1,3
+mechdef_cyclone_CYC-A3,Mech,1,3

--- a/IRTweaks/data/itemCollection_Mechs_Starting_Marik_Light.csv
+++ b/IRTweaks/data/itemCollection_Mechs_Starting_Marik_Light.csv
@@ -7,3 +7,4 @@ mechdef_hammer_HMR-3P,Mech,1,3
 mechdef_spider_SDR-8M,Mech,1,3
 mechdef_owens_OW-1D,Mech,1,2
 mechdef_venom_SDR-9K,Mech,1,3
+mechdef_cyclone_CYC-A3,Mech,1,3

--- a/RogueSociety/mech/mechdef_helepolis_iic_HEP-IIC-Z.json
+++ b/RogueSociety/mech/mechdef_helepolis_iic_HEP-IIC-Z.json
@@ -10,6 +10,7 @@
       "unit_lance_assassin",
       "unit_role_sniper",
       "unit_sniper",
+      "unit_arrow",
       "unit_advanced",
       "clanburrock",
       "clancoyote",
@@ -27,7 +28,7 @@
     "UIName": "Helepolis IIC HEP-IIC Z",
     "Id": "mechdef_helepolis_iic_HEP-IIC-Z",
     "Name": "Helepolis IIC HEP-IIC-Z",
-    "Details": "Despite the design being considered obsolete well before the Exodus, the schematics for the Helepolis seige mech survived the journey to the Pentagon Worlds where it went largely ignored until the Golden Century. A small group of Coyote scientists retooled the arcane design, increasing its tonnage and applying most of the weight saving techologies available, and submitted it to their Khan. Despite being rejected as a dishonorable design the HEP-IIC survived in Society caches and has slowly been upgraded over the years. The Z variant sports a Sniper Artillery Piece and a Society MRM60.\n\n<b><color=#e62e00>Quirk: Stable</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.29</color></b>",
+    "Details": "Despite the design being considered obsolete well before the Exodus, the schematics for the Helepolis seige mech survived the journey to the Pentagon Worlds where it went largely ignored until the Golden Century. A small group of Coyote scientists retooled the arcane design, increasing its tonnage and applying most of the weight saving techologies available, and submitted it to their Khan. Despite being rejected as a dishonorable design the HEP-IIC survived in Society caches and has slowly been upgraded over the years. The Z variant features a pair of Arrow Vs and can only rely on a iATM3 for short-ranged defense\n\n<b><color=#e62e00>Quirk: Stable</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.29</color></b>",
     "Icon": "helepolis"
   },
   "simGameMechPartCost": 739854,

--- a/RogueSociety/mech/mechdef_helepolis_iic_HEP-IIC-ZA.json
+++ b/RogueSociety/mech/mechdef_helepolis_iic_HEP-IIC-ZA.json
@@ -9,8 +9,8 @@
       "unit_lance_support",
       "unit_lance_assassin",
       "unit_role_sniper",
+      "unit_sniper",
       "unit_advanced",
-      "unit_arrow",
       "clanburrock",
       "clancoyote",
       "society"
@@ -27,7 +27,7 @@
     "UIName": "Helepolis IIC HEP-IIC-ZA",
     "Id": "mechdef_helepolis_iic_HEP-IIC-ZA",
     "Name": "Helepolis IIC HEP-IIC-ZA",
-    "Details": "Despite the design being considered obsolete well before the Exodus, the schematics for the Helepolis seige mech survived the journey to the Pentagon Worlds where it went largely ignored until the Golden Century. A small group of Coyote scientists retooled the arcane design, increasing its tonnage and applying most of the weight saving techologies available, and submitted it to their Khan. Despite being rejected as a dishonorable design the HEP-IIC survived in Society caches and has slowly been upgraded over the years. The ZA variant features a pair of Arrow Vs and can only rely on a iATM3 for short-ranged defense.\n\n<b><color=#e62e00>Quirk: Stable</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.29</color></b>",
+    "Details": "Despite the design being considered obsolete well before the Exodus, the schematics for the Helepolis seige mech survived the journey to the Pentagon Worlds where it went largely ignored until the Golden Century. A small group of Coyote scientists retooled the arcane design, increasing its tonnage and applying most of the weight saving techologies available, and submitted it to their Khan. Despite being rejected as a dishonorable design the HEP-IIC survived in Society caches and has slowly been upgraded over the years. The ZA variant sports a Sniper Artillery Piece and a Society MRM60..\n\n<b><color=#e62e00>Quirk: Stable</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.29</color></b>",
     "Icon": "helepolis"
   },
   "simGameMechPartCost": 739854,


### PR DESCRIPTION
Corrected the fluff/tags mix-up on the HEP-IIC-Z and -ZA.
Added Cyclone to several starting lists for factions that would have access to it.