### PR TITLE
PirateJammer: Change negated BaseInitiative bonus

### DIFF
--- a/RogueModuleTech/ProtoMech/PMInternals/Gear_Cockpit_Proto_Superheavymetal.json
+++ b/RogueModuleTech/ProtoMech/PMInternals/Gear_Cockpit_Proto_Superheavymetal.json
@@ -118,7 +118,7 @@
           "statisticData": {
             "statName": "BaseInitiative",
             "operation": "Int_Add",
-            "modValue": "-1",
+            "modValue": "1",
             "modType": "System.Int32"
           }
         },

--- a/RogueModuleTech/Quirks/Upgrade/Quirk_Pirate_ECM.json
+++ b/RogueModuleTech/Quirks/Upgrade/Quirk_Pirate_ECM.json
@@ -100,7 +100,7 @@
           "statisticData": {
             "statName": "BaseInitiative",
             "operation": "Int_Add",
-            "modValue": "-2",
+            "modValue": "2",
             "modType": "System.Int32"
           }
         },


### PR DESCRIPTION
PirateJammer provides a initiative debuff to enemies in range. And
counterintuitive positive values decrease the overall initiative.