### PR TITLE
5 new Society vehicles

### DIFF
--- a/RogueSociety/vehicle/vehicledef_BADGER_C_Z.json
+++ b/RogueSociety/vehicle/vehicledef_BADGER_C_Z.json
@@ -1,121 +1,111 @@
 {
   "VehicleTags": {
     "items": [
-      "mr-resize-1.50",
       "unit_vehicle",
-      "unit_vehicle_clan",
-      "unit_medium",
-      "unit_vtol",
+      "unit_light",
+      "unit_tracks",
       "unit_release",
-      "unit_lance_support",
-      "unit_advanced",
+      "unit_generic",
       "unit_bracket_med",
-      "unit_solaris",
-      "unit_noconvoy",
+      "unit_noncombatant",
+      "unit_vehicle_apc",
+      "unit_vehicle_clan",
+      "omni_tank",
       "clanburrock",
       "clancoyote",
       "society"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "vehiclechassisdef_HawkMoth_Society_LGauss",
+  "ChassisID": "vehiclechassisdef_BADGER_C_Z",
   "Description": {
-    "Cost": 4585864,
+    "Cost": 2106815,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Society Hawk Moth",
-    "Id": "vehicledef_HawkMoth_Society_LGauss",
-    "Name": "Society Hawk Moth",
-    "Details": "A fast unit, the Light VTOL is not designed for protracted combat. Carrying an array of ranged weapons, the Light VTOL is designed to support allied units from range.\n\n <b><color=#ffcc00>VTOL: Ignores Terrain, slow in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 9/14 Hex: 270/420 Meters.</color></b>\n\n<b>Armor:</b> Glazed (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        93     15\n<b>Left</b>          60     15\n<b>Right</b>        60     15\n<b>Rear</b>         45     15\n\n<b>Total</b>      268     75\n",
-    "Icon": "HawkMoth"
+    "UIName": "Badger (C) Tracked Transport (Z)",
+    "Id": "vehicledef_BADGER_C_Z",
+    "Name": "Badger (C) Tracked Transport (Z)",
+    "Details": "The Badger-E carries an ATM-3 launcher and ER Small Laser in the turret.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<b>Armor:</b> Armor (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       120     15\n<b>Left</b>          90     15\n<b>Right</b>        90     15\n<b>Rear</b>         70     15\n<b>Turret</b>       94     15\n\n<b>Total</b>      464     75\n",
+    "Icon": "Badger"
   },
   "Version": 1,
   "Locations": [
     {
       "Location": "Front",
-      "CurrentArmor": 93,
+      "CurrentArmor": 120,
       "CurrentInternalStructure": 15,
-      "AssignedArmor": 93,
+      "AssignedArmor": 120,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Left",
-      "CurrentArmor": 60,
+      "CurrentArmor": 90,
       "CurrentInternalStructure": 15,
-      "AssignedArmor": 60,
+      "AssignedArmor": 90,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Right",
-      "CurrentArmor": 60,
+      "CurrentArmor": 90,
       "CurrentInternalStructure": 15,
-      "AssignedArmor": 60,
+      "AssignedArmor": 90,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Rear",
-      "CurrentArmor": 45,
+      "CurrentArmor": 70,
       "CurrentInternalStructure": 15,
-      "AssignedArmor": 45,
+      "AssignedArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Turret",
-      "CurrentArmor": 10,
+      "CurrentArmor": 94,
       "CurrentInternalStructure": 15,
-      "AssignedArmor": 10,
+      "AssignedArmor": 94,
       "DamageLevel": "Functional"
     }
   ],
   "inventory": [
     {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Weapon_Gauss_Gauss_LIGHT_ULTRA",
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Weapon_LRM_iATM3_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_Light_GAUSS_AP",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_iATM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_Light_GAUSS_AP",
+      "ComponentDefID": "Ammo_AmmunitionBox_HE_iATM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_Light_GAUSS_AP",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_FCS_Breaching",
+      "ComponentDefID": "Gear_Sensors_Clan",
       "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Gear_LIGHT_AP_CLAN",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Sensors_Society",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
+      "HardpointSlot": -1
     },
     {
       "MountedLocation": "Front",
@@ -131,6 +121,20 @@
       "HardpointSlot": -1
     },
     {
+      "MountedLocation": "Left",
+      "ComponentDefID": "Gear_Tracked_Left",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Right",
+      "ComponentDefID": "Gear_Tracked_Right",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "Rear",
       "ComponentDefID": "Tank_CASE_CLAN",
       "ComponentDefType": "Upgrade",
@@ -139,41 +143,55 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "emod_armorslots_clanglazed",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1
-    },
-    {
-      "MountedLocation": "Turret",
-      "ComponentDefID": "Gear_VTOL",
+      "ComponentDefID": "Tank_InfantryCompartment",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Engine_085",
+      "ComponentDefID": "emod_armorslots_clstandard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1
+    },
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Tank_Turret",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_Engine_180",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "emod_engineslots_std_center",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Left",
-      "ComponentDefID": "emod_engineslots_size2",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Right",
-      "ComponentDefID": "emod_engineslots_size2",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "emod_engineslots_cxl_center",
+      "ComponentDefID": "Gear_HeatSink_Generic_Standard",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/RogueSociety/vehicle/vehicledef_BANDIT-Z_CLAN.json
+++ b/RogueSociety/vehicle/vehicledef_BANDIT-Z_CLAN.json
@@ -1,0 +1,187 @@
+{
+  "VehicleTags": {
+    "items": [
+      "mr-resize-1.50",
+      "unit_vehicle",
+      "unit_medium",
+      "unit_hover",
+      "unit_release",
+      "unit_indirectFire",
+      "unit_lance_support",
+      "unit_bracket_low",
+      "unit_vehicle_apc",
+      "unit_vehicle_clan",
+      "clanburrock",
+      "clancoyote",
+      "society",
+      "omni_tank"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "vehiclechassisdef_BANDIT-Z_CLAN",
+  "Description": {
+    "Cost": 4769093,
+    "Rarity": 3,
+    "Purchasable": false,
+    "UIName": "Bandit Hovercraft (C)",
+    "Id": "vehicledef_BANDIT-Z_CLAN",
+    "Name": "Bandit Hovercraft (C)",
+    "Details": "The Bandit-Z carries an iATM-9 with 3 tons of ammunition to support its infantry cargo.\n\n <b><color=#ffcc00>Hover: Fast on open ground and water, slow in rough terrain, not very agile.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 9/14 Hex: 270/420 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       222     25\n<b>Left</b>         200     25\n<b>Right</b>       200     25\n<b>Rear</b>         90     25\n<b>Turret</b>      160     25\n\n<b>Total</b>      872    125\n",
+    "Icon": "Bandit"
+  },
+  "Version": 1,
+  "Locations": [
+    {
+      "Location": "Front",
+      "CurrentArmor": 222,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 222,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "Left",
+      "CurrentArmor": 200,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 200,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "Right",
+      "CurrentArmor": 200,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 200,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "Rear",
+      "CurrentArmor": 90,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 90,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "Turret",
+      "CurrentArmor": 160,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 160,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Weapon_LRM_iATM9_CLAN",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_ER_iATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_iATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_HE_iATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Front",
+      "ComponentDefID": "Gear_FCS_Generic_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1
+    },
+    {
+      "MountedLocation": "Front",
+      "ComponentDefID": "Gear_Sensors_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1
+    },
+    {
+      "MountedLocation": "Front",
+      "ComponentDefID": "Tank_CrewCompartment",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Front",
+      "ComponentDefID": "emod_structureslots_standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1
+    },
+    {
+      "MountedLocation": "Left",
+      "ComponentDefID": "Gear_Hover_Left",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Right",
+      "ComponentDefID": "Gear_Hover_Right",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Tank_CASE_CLAN",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Tank_InfantryCompartment",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1
+    },
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Tank_Turret",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_Engine_215",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "emod_engineslots_std_center",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Tank_Coolant_System",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/RogueSociety/vehicle/vehicledef_DEMOLISHER_CLAN_Z.json
+++ b/RogueSociety/vehicle/vehicledef_DEMOLISHER_CLAN_Z.json
@@ -1,0 +1,242 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_vehicle_clan",
+            "unit_assault",
+            "unit_tracks",
+            "unit_lance_tank",
+            "unit_bracket_high",
+            "unit_predator",
+            "unit_demolisher",
+            "unit_advanced",
+            "clanburrock",
+            "clancoyote",
+            "society"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_DEMOLISHER_CLAN_Z",
+    "Description": {
+        "Cost": 8500005,
+        "Rarity": 5,
+        "Purchasable": false,
+        "UIName": "Society Demolisher",
+        "Id": "vehicledef_DEMOLISHER_CLAN_Z",
+        "Name": "Society Demolisher",
+        "Details": "Developed by the Clans in 3058, this variant carries twin LB 20-X ACs as its main armament and with 40 salvos can deliver a lot of damage to its enemies. Mounted coaxially with these huge autocannon are a pair of Medium Pulse Lasers. Six Machine Guns scattered across the front and side arcs protect it from infantry. Like most Clan vehicles, the Clan Demolisher carries CASE to protect the ammunition bay.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       252     40\n<b>Left</b>         200     40\n<b>Right</b>       200     40\n<b>Rear</b>        120     40\n<b>Turret</b>      160     40\n\n<b>Total</b>      932    200\n",
+        "Icon": "Demolisher"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 252,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 252,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 200,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 200,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 200,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 200,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 120,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 120,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 160,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 160,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Gauss_HAG30_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Gauss_HAG30_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_LBX_CLUSTER_AC20",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Ammo_AmmunitionBox_Hyper_GAUSS_double",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Ammo_AmmunitionBox_Hyper_GAUSS_double",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Hyper_GAUSS_double",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Hyper_GAUSS",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_Nova_CEWS",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Crit",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Kallon_HardLock",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Gunnery",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Tactics",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_Sensors_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_CASE_CLAN",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_clstandard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_240",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_FuelCell",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/RogueSociety/vehicle/vehicledef_LIGHTNING_Z.json
+++ b/RogueSociety/vehicle/vehicledef_LIGHTNING_Z.json
@@ -1,0 +1,198 @@
+{
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_hover",
+            "unit_generic",
+            "unit_predator",
+            "unit_bracket_low",
+            "clanburrock",
+            "clancoyote",
+            "society"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_LIGHTNING_Z",
+    "Description": {
+        "Cost": 4396880,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Lightning Attack Hovercraft (Society)",
+        "Id": "vehicledef_LIGHTNING_Z",
+        "Name": "Lightning Attack Hovercraft (Society)",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Intended as a scout or vanguard unit, the Light Tank is constantly on the move, probing ahead of the rest of the troops.\n\n <b><color=#ffcc00>Hover: Fast on open ground and water, slow in rough terrain, not very agile.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 11/17 Hex: 330/510 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       121     20\n<b>Left</b>          82     20\n<b>Right</b>        82     20\n<b>Rear</b>         50     20\n\n<b>Total</b>      335     80\n",
+        "Icon": "Lightning"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 121,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 121,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 82,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 82,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 82,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 82,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 50,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 50,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_TAG",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 4,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM4_STREAK_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_SRM_SRM4_STREAK_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Streak_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_RCA_InstaTrac-XII",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_Sensors_SLDF",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_ferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/RogueSociety/vehicle/vehicledef_ORO_CLAN_SOCIETY.json
+++ b/RogueSociety/vehicle/vehicledef_ORO_CLAN_SOCIETY.json
@@ -1,0 +1,199 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.5",
+            "unit_vehicle",
+            "unit_vehicle_clan",
+            "unit_heavy",
+            "unit_tracks",
+            "unit_release",
+            "unit_predator",
+            "unit_lance_assassin",
+            "unit_bracket_med",
+            "clanburrock",
+            "clancoyote",
+            "society"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_ORO_CLAN_SOCIETY",
+    "Description": {
+        "Cost": 6166544,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Oro",
+        "Id": "vehicledef_ORO_CLAN_SOCIETY",
+        "Name": "Oro",
+        "Details": "Largely similar to the stock Oro, the Society model drops the ER Medium Laser for a Nova CEWS and additional armour; resulting in a tank that is better protected and more effective. Qualities essential when considering the poorly skilled vehicle crews the Society is forced to use.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     30\n<b>Left</b>         120     30\n<b>Right</b>       120     30\n<b>Rear</b>         90     30\n<b>Turret</b>      120     30\n\n<b>Total</b>      630    150\n",
+        "Icon": "Oro"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 180,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 180,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 130,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 130,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 130,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 130,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 120,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 120,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 120,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 120,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Autocannon_AC20_LBX_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_LargeLaserPulse_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LBX_CLUSTER_AC20",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LBX_CLUSTER_AC20",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LBX_SLUG_AC20",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_Nova_CEWS",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_FCS_Generic_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_Sensors_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_CASE_CLAN",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_240",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/RogueSociety/vehicleChassis/vehiclechassisdef_BADGER_C_Z.json
+++ b/RogueSociety/vehicleChassis/vehiclechassisdef_BADGER_C_Z.json
@@ -1,0 +1,132 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Badger",
+      "Exclude": false,
+      "Include": true
+    },
+    "CustomWeights": [
+      {
+        "ComponentDefID": "Tank_InfantryCompartment",
+        "Tonnage": 5
+      }
+    ]
+  },
+  "Description": {
+    "Cost": 2106815,
+    "Rarity": 0,
+    "Purchasable": false,
+    "UIName": "Badger (C) Tracked Transport (Z)",
+    "Id": "vehiclechassisdef_BADGER_C_Z",
+    "Name": "Badger",
+    "Details": "The Badger-E carries an ATM-3 launcher and ER Small Laser in the turret.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<b>Armor:</b> Armor (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       120     15\n<b>Left</b>          90     15\n<b>Right</b>        90     15\n<b>Rear</b>         70     15\n<b>Turret</b>       94     15\n\n<b>Total</b>      464     75\n",
+    "Icon": "Badger"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_6-9cv",
+  "movementType": "Tracked",
+  "PathingCapDefID": "pathingdef_light_tracked",
+  "HardpointDataDefID": "hardpointdatadef_badger",
+  "PrefabIdentifier": "chrprfvhcl_badger",
+  "PrefabBase": "badger",
+  "Tonnage": 30,
+  "weightClass": "LIGHT",
+  "BattleValue": 564,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 3,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3.25,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3.25,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    },
+    {
+      "x": -1.5,
+      "y": 4,
+      "z": 0
+    },
+    {
+      "x": 1.5,
+      "y": 4,
+      "z": 0
+    },
+    {
+      "x": 0,
+      "y": 2.5,
+      "z": -4
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 120,
+      "InternalStructure": 15
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 90,
+      "InternalStructure": 15
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 90,
+      "InternalStructure": 15
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 70,
+      "InternalStructure": 15
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 94,
+      "InternalStructure": 15
+    }
+  ]
+}

--- a/RogueSociety/vehicleChassis/vehiclechassisdef_BANDIT-Z_CLAN.json
+++ b/RogueSociety/vehicleChassis/vehiclechassisdef_BANDIT-Z_CLAN.json
@@ -1,0 +1,132 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Bandit",
+      "Exclude": false,
+      "Include": true
+    },
+    "CustomWeights": [
+      {
+        "ComponentDefID": "Tank_InfantryCompartment",
+        "Tonnage": 5
+      }
+    ]
+  },
+  "CustomParts": {
+    "MoveCost": "Hover",
+    "MoveClamp": 0.5
+  },
+  "Description": {
+    "Cost": 4769093,
+    "Rarity": 3,
+    "Purchasable": false,
+    "UIName": "Bandit Hovercraft (C)",
+    "Id": "vehiclechassisdef_BANDIT-Z_CLAN",
+    "Name": "Bandit (C)",
+    "Details": "The Bandit-Z carries an iATM-9 with 3 tons of ammunition to support its infantry cargo.\n\n <b><color=#ffcc00>Hover: Fast on open ground and water, slow in rough terrain, not very agile.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 9/14 Hex: 270/420 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       222     25\n<b>Left</b>         200     25\n<b>Right</b>       200     25\n<b>Rear</b>         90     25\n<b>Turret</b>      160     25\n\n<b>Total</b>      872    125\n",
+    "Icon": "Bandit"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_9-14cv",
+  "movementType": "Wheeled",
+  "PathingCapDefID": "pathingdef_medium_hover",
+  "HardpointDataDefID": "hardpointdatadef_bandit",
+  "PrefabIdentifier": "chrprfvhcl_banditbase",
+  "PrefabBase": "bandit",
+  "Tonnage": 50,
+  "weightClass": "MEDIUM",
+  "BattleValue": 993,
+  "TopSpeed": 500,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 4,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3,
+      "z": -0.5
+    },
+    {
+      "x": 0.0,
+      "y": 1.5,
+      "z": 3.5
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3,
+      "z": -0.5
+    },
+    {
+      "x": 0.0,
+      "y": 1.5,
+      "z": 3.5
+    },
+    {
+      "x": -2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 0.0,
+      "y": 1.6,
+      "z": -4.0
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 222,
+      "InternalStructure": 25
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 200,
+      "InternalStructure": 25
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 200,
+      "InternalStructure": 25
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 100,
+      "InternalStructure": 25
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 160,
+      "InternalStructure": 25
+    }
+  ]
+}

--- a/RogueSociety/vehicleChassis/vehiclechassisdef_DEMOLISHER_CLAN_Z.json
+++ b/RogueSociety/vehicleChassis/vehiclechassisdef_DEMOLISHER_CLAN_Z.json
@@ -1,0 +1,126 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Demolisher",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "Description": {
+    "Cost": 8500005,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Society Demolisher",
+    "Id": "vehiclechassisdef_DEMOLISHER_CLAN_Z",
+    "Name": "Demolisher",
+    "Details": "Developed by the Clans in 3058, this variant carries twin LB 20-X ACs as its main armament and with 40 salvos can deliver a lot of damage to its enemies. Mounted coaxially with these huge autocannon are a pair of Medium Pulse Lasers. Six Machine Guns scattered across the front and side arcs protect it from infantry. Like most Clan vehicles, the Clan Demolisher carries CASE to protect the ammunition bay.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<b>Armor:</b> Armor (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       252     40\n<b>Left</b>         200     40\n<b>Right</b>       200     40\n<b>Rear</b>        120     40\n<b>Turret</b>      160     40\n\n<b>Total</b>      932    200\n",
+    "Icon": "Demolisher"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_3-5cv",
+  "movementType": "Tracked",
+  "PathingCapDefID": "pathingdef_assault_tracked",
+  "HardpointDataDefID": "hardpointdatadef_demolisher",
+  "PrefabIdentifier": "chrPrfVhcl_demolisher",
+  "PrefabBase": "demolisher",
+  "Tonnage": 80,
+  "weightClass": "ASSAULT",
+  "BattleValue": 2993,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 4,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 4.5
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 4.5
+    },
+    {
+      "x": -2,
+      "y": 3,
+      "z": 0
+    },
+    {
+      "x": 2,
+      "y": 3,
+      "z": 0
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "z": -4.5
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 252,
+      "InternalStructure": 40
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 200,
+      "InternalStructure": 40
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 200,
+      "InternalStructure": 40
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 120,
+      "InternalStructure": 40
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Ballistic",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 160,
+      "InternalStructure": 40
+    }
+  ]
+}

--- a/RogueSociety/vehicleChassis/vehiclechassisdef_LIGHTNING_Z.json
+++ b/RogueSociety/vehicleChassis/vehiclechassisdef_LIGHTNING_Z.json
@@ -1,0 +1,134 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Lightning",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "MoveCost": "Hover",
+    "MoveClamp": 0.5
+  },
+  "Description": {
+    "Cost": 4396880,
+    "Rarity": 0,
+    "Purchasable": false,
+    "UIName": "Lightning Attack Hovercraft (Society)",
+    "Id": "vehiclechassisdef_LIGHTNING_Z",
+    "Name": "Lightning",
+    "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Intended as a scout or vanguard unit, the Light Tank is constantly on the move, probing ahead of the rest of the troops.\n\n <b><color=#ffcc00>Hover: Fast on open ground and water, slow in rough terrain, not very agile.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 11/17 Hex: 330/510 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       121     20\n<b>Left</b>          82     20\n<b>Right</b>        82     20\n<b>Rear</b>         50     20\n\n<b>Total</b>      335     80\n",
+    "Icon": "Lightning"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_11-17cv",
+  "movementType": "Wheeled",
+  "PathingCapDefID": "pathingdef_light_hover",
+  "HardpointDataDefID": "hardpointdatadef_lightning",
+  "PrefabIdentifier": "chrprfvhcl_lightning",
+  "PrefabBase": "lightning",
+  "Tonnage": 35,
+  "weightClass": "LIGHT",
+  "BattleValue": 564,
+  "TopSpeed": 125,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 4,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 2.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 2.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    },
+    {
+      "x": -2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": -4.5
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "AntiPersonnel",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 121,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 82,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 82,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 50,
+      "InternalStructure": 20
+    }
+  ]
+}

--- a/RogueSociety/vehicleChassis/vehiclechassisdef_ORO_CLAN_SOCIETY.json
+++ b/RogueSociety/vehicleChassis/vehiclechassisdef_ORO_CLAN_SOCIETY.json
@@ -1,0 +1,126 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Oro",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "Description": {
+        "Cost": 6166544,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Oro",
+        "Id": "vehiclechassisdef_ORO_CLAN_SOCIETY",
+        "Name": "Oro",
+        "Details": "Largely similar to the stock Oro, the Society model drops the ER Medium Laser for a Nova CEWS and additional armour; resulting in a tank that is better protected and more effective. Qualities essential when considering the poorly skilled vehicle crews the Society is forced to use.\n\n <b><color=#ffcc00>Tracked: High traction, agile turning.</color></b>\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Ferro-Fibrous (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     30\n<b>Left</b>         120     30\n<b>Right</b>       120     30\n<b>Rear</b>         90     30\n<b>Turret</b>      120     30\n\n<b>Total</b>      630    150\n",
+        "Icon": "Oro"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_4-6cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_heavy_tracked",
+    "HardpointDataDefID": "hardpointdatadef_oro",
+    "PrefabIdentifier": "chrprfvhcl_orobase",
+    "PrefabBase": "oro",
+    "Tonnage": 60,
+    "weightClass": "HEAVY",
+    "BattleValue": 1116,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 4,
+            "z": -2
+        },
+        {
+            "x": 0,
+            "y": 2.5,
+            "z": 4
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 4,
+            "z": -2
+        },
+        {
+            "x": 0,
+            "y": 2.5,
+            "z": 4
+        },
+        {
+            "x": -1.5,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 1.5,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 0.0,
+            "y": 2.5,
+            "z": -4
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 180,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 120,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 120,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 90,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Ballistic",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 120,
+            "InternalStructure": 30
+        }
+    ]
+}


### PR DESCRIPTION
Added 5 new custom Society tanks - a Badger and Bandit refit (both replace the ATM's with iATM's), a refit of the Royal Lightning (swaps the IS MPL's for Clan ERML's and the IS SSRM-2's for Clan SSRM-4's and adds in a TC), the Oro (loses the ERML and it's 5 heatsinks for more armour, ammo and a NCEWS)  and the Demolisher (Double HAG/30 with TC and NCEWS)