### PR TITLE
Hollander size tweak and Hipparch Cavalry Tank

### DIFF
--- a/Base 3061/chassis/chassisdef_hollander_BZK-F3.json
+++ b/Base 3061/chassis/chassisdef_hollander_BZK-F3.json
@@ -33,7 +33,9 @@
   },
   "VariantName": "BZK-F3",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "MR-Resize-0.8"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Sniper",

--- a/Base 3061/chassis/chassisdef_hollander_BZK-G1.json
+++ b/Base 3061/chassis/chassisdef_hollander_BZK-G1.json
@@ -33,7 +33,9 @@
   },
   "VariantName": "BZK-G1",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "MR-Resize-0.8"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Striker",

--- a/Base 3061/chassis/chassisdef_hollander_ii_BZK-F5.json
+++ b/Base 3061/chassis/chassisdef_hollander_ii_BZK-F5.json
@@ -34,7 +34,7 @@
   "VariantName": "BZK-F5",
   "ChassisTags": {
     "items": [
-      "MR-Resize-1.15"
+      "MR-Resize-0.9"
     ],
     "tagSetSourceFile": ""
   },

--- a/Base 3061/chassis/chassisdef_hollander_ii_BZK-F7.json
+++ b/Base 3061/chassis/chassisdef_hollander_ii_BZK-F7.json
@@ -34,7 +34,7 @@
   "VariantName": "BZK-F7",
   "ChassisTags": {
     "items": [
-      "MR-Resize-1.15"
+      "MR-Resize-0.9"
     ],
     "tagSetSourceFile": ""
   },

--- a/Base 3061/vehicle/light/vehicledef_HIPPARCH.json
+++ b/Base 3061/vehicle/light/vehicledef_HIPPARCH.json
@@ -1,0 +1,215 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.25",
+            "unit_vehicle",
+            "unit_light",
+            "unit_hover",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_noconvoy",
+            "unit_generic",
+            "unit_bracket_low",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "comment_proxy_icon",
+            "unit_proxy",
+            "marian",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "chainelane",
+            "tortuga",
+            "auriganpirates",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_HIPPARCH",
+    "Description": {
+        "Cost": 378950,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Hipparch Cavalry Tank",
+        "Id": "vehicledef_HIPPARCH",
+        "Name": "Hipparch Cavalry Tank",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Intended as a scout or vanguard unit, the Light Tank is constantly on the move, probing ahead of the rest of the troops.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 7/11 Hex: 210/330 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        91     15\n<b>Left</b>          55     15\n<b>Right</b>        55     15\n<b>Rear</b>         55     15\n<b>Turret</b>       80     15\n\n<b>Total</b>      336     75\n",
+        "Icon": "J.edgar"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 65,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 65,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 65,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 65,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM2_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_140",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_HIPPARCH.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_HIPPARCH.json
@@ -1,0 +1,135 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Hipparch",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "CustomParts": {
+        "MoveCost": "Hover",
+        "MoveClamp": 0.5,
+        "FiringArc": 50
+    },
+    "Description": {
+        "Cost": 378950,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Hiparch Cavalry Tank",
+        "Id": "vehiclechassisdef_HIPPARCH",
+        "Name": "Hipparch",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Intended as a scout or vanguard unit, the Light Tank is constantly on the move, probing ahead of the rest of the troops.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 7/11 Hex: 210/330 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        91     15\n<b>Left</b>          55     15\n<b>Right</b>        55     15\n<b>Rear</b>         55     15\n<b>Turret</b>       80     15\n\n<b>Total</b>      336     75\n",
+        "Icon": "J.edgar"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_9-14cv",
+    "movementType": "Wheeled",
+    "PathingCapDefID": "pathingdef_medium_hover",
+    "HardpointDataDefID": "hardpointdatadef_jedgar",
+    "PrefabIdentifier": "chrprfvhcl_jedgarbase",
+    "PrefabBase": "jedgar",
+    "Tonnage": 30,
+    "weightClass": "LIGHT",
+    "BattleValue": 564,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 3,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3.5
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3.5
+        },
+        {
+            "x": -2,
+            "y": 3,
+            "z": 0
+        },
+        {
+            "x": 2,
+            "y": 3,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": -4.5
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 70,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 65,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 65,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 60,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 60,
+            "InternalStructure": 15
+        }
+    ]
+}

--- a/PirateTech/chassis/chassisdef_hollander_BZK-0P.json
+++ b/PirateTech/chassis/chassisdef_hollander_BZK-0P.json
@@ -33,7 +33,9 @@
   },
   "VariantName": "BZK-0P",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "MR-Resize-0.8"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Junkyard Blitzkrieg",

--- a/PirateTech/chassis/chassisdef_hollander_BZK-P.json
+++ b/PirateTech/chassis/chassisdef_hollander_BZK-P.json
@@ -35,7 +35,9 @@
   },
   "VariantName": "BZK-P",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "MR-Resize-0.8"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Sniper",

--- a/PirateTech/chassis/chassisdef_hollander_ii_BZK-P.json
+++ b/PirateTech/chassis/chassisdef_hollander_ii_BZK-P.json
@@ -36,7 +36,7 @@
   "VariantName": "BZK-P",
   "ChassisTags": {
     "items": [
-      "MR-Resize-1.15"
+      "MR-Resize-0.9"
     ],
     "tagSetSourceFile": ""
   },

--- a/RISCtech/chassis/chassisdef_hollander_BZK-RX.json
+++ b/RISCtech/chassis/chassisdef_hollander_BZK-RX.json
@@ -34,6 +34,7 @@
   "VariantName": "BZK-RX",
   "ChassisTags": {
     "items": [
+      "MR-Resize-0.8",
       "RISCBattleMech"
     ],
     "tagSetSourceFile": ""

--- a/RISCtech/chassis/chassisdef_hollander_ii_BZK-RX.json
+++ b/RISCtech/chassis/chassisdef_hollander_ii_BZK-RX.json
@@ -34,7 +34,7 @@
   "VariantName": "BZK-RX",
   "ChassisTags": {
     "items": [
-      "MR-Resize-1.15",
+      "MR-Resize-0.9",
       "RISCBattleMech"
     ],
     "tagSetSourceFile": ""

--- a/RogueModuleElites/chassis/chassisdef_hollander_ii_BZK-S7.json
+++ b/RogueModuleElites/chassis/chassisdef_hollander_ii_BZK-S7.json
@@ -34,7 +34,7 @@
   "VariantName": "BZK-S7",
   "ChassisTags": {
     "items": [
-      "MR-Resize-1.15"
+      "MR-Resize-0.9"
     ],
     "tagSetSourceFile": ""
   },


### PR DESCRIPTION
Resized Hollanders to 0.8 and Hollanders II's to 0.9 (they were 1.15). Added the Hipparch Cavalry Tank from Historical: Reunification War