### PR TITLE
Crab actuator tweaks

### DIFF
--- a/Jihad Flashpoint/chassis/chassisdef_crab_CRB-21.json
+++ b/Jihad Flashpoint/chassis/chassisdef_crab_CRB-21.json
@@ -1,5 +1,9 @@
 {
   "Custom": {
+    "ArmActuatorSupport": {
+      "LeftLimit": "Lower",
+      "RightLimit": "Lower"
+    },
     "DropCostFactor": {
       "DropModifier": 1.04
     },

--- a/Jihad Flashpoint/chassis/chassisdef_crab_CRB-22S.json
+++ b/Jihad Flashpoint/chassis/chassisdef_crab_CRB-22S.json
@@ -1,5 +1,9 @@
 {
   "Custom": {
+    "ArmActuatorSupport": {
+      "LeftLimit": "Lower",
+      "RightLimit": "Lower"
+    },
     "DropCostFactor": {
       "DropModifier": 1.1
     },

--- a/Jihad Flashpoint/mech/mechdef_crab_CRB-21.json
+++ b/Jihad Flashpoint/mech/mechdef_crab_CRB-21.json
@@ -322,15 +322,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -351,15 +342,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/Jihad Flashpoint/mech/mechdef_crab_CRB-22S.json
+++ b/Jihad Flashpoint/mech/mechdef_crab_CRB-22S.json
@@ -261,15 +261,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_shoulder",
       "ComponentDefType": "Upgrade",
@@ -290,15 +281,6 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "emod_arm_part_lower",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "SimGameUID": "",
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "emod_arm_part_hand",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "SimGameUID": "",

--- a/RogueModuleElitesFlashpoint/chassis/chassisdef_hardshell_crab_CRB-27-H.json
+++ b/RogueModuleElitesFlashpoint/chassis/chassisdef_hardshell_crab_CRB-27-H.json
@@ -1,5 +1,8 @@
 {
   "Custom": {
+    "ArmActuatorSupport": {
+      "LeftLimit": "Lower"
+    },
     "DropCostFactor": {
       "DropModifier": 1.12
     },

--- a/RogueModuleElitesFlashpoint/mech/mechdef_hardshell_crab_CRB-27-H.json
+++ b/RogueModuleElitesFlashpoint/mech/mechdef_hardshell_crab_CRB-27-H.json
@@ -385,16 +385,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "emod_arm_part_hand",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "SimGameUID": "",
-      "IsFixed": false,
-      "hasPrefabName": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_Actuator_Friedhof_Colossus",
       "ComponentDefType": "Upgrade",


### PR DESCRIPTION
Fixed CRB-27H to follow CRB-27 actuators and removed hands from the CRB21/22S (inline with the later era crabs)