### PR TITLE
Fixes for vehicle validation report

### DIFF
--- a/Base 3061/VTOL/MediumVTOL/vehicledef_Balac_Hybrid.json
+++ b/Base 3061/VTOL/MediumVTOL/vehicledef_Balac_Hybrid.json
@@ -108,7 +108,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_HMG_half",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_HMG",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/VTOL/MediumVTOL/vehicledef_Balac_LRM.json
+++ b/Base 3061/VTOL/MediumVTOL/vehicledef_Balac_LRM.json
@@ -178,6 +178,12 @@
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },{
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",

--- a/Base 3061/VTOL/vehiclechassis/vehiclechassisdef_Balac_LRM.json
+++ b/Base 3061/VTOL/vehiclechassis/vehiclechassisdef_Balac_LRM.json
@@ -4,7 +4,13 @@
       "PrefabID": "Balac",
       "Exclude": false,
       "Include": true
-    }
+    },
+    "CustomWeights": [
+      {
+        "ComponentDefID": "Tank_CargoCompartment",
+        "Tonnage": 0.5
+      }
+    ]
   },
   "CustomParts": {
     "AOEHeight": 55,

--- a/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover.json
+++ b/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover.json
@@ -227,7 +227,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefID": "Gear_Engine_75",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover_LRM.json
+++ b/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover_LRM.json
@@ -213,7 +213,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefID": "Gear_Engine_75",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover_MG.json
+++ b/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover_MG.json
@@ -212,7 +212,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefID": "Gear_Engine_75",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover_SRM.json
+++ b/Base 3061/vehicle/apc/vehicledef_APC_HeavyHover_SRM.json
@@ -219,7 +219,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Engine_100",
+      "ComponentDefID": "Gear_Engine_75",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/vehicle/assault/vehicledef_ALACORN_III.json
+++ b/Base 3061/vehicle/assault/vehicledef_ALACORN_III.json
@@ -79,9 +79,9 @@
     },
     {
       "Location": "Rear",
-      "CurrentArmor": 225,
+      "CurrentArmor": 217,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 225,
+      "AssignedArmor": 217,
       "DamageLevel": "Functional"
     },
     {
@@ -112,6 +112,13 @@
       "ComponentDefID": "Weapon_Autocannon_AC10_0-STOCK",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC10",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {

--- a/Base 3061/vehicle/assault/vehicledef_ALACORN_IV.json
+++ b/Base 3061/vehicle/assault/vehicledef_ALACORN_IV.json
@@ -45,7 +45,7 @@
   },
   "ChassisID": "vehiclechassisdef_ALACORN_IV",
   "Description": {
-    "Cost": 16324425,
+    "Cost": 5765175,
     "Rarity": 0,
     "Purchasable": false,
     "UIName": "Alacorn Mk.IV",

--- a/Base 3061/vehicleChassis/vehiclechassisdef_ALACORN_III.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_ALACORN_III.json
@@ -102,7 +102,7 @@
       "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 0,
-      "MaxArmor": 201,
+      "MaxArmor": 217,
       "InternalStructure": 50
     },
     {

--- a/Base 3061/vehicleChassis/vehiclechassisdef_ALACORN_IV.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_ALACORN_IV.json
@@ -7,7 +7,7 @@
     }
   },
   "Description": {
-    "Cost": 16324425,
+    "Cost": 5765175,
     "Rarity": 0,
     "Purchasable": false,
     "UIName": "Alacorn Mk.IV",

--- a/DarkAge/vehicle/vehicledef_JES_III.json
+++ b/DarkAge/vehicle/vehicledef_JES_III.json
@@ -43,16 +43,16 @@
     },
     {
       "Location": "Left",
-      "CurrentArmor": 105,
+      "CurrentArmor": 113,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 113,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Right",
-      "CurrentArmor": 105,
+      "CurrentArmor": 113,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 113,
       "DamageLevel": "Functional"
     },
     {

--- a/DarkAge/vehicle/vehicledef_JES_III_C3.json
+++ b/DarkAge/vehicle/vehicledef_JES_III_C3.json
@@ -35,23 +35,23 @@
   "Locations": [
     {
       "Location": "Front",
-      "CurrentArmor": 200,
+      "CurrentArmor": 208,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 200,
+      "AssignedArmor": 208,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Left",
-      "CurrentArmor": 105,
+      "CurrentArmor": 109,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 109,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Right",
-      "CurrentArmor": 105,
+      "CurrentArmor": 109,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 109,
       "DamageLevel": "Functional"
     },
     {

--- a/DarkAge/vehicle/vehicledef_JES_III_MML.json
+++ b/DarkAge/vehicle/vehicledef_JES_III_MML.json
@@ -43,16 +43,16 @@
     },
     {
       "Location": "Left",
-      "CurrentArmor": 105,
+      "CurrentArmor": 101,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 101,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Right",
-      "CurrentArmor": 105,
+      "CurrentArmor": 101,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 101,
       "DamageLevel": "Functional"
     },
     {
@@ -129,7 +129,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -275,6 +275,34 @@
     {
       "MountedLocation": "Rear",
       "ComponentDefID": "Tank_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/DarkAge/vehicle/vehicledef_JES_III_Speed.json
+++ b/DarkAge/vehicle/vehicledef_JES_III_Speed.json
@@ -184,7 +184,7 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "emod_armorslots_standard",
+      "ComponentDefID": "emod_armorslots_heavyferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1
     },

--- a/DarkAge/vehicle/vehicledef_JES_III_TBM.json
+++ b/DarkAge/vehicle/vehicledef_JES_III_TBM.json
@@ -43,16 +43,16 @@
     },
     {
       "Location": "Left",
-      "CurrentArmor": 105,
+      "CurrentArmor": 109,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 109,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Right",
-      "CurrentArmor": 105,
+      "CurrentArmor": 109,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 105,
+      "AssignedArmor": 109,
       "DamageLevel": "Functional"
     },
     {
@@ -115,27 +115,34 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Rear",
+      "MountedLocation": "Left",
       "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Rear",
+      "MountedLocation": "Left",
       "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Rear",
+      "MountedLocation": "Right",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Right",
       "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
@@ -150,7 +157,28 @@
     },
     {
       "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10_HE",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
       "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10_Kinetic",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10_Kinetic",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_TB10_Thermo",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/DarkAge/vehicle/vehicledef_Partisan_AA_vehicle_mk2.json
+++ b/DarkAge/vehicle/vehicledef_Partisan_AA_vehicle_mk2.json
@@ -18,13 +18,13 @@
   },
   "ChassisID": "vehiclechassisdef_Partisan_AA_vehicle_mk2",
   "Description": {
-    "Cost": 3070283,
+    "Cost": 2149130,
     "Rarity": 0,
     "Purchasable": false,
     "UIName": "Partisan AA Mk.2",
     "Id": "vehicledef_Partisan_AA_vehicle_mk2",
     "Name": "Partisan AA Mk.2",
-    "Details": "Unveiled in 3110 the Partisan AA Vehicle, a lighter take on the original Partisan Air Defense Tank, was meant to be cheaper and faster but still be equally effective in the anti-aircraft role. Produced in 3134, this version of the Partisan AA would give the vehicle a longer reach than before, while gaining secondary weaponry which the Standard Model lacked. Gone is the standard LB-5X Class autocannons, in their place are a pair of Class 2 Hypervelocity Autocannons with two tons of ammunition. Though lacking the punch of the Standard's bigger LB-5Xs, the HVAC/2s accuracy is improved by adding a Targeting Computer to the vehicle. As a secondary weapon, the vehicle is fitted with a 10-tubed Rocket Launcher in the turret.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       120     25\n<b>Left</b>         100     25\n<b>Right</b>       100     25\n<b>Rear</b>         80     25\n\n<b>Total</b>      490    125\n",
+    "Details": "Unveiled in 3110 the Partisan AA Vehicle, a lighter take on the original Partisan Air Defense Tank, was meant to be cheaper and faster but still be equally effective in the anti-aircraft role. Produced in 3134, this version of the Partisan AA would give the vehicle a longer reach than before, while gaining secondary weaponry which the Standard Model lacked. Gone is the standard LB-5X Class autocannons, in their place are a pair of Class 2 Hypervelocity Autocannons with two tons of ammunition. Though lacking the punch of the Standard's bigger LB-5Xs, the HVAC/2s accuracy is improved by adding a Targeting Computer to the vehicle. As a secondary weapon, the vehicle is fitted with a 10-tubed Rocket Launcher in the turret.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n  <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       120    25\n<b>Left</b>         100    25\n<b>Right</b>       100    25\n<b>Rear</b>        80    25\n<b>Turret</b>      90    25\n\n<b>Total</b>      490    125\n",
     "Icon": "Vali"
   },
   "Version": 1,
@@ -84,7 +84,7 @@
       "MountedLocation": "Turret",
       "ComponentDefID": "Weapon_LRM_ROCKETLAUNCHER10",
       "ComponentDefType": "Weapon",
-      "HardpointSlot": 1,
+      "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
@@ -110,7 +110,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Crit",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Kallon_HardLock",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -124,14 +124,7 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Kallon_HardLock",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_MedRange",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Crit",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -194,6 +187,13 @@
       "MountedLocation": "Rear",
       "ComponentDefID": "Tank_Coolant_System",
       "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Tank_Turret",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     }

--- a/Republic 3081-3130/vehicle/vehicledef_Partisan_AA_vehicle.json
+++ b/Republic 3081-3130/vehicle/vehicledef_Partisan_AA_vehicle.json
@@ -23,13 +23,13 @@
   },
   "ChassisID": "vehiclechassisdef_Partisan_AA_vehicle",
   "Description": {
-    "Cost": 2458095,
+    "Cost": 2149130,
     "Rarity": 0,
     "Purchasable": false,
     "UIName": "Partisan AA Vehicle",
     "Id": "vehicledef_Partisan_AA_vehicle",
     "Name": "Partisan AA Vehicle",
-    "Details": "Unveiled in 3110 the Partisan AA Vehicle, a lighter take on the original Partisan Air Defense Tank, was meant to be cheaper and faster but still be equally effective in the anti-aircraft role. The Partisan AA Vehicle is armed with dual Defiance Shredder LB 5-X Autocannons mounted in the vehicle's turret. These guns, along with its excellent anti-aircraft equipment, allow the vehicle to engage aircraft, such as VTOLs and other airborne targets. The vehicle's three tons of ammunition is enough to sustain the vehicle in combat.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       120     25\n<b>Left</b>         100     25\n<b>Right</b>       100     25\n<b>Rear</b>         80     25\n\n<b>Total</b>      490    125\n",
+    "Details": "Unveiled in 3110 the Partisan AA Vehicle, a lighter take on the original Partisan Air Defense Tank, was meant to be cheaper and faster but still be equally effective in the anti-aircraft role. The Partisan AA Vehicle is armed with dual Defiance Shredder LB 5-X Autocannons mounted in the vehicle's turret. These guns, along with its excellent anti-aircraft equipment, allow the vehicle to engage aircraft, such as VTOLs and other airborne targets. The vehicle's three tons of ammunition is enough to sustain the vehicle in combat.\n\n <b><color=#ffcc00>Wheeled: Fast in open ground, slow in rough terrain.</color></b>\n\n  <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       120    25\n<b>Left</b>         100    25\n<b>Right</b>       100    25\n<b>Rear</b>        80    25\n<b>Turret</b>      90    25\n\n<b>Total</b>      490    125\n",
     "Icon": "Vali"
   },
   "Version": 1,
@@ -108,14 +108,14 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_FCS_Flak",
+      "ComponentDefID": "Tank_CrewCompartment",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Tank_CrewCompartment",
+      "ComponentDefID": "Gear_FCS_Flak",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -171,6 +171,13 @@
       "MountedLocation": "Rear",
       "ComponentDefID": "Tank_Coolant_System",
       "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Tank_Turret",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     }


### PR DESCRIPTION
Some fixes to address vehicle validation report issues with:
Alacorn III and IV
Partisan AA Vehicle and Mk2
Heavy Hover APC
JES III Missile carriers