### PR TITLE
Correct Laser AMS (C) heat

### DIFF
--- a/RogueModuleTech/AMS/Weapon_Laser_AMS_CLAN.json
+++ b/RogueModuleTech/AMS/Weapon_Laser_AMS_CLAN.json
@@ -115,7 +115,7 @@
       "AMSDamage": 2,
       "ShotsWhenFired": 15,
       "AMSHitChance": 0.35,
-      "HeatGenerated": 8,
+      "HeatGenerated": 2,
       "AMSShootsEveryAttack": false
     },
     {
@@ -131,7 +131,7 @@
       "FlatJammingChance": 0.3,
       "GunneryJammingMult": 0.01,
       "GunneryJammingBase": 1,
-      "HeatGenerated": 22,
+      "HeatGenerated": 16,
       "AMSShootsEveryAttack": true
     },
     {


### PR DESCRIPTION
Bump clan Laser AMS heat down to the values specified in the traits (account for base HeatGenerated of +6)
See #rogueticket-2986