### PR TITLE
Update description text in Pulse Laser Module

### DIFF
--- a/RogueModuleTech/RISC/Upgrades/Gear_Pulse_Module.json
+++ b/RogueModuleTech/RISC/Upgrades/Gear_Pulse_Module.json
@@ -262,7 +262,7 @@
     "UIName": "Laser Pulse Module",
     "Id": "Gear_Pulse_Module",
     "Name": "Pulse Module",
-    "Details": "Developed by the Republic Institute of Strategic Combat just shortly prior to the infamous Black Out, the Laser Pulse Module is designed to be fitted on any Standard or ER Laser, giving it an alternate fire mode which increases the heat output but increases the accuracy along the same lines as a Pulse Laser. When Destroyed Explodes.",
+    "Details": "Developed by the Republic Institute of Strategic Combat just shortly prior to the infamous Black Out, the Laser Pulse Module was originally designed to be fitted on any Standard or ER Laser, giving it an alternate fire mode which increases the heat output but increases the accuracy along the same lines as a Pulse Laser. Recent iterations on the prototype design have allowed integration into already existing pulse lasers by inducing microdelays into the pulse duration that allow even more vaporised armour to dissapate.",
     "Icon": "energise"
   },
   "BonusValueA": "",


### PR DESCRIPTION
The current functionality of the canon pulse laser module can't be easily replicated due to the way that weapon categories are set up. This description could be slightly misleading, so I've included a plausible non-canon explanation for this discrepancy that can be changed back later if the issue is ever addressed further down the line.