### PR TITLE
Mechs

### DIFF
--- a/Base 3061/chassis/chassisdef_crosscut_ED-X2M.json
+++ b/Base 3061/chassis/chassisdef_crosscut_ED-X2M.json
@@ -17,7 +17,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Easy_To_Pilot",
+      "ComponentDefID": "Special_Easy_To_Maintain",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "SimGameUID": "",

--- a/Base 3061/chassis/chassisdef_crosscut_ED-X4X.json
+++ b/Base 3061/chassis/chassisdef_crosscut_ED-X4X.json
@@ -17,7 +17,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Easy_To_Pilot",
+      "ComponentDefID": "Special_Easy_To_Maintain",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "SimGameUID": "",

--- a/Base 3061/chassis/chassisdef_wasp_WSP-1A.json
+++ b/Base 3061/chassis/chassisdef_wasp_WSP-1A.json
@@ -102,12 +102,7 @@
     },
     {
       "Location": "LeftTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Missile",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 50,
@@ -170,7 +165,12 @@
     },
     {
       "Location": "LeftLeg",
-      "Hardpoints": [],
+      "Hardpoints": [
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 6,
       "MaxArmor": 40,

--- a/Base 3061/mech/mechdef_wasp_WSP-1A.json
+++ b/Base 3061/mech/mechdef_wasp_WSP-1A.json
@@ -369,7 +369,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "LeftLeg",
       "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
@@ -409,7 +409,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftLeg",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_JumpJet_Generic_Standard",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": 0,
@@ -425,7 +425,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightLeg",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_JumpJet_Generic_Standard",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": 0,

--- a/DarkAge/chassis/chassisdef_crosscut_ED-IIC.json
+++ b/DarkAge/chassis/chassisdef_crosscut_ED-IIC.json
@@ -1,7 +1,7 @@
 {
   "Custom": {
     "ArmActuatorSupport": {
-      "LeftLimit": "Hand",
+      "LeftLimit": "Lower",
       "RightLimit": "Hand"
     },
     "DropCostFactor": {
@@ -17,19 +17,11 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Easy_To_Maintain",
+      "ComponentDefID": "Special_Easy_To_Pilot",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "SimGameUID": "",
       "IsFixed": false,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_engineslots_FuelCell",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
       "hasPrefabName": false,
       "DamageLevel": "Functional"
     },
@@ -51,12 +43,12 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Crosscut",
-    "Id": "chassisdef_crosscut_ED-X5M",
+    "Id": "chassisdef_crosscut_ED-IIC",
     "Name": "Crosscut",
-    "Details": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The X5M is a slight improvement on the X2M, since it upgrades both the engine type and the gun. For the poor sods who have to ride a logger-mech into battle, the gun is particularly appreciated, since the new light AC2 allows their idustrial armor to stay far back from the fight.\n\n<b><color=#e62e00>Quirk: Easy to Pilot</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.72</color></b>",
+    "Details": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The X2M is a militarized crosscut on the cheap, with only minor modifications to the base industrial model.\n\n<b><color=#e62e00>Quirk: Easy to Pilot</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.72</color></b>",
     "Icon": "Crosscut"
   },
-  "VariantName": "ED-X5M",
+  "VariantName": "ED-IIC",
   "ChassisTags": {
     "items": [
       "IndustrialMech",
@@ -65,7 +57,7 @@
     "tagSetSourceFile": ""
   },
   "StockRole": "Industrial Mech",
-  "YangsThoughts": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The X5M is a slight improvement on the X2M, since it upgrades both the engine type and the gun. For the poor sods who have to ride a logger-mech into battle, the gun is particularly appreciated, since the new light AC2 allows their idustrial armor to stay far back from the fight.",
+  "YangsThoughts": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The X2M is a militarized crosscut on the cheap, with only minor modifications to the base industrial model.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_crosscut",
@@ -115,7 +107,7 @@
       "Location": "LeftArm",
       "Hardpoints": [
         {
-          "WeaponMount": "Ballistic",
+          "WeaponMount": "Energy",
           "Omni": false
         }
       ],
@@ -174,7 +166,7 @@
       "Hardpoints": [
         {
           "Omni": false,
-          "WeaponMount": "Missile"
+          "WeaponMount": "Ballistic"
         }
       ],
       "Tonnage": 0,

--- a/DarkAge/chassis/chassisdef_crosscut_ED-IIC.json
+++ b/DarkAge/chassis/chassisdef_crosscut_ED-IIC.json
@@ -17,7 +17,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Easy_To_Pilot",
+      "ComponentDefID": "Special_Easy_To_Maintain",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "SimGameUID": "",
@@ -45,7 +45,7 @@
     "UIName": "Crosscut",
     "Id": "chassisdef_crosscut_ED-IIC",
     "Name": "Crosscut",
-    "Details": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The X2M is a militarized crosscut on the cheap, with only minor modifications to the base industrial model.\n\n<b><color=#e62e00>Quirk: Easy to Pilot</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.72</color></b>",
+    "Details": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The IIC is a militarized Crosscut built with Clantech, powered by a 300 rated XL Engine and armed with an iHML in addition to the standard Chainsaw.\n\n<b><color=#e62e00>Quirk: Easy to Pilot</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.72</color></b>",
     "Icon": "Crosscut"
   },
   "VariantName": "ED-IIC",
@@ -57,7 +57,7 @@
     "tagSetSourceFile": ""
   },
   "StockRole": "Industrial Mech",
-  "YangsThoughts": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The X2M is a militarized crosscut on the cheap, with only minor modifications to the base industrial model.",
+  "YangsThoughts": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The IIC is a militarized Crosscut built with Clantech, powered by a 300 rated XL Engine and armed with an iHML in addition to the standard Chainsaw.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_crosscut",

--- a/DarkAge/mech/mechdef_crosscut_ED-IIC.json
+++ b/DarkAge/mech/mechdef_crosscut_ED-IIC.json
@@ -1,0 +1,325 @@
+{
+    "MechTags": {
+        "items": [
+            "unit_advanced",
+            "unit_bracket_low",
+            "unit_release",
+            "unit_mech",
+            "unit_light",
+            "unit_ready",
+            "unit_lance_vanguard",
+            "unit_role_brawler",
+            "unit_melee",
+            "unit_industrial",
+            "Republic",
+            "clandiamondshark",
+            "auriganpirates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "chassisdef_crosscut_ED-IIC",
+    "Description": {
+        "Cost": 76429,
+        "Rarity": 1,
+        "Purchasable": true,
+        "Manufacturer": null,
+        "Model": null,
+        "UIName": "Crosscut ED-IIC",
+        "Id": "mechdef_crosscut_ED-IIC",
+        "Name": "Crosscut ED-IIC",
+        "Details": "The Crosscut is a popular type of LoggerMech, praised for operating efficiency in woodlands and dominating commercial forestry. The IIC is a militarized Crosscut built with Clantech, powered by a 300 rated XL Engine and armed with an iHML in addition to the standard Chainsaw.\n\n<b><color=#e62e00>Quirk: Easy to Pilot</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.72</color></b>",
+        "Icon": "Crosscut"
+    },
+    "simGameMechPartCost": 76429,
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Head",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 16,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftArm",
+            "CurrentArmor": 40,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 40,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftTorso",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": 20,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": 20,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "CenterTorso",
+            "CurrentArmor": 55,
+            "CurrentRearArmor": 30,
+            "CurrentInternalStructure": 50,
+            "AssignedArmor": 55,
+            "AssignedRearArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightTorso",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": 20,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": 20,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightArm",
+            "CurrentArmor": 40,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 40,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftLeg",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightLeg",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_FCS_Improved",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Gyro_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_Heatsinks",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": null,
+            "GUID": null,
+            "prefabName": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_kit_cdhs",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": null,
+            "GUID": null,
+            "prefabName": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_engineslots_cxl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "prefabName": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "prefabName": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "prefabName": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_300",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Weapon_Laser_ImprovedHeavyMediumLaser_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Republic 3081-3130/chassis/chassisdef_Valkyrie_VLK-QD5.json
+++ b/Republic 3081-3130/chassis/chassisdef_Valkyrie_VLK-QD5.json
@@ -1,0 +1,236 @@
+{
+    "Custom": {
+        "ArmActuatorSupport": {
+            "RightLimit": "Lower"
+        },
+        "DropCostFactor": {
+            "DropModifier": 0.99
+        },
+        "AssemblyVariant": {
+            "PrefabID": "valkyrie",
+            "Exclude": false,
+            "Include": true
+        },
+        "ChassisDefaults": []
+    },
+    "FixedEquipment": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Special_Improved_Comms",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "Description": {
+        "Cost": 389078,
+        "Rarity": 3,
+        "Purchasable": true,
+        "Manufacturer": "",
+        "Model": "",
+        "UIName": "Valkyrie",
+        "Id": "chassisdef_Valkyrie_VLK-QD5",
+        "Name": "Valkyrie",
+        "Details": "Debuting in 3101, the Valkyrie QD-5 is a revamp of the older QD-4 model. Powered by a 150 rated XL Engine and armoured with Light Ferro-Fibrous; the QD-5 is armed with a Medium Pulse Laser, MML-7 and an ATM-3.\n\n<b><color=#e62e00>Quirk: Improved Communications</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.99</color></b>",
+        "Icon": "valkyrie"
+    },
+    "VariantName": "VLK-QD5",
+    "ChassisTags": {
+        "items": [
+            "mr-resize-0.8-0.8-0.9"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "StockRole": "Missile Boat",
+    "YangsThoughts": "Debuting in 3101, the Valkyrie QD-5 is a revamp of the older QD-4 model. Powered by a 150 rated XL Engine and armoured with Light Ferro-Fibrous; the QD-5 is armed with a Medium Pulse Laser, MML-7 and an ATM-3.",
+    "MovementCapDefID": "movedef_lightmech",
+    "PathingCapDefID": "pathingdef_light",
+    "HardpointDataDefID": "hardpointdatadef_valkyrie",
+    "PrefabIdentifier": "chrprfmech_valkyriehotd-001",
+    "PrefabBase": "valkyrie",
+    "Tonnage": 30,
+    "InitialTonnage": 3,
+    "weightClass": "LIGHT",
+    "BattleValue": 2061000,
+    "Heatsinks": 0,
+    "TopSpeed": 86,
+    "TurnRadius": 90,
+    "MaxJumpjets": 20,
+    "Stability": 100,
+    "StabilityDefenses": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+    ],
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "PunchesWithLeftArm": true,
+    "MeleeDamage": 15,
+    "MeleeInstability": 7,
+    "MeleeToHitModifier": 0,
+    "DFADamage": 45,
+    "DFAToHitModifier": 0,
+    "DFASelfDamage": 30,
+    "DFAInstability": 23,
+    "Locations": [
+        {
+            "Location": "Head",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 45,
+            "MaxRearArmor": -1,
+            "InternalStructure": 16
+        },
+        {
+            "Location": "LeftArm",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 50,
+            "MaxRearArmor": -1,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "LeftTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 70,
+            "MaxRearArmor": 35,
+            "InternalStructure": 35
+        },
+        {
+            "Location": "CenterTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 15,
+            "MaxArmor": 100,
+            "MaxRearArmor": 50,
+            "InternalStructure": 50
+        },
+        {
+            "Location": "RightTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "AntiPersonnel",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 70,
+            "MaxRearArmor": 35,
+            "InternalStructure": 35
+        },
+        {
+            "Location": "RightArm",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 50,
+            "MaxRearArmor": -1,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "LeftLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 70,
+            "MaxRearArmor": -1,
+            "InternalStructure": 35
+        },
+        {
+            "Location": "RightLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 70,
+            "MaxRearArmor": -1,
+            "InternalStructure": 35
+        }
+    ],
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 9.5,
+            "z": 0.5
+        },
+        {
+            "x": -2.5,
+            "y": 8.5,
+            "z": -0.5
+        },
+        {
+            "x": 2.5,
+            "y": 8.5,
+            "z": -0.5
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 9.5,
+            "z": 0.5
+        },
+        {
+            "x": -2.5,
+            "y": 8.5,
+            "z": -0.5
+        },
+        {
+            "x": 2.5,
+            "y": 8.5,
+            "z": -0.5
+        },
+        {
+            "x": -1.5,
+            "y": 3,
+            "z": 0.5
+        },
+        {
+            "x": 1.5,
+            "y": 3,
+            "z": 0.5
+        }
+    ]
+}

--- a/Republic 3081-3130/mech/mechdef_Valkyrie_VLK-QD5.json
+++ b/Republic 3081-3130/mech/mechdef_Valkyrie_VLK-QD5.json
@@ -1,0 +1,469 @@
+{
+    "MechTags": {
+        "items": [
+            "unit_release",
+            "unit_mech",
+            "unit_light",
+            "unit_lance_assassin",
+            "unit_lance_support",
+            "unit_indirectFire",
+            "unit_role_sniper",
+            "unit_bracket_low",
+            "unit_advanced",
+            "unit_jumpOK",
+            "marik"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "chassisdef_Valkyrie_VLK-QD5",
+    "Description": {
+        "Cost": 77816,
+        "Rarity": 1,
+        "Purchasable": true,
+        "Manufacturer": null,
+        "Model": null,
+        "UIName": "Valkyrie VLK-QD5",
+        "Id": "mechdef_Valkyrie_VLK-QD5",
+        "Name": "Valkyrie VLK-QD5",
+        "Details": "Debuting in 3101, the Valkyrie QD-5 is a revamp of the older QD-4 model. Powered by a 150 rated XL Engine and armoured with Light Ferro-Fibrous; the QD-5 is armed with a Medium Pulse Laser, MML-7 and an ATM-3.\n\n<b><color=#e62e00>Quirk: Improved Communications</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.99</color></b>",
+        "Icon": "valkyrie"
+    },
+    "simGameMechPartCost": 77816,
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Head",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 16,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftArm",
+            "CurrentArmor": 40,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 40,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftTorso",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": 13,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": 13,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "CenterTorso",
+            "CurrentArmor": 65,
+            "CurrentRearArmor": 20,
+            "CurrentInternalStructure": 50,
+            "AssignedArmor": 65,
+            "AssignedRearArmor": 20,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightTorso",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": 13,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": 13,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightArm",
+            "CurrentArmor": 40,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 40,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftLeg",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightLeg",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_armorslots_lightferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Cockpit_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_FCS_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Gyro_XL",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_150",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_engineslots_xl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_Heatsinks",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_kit_dhs",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_hand",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Weapon_MML_7",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Weapon_LRM_ATM3_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaserPulse_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Ammo_AmmunitionBox_HE_ATM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "emod_case",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        }
+    ]
+}


### PR DESCRIPTION
Added Valkyrie QD-5 and Crosscut IIC from XTRO: Caveat Emptor. Corrected Crosscut quirk (was Easy to Pilot. Actual TT quirks are Easy to Maintain and Hard to Pilot). Moved Wasp 1A SRM to use Leg hardpoint 