### PR TITLE
Gear_Cockpit_Proto_Superheavymetal: Change bonus description: Initiative from +1 to +2

### DIFF
--- a/RogueModuleTech/ProtoMech/PMInternals/Gear_Cockpit_Proto_Superheavymetal.json
+++ b/RogueModuleTech/ProtoMech/PMInternals/Gear_Cockpit_Proto_Superheavymetal.json
@@ -24,7 +24,7 @@
         "Recoil: -1",
         "CalledShot: 20%",
         "StabDamageTaken: -50%",
-        "Initiative: +1",
+        "Initiative: +2",
         "EvaMax: +2",
         "EvaPips: +1",
         "AccuracyER: +2",


### PR DESCRIPTION
Change Initiative from +1 to +2 to be consistent with BaseInitiative in
statusEffects and not with BaseInitiative in Auras statusEffects used
by PirateJammer.