### PR TITLE
Change RecoilExponent and AccuracyExponent bonus

### DIFF
--- a/RogueModuleTech/Artillery/Weapon_Artillery_ArrowIV.json
+++ b/RogueModuleTech/Artillery/Weapon_Artillery_ArrowIV.json
@@ -20,7 +20,7 @@
         "WpnRecoil: 1",
         "ForbiddenRange: 180",
         "AMSChance: -20%",
-        "RecoilExponent: 0.15",
+        "RecoilExponent: 0.1",
         "AccuracyExponent: -0.1",
         "RangeExponent: -0.25"
       ]

--- a/RogueModuleTech/RISC/Weapons/Weapon_PPC_TSEMP.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_PPC_TSEMP.json
@@ -16,7 +16,7 @@
         "EMPHEAT: 80%",
         "WpnRecoil: 2",
         "RecoilExponent: 0.5",
-        "AccuracyExponent: -0.3",
+        "AccuracyExponent: -0.35",
         "ExplodiumFlat: 20%",
         "CapacitorBoom: 35",
         "NoAA",

--- a/RogueModuleTech/Weapons/Weapon_Gauss_Gauss_HEAVY.json
+++ b/RogueModuleTech/Weapons/Weapon_Gauss_Gauss_HEAVY.json
@@ -13,7 +13,7 @@
         "DmgFallOff: 70%",
         "WpnRecoil: 2",
         "RecoilExponent: 0.5",
-        "AccuracyExponent: -0.3",
+        "AccuracyExponent: -0.35",
         "TACExponent: -0.2",
         "CRITExponent: -0.2",
         "IsHeavyGauss",


### PR DESCRIPTION
Change RecoilExponent bonus to be consistent with RefireModifier in
evasivePipsMods and AccuracyExponent bonus to be consistent with
AccuracyModifier in evasivePipsMods.