### PR TITLE
Cargo temp tank coolant

### DIFF
--- a/RogueModuleTech/Tanks/TankEngines/Tank_Coolant_System.json
+++ b/RogueModuleTech/Tanks/TankEngines/Tank_Coolant_System.json
@@ -8,6 +8,11 @@
         "CategoryID": "EngineHeatBlock"
       }
     ],
+    "BonusDescriptions": {
+      "Bonuses": [
+        "TankCoolantCrit"
+      ]
+    },
     "WorkOrderCosts": {
       "Default": {
         "TechCost": "0.06667 * [[Chassis.Tonnage]]",

--- a/RogueModuleTech/Tanks/TankEngines/Tank_Coolant_System.json
+++ b/RogueModuleTech/Tanks/TankEngines/Tank_Coolant_System.json
@@ -6,9 +6,6 @@
       },
       {
         "CategoryID": "EngineHeatBlock"
-      },
-      {
-        "CategoryID": "EnginePart"
       }
     ],
     "WorkOrderCosts": {

--- a/RogueTech Core/bonusDescriptions/BonusDescriptions_Vehicles.json
+++ b/RogueTech Core/bonusDescriptions/BonusDescriptions_Vehicles.json
@@ -7,6 +7,12 @@
       "Full": "Tracks let you crawl up and over pretty much anything, just don't expect speed."
     },
     {
+      "Bonus": "TrackedMotive",
+      "Short": "Tracks",
+      "Long": "Tracks",
+      "Full": "Tracks let you crawl up and over pretty much anything, just don't expect speed."
+    },
+    {
       "Bonus": "WheeledMotive",
       "Short": "Wheels",
       "Long": "Wheels",
@@ -53,6 +59,12 @@
       "Short": "Turret",
       "Long": "Turret",
       "Full": "Critical hits to the Turret system reduce Accuracy and increase Recoil"
+    },
+    {
+      "Bonus": "TankCoolantCrit",
+      "Short": "Coolant",
+      "Long": "Coolant",
+      "Full": "Critical hits to the Coolant system will decrease Energy weapon damage output."
     }
   ]
 }

--- a/RogueTech Core/categories/Categories_MechEngineer.json
+++ b/RogueTech Core/categories/Categories_MechEngineer.json
@@ -312,6 +312,17 @@
       "MinEquiped": 1,
       "AutoReplace": true,
       "DefaultCustoms": {
+        "VehicleCriticalEffects": {
+          "LinkedStatisticName": "VehicleEngineCrits",
+          "PenalizedEffectIDs": [
+            [
+              "CriticalEffect-VehicleCoolantCrit1",
+              "CriticalEffect-VehicleCoolantCrit2",
+              "CriticalEffect-CoolantTankCritPenalty"
+            ]
+          ],
+          "DeathMethod": "EngineDestroyed"
+        },
         "InventorySorter": {
           "SortKey": "CzOrder5"
         },

--- a/RogueTech Core/criticalEffects/MechEngineer_TankCritPenalty.json
+++ b/RogueTech Core/criticalEffects/MechEngineer_TankCritPenalty.json
@@ -249,6 +249,31 @@
         "modType": "System.Single"
       },
       "nature": "Debuff"
+    },
+    {
+      "durationData": {
+        "duration": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "Description": {
+        "Id": "CriticalEffect-CoolantTankCritPenalty",
+        "Name": "Tank Crit Penalty",
+        "Details": "Tank more likely to be crit.",
+        "Icon": "uixSvgIcon_equipment_TTS"
+      },
+      "statisticData": {
+        "statName": "CriticalHitChanceReceivedMultiplier",
+        "operation": "Float_Multiply",
+        "modValue": "1.3",
+        "modType": "System.Single"
+      },
+      "nature": "Debuff"
     }
   ]
 }

--- a/RogueTech Core/criticalEffects/MechEngineer_VehicleCoolant.json
+++ b/RogueTech Core/criticalEffects/MechEngineer_VehicleCoolant.json
@@ -1,0 +1,70 @@
+{
+  "Settings": [
+    {
+      "Description": {
+        "Id": "CriticalEffect-VehicleCoolantCrit1",
+        "Name": "Reduced Cooling",
+        "Details": "As a vehicle's cooling system degrades the power it can run through it's energy weapons without cooking decreases.",
+        "Icon": "UixSvgIcon_specialAbility_HiredGuns"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false,
+        "hideApplicationFloatie": true
+      },
+      "statisticData": {
+        "statName": "DamagePerShot",
+        "operation": "Float_Multiply",
+        "modValue": "0.8",
+        "modType": "System.Single",
+        "additionalRules": "NotSet",
+        "targetCollection": "Weapon",
+        "targetWeaponCategory": "Energy",
+        "targetWeaponType": "NotSet",
+        "targetAmmoCategory": "NotSet",
+        "targetWeaponSubType": "NotSet"
+      }
+    },
+    {
+      "Description": {
+        "Id": "CriticalEffect-VehicleCoolantCrit2",
+        "Name": "Reduced Cooling",
+        "Details": "As a vehicle's cooling system degrades the power it can run through it's energy weapons without cooking decreases.",
+        "Icon": "UixSvgIcon_specialAbility_HiredGuns"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false,
+        "hideApplicationFloatie": true
+      },
+      "statisticData": {
+        "statName": "DamagePerShot",
+        "operation": "Float_Multiply",
+        "modValue": "0.8",
+        "modType": "System.Single",
+        "additionalRules": "NotSet",
+        "targetCollection": "Weapon",
+        "targetWeaponCategory": "Energy",
+        "targetWeaponType": "NotSet",
+        "targetAmmoCategory": "NotSet",
+        "targetWeaponSubType": "NotSet"
+      }
+    }
+  ]
+}

--- a/RogueTech Core/criticalEffects/MechEngineer_VehicleCoolant.json
+++ b/RogueTech Core/criticalEffects/MechEngineer_VehicleCoolant.json
@@ -23,7 +23,7 @@
       "statisticData": {
         "statName": "DamagePerShot",
         "operation": "Float_Multiply",
-        "modValue": "0.8",
+        "modValue": "0.75",
         "modType": "System.Single",
         "additionalRules": "NotSet",
         "targetCollection": "Weapon",
@@ -56,7 +56,7 @@
       "statisticData": {
         "statName": "DamagePerShot",
         "operation": "Float_Multiply",
-        "modValue": "0.8",
+        "modValue": "0.5",
         "modType": "System.Single",
         "additionalRules": "NotSet",
         "targetCollection": "Weapon",


### PR DESCRIPTION
New MC critical effects for tank coolant systems. Disconnected from Engine crits so they can drive with no coolant system.
Coolant crits reduce Energy weapon damage output.

I don't do much with MC so I'm not sure this is complete and functional.