### PR TITLE
Fix MineClearanceBoom bonuses

### DIFF
--- a/RogueModuleTech/Weapons/Weapon_Suspicious_Cargo.json
+++ b/RogueModuleTech/Weapons/Weapon_Suspicious_Cargo.json
@@ -102,7 +102,7 @@
   "FireOnSuccessHit": true,
   "AlwaysIndirectVisuals": true,
   "AMSImmune": true,
-  "ClearMineFieldRadius": 25,
+  "ClearMineFieldRadius": 24,
   "CantHitUnaffecedByPathing": true,
   "ProjectileSpeedMultiplier": 5,
   "ProjectileScale": {

--- a/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_ArrowIV.json
+++ b/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_ArrowIV.json
@@ -10,7 +10,7 @@
         "AreaOfEffect: 75",
         "AreaOfEffectConversion: 90%",
         "ArrowIVAmmo: 5",
-        "MineClearanceBoom: 5",
+        "MineClearanceBoom: 2",
         "MissileHP: 30",
         "AmmoCost: 1300"
       ]

--- a/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_LongTom.json
+++ b/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_LongTom.json
@@ -10,7 +10,7 @@
         "AreaOfEffect: 105",
         "AreaOfEffectConversion: 90%",
         "LongTomAmmo: 5",
-        "MineClearanceBoom: 10",
+        "MineClearanceBoom: 3",
         "AmmoCost: 2170"
       ]
     },

--- a/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Sniper.json
+++ b/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Sniper.json
@@ -10,7 +10,7 @@
         "AreaOfEffect: 75",
         "AreaOfEffectConversion: 90%",
         "SniperAmmo: 10",
-        "MineClearanceBoom: 6",
+        "MineClearanceBoom: 2",
         "AmmoCost: 1300"
       ]
     },

--- a/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Sniper_half.json
+++ b/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Sniper_half.json
@@ -10,7 +10,7 @@
         "AreaOfEffect: 75",
         "AreaOfEffectConversion: 90%",
         "SniperAmmo: 5",
-        "MineClearanceBoom: 6",
+        "MineClearanceBoom: 2",
         "AmmoCost: 1300"
       ]
     },

--- a/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Thumper.json
+++ b/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Thumper.json
@@ -10,7 +10,7 @@
         "AreaOfEffect: 60",
         "AreaOfEffectConversion: 90%",
         "ThumperAmmo: 20",
-        "MineClearanceBoom: 4",
+        "MineClearanceBoom: 2",
         "AmmoCost: 930"
       ]
     },

--- a/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Thumper_half.json
+++ b/RogueMunitions/Artillery/Ammo_AmmunitionBox_Generic_Thumper_half.json
@@ -10,7 +10,7 @@
         "AreaOfEffect: 60",
         "AreaOfEffectConversion: 90%",
         "ThumperAmmo: 10",
-        "MineClearanceBoom: 4",
+        "MineClearanceBoom: 2",
         "AmmoCost: 930"
       ]
     },

--- a/RogueSociety/weapons/Weapon_Tesla_Rifle.json
+++ b/RogueSociety/weapons/Weapon_Tesla_Rifle.json
@@ -99,7 +99,7 @@
   "AllowedLocations": "All",
   "DisallowedLocations": "All",
   "CriticalComponent": false,
-  "ClearMineFieldRadius": 2,
+  "ClearMineFieldRadius": 15,
   "evasivePipsMods": {
     "RefireModifier": 0.25,
     "AccuracyModifier": -0.25


### PR DESCRIPTION
Here is another fix I'm not 100% sure I got everything right. I created the following table 
from the existing values:

MineClearanceBoom    ClearMineFieldRadius
1                    <=8
2                    <=16
3                    <=24
4                    <=32
5                    <=40
6                    <=48

Here are some examples that match:

Name                               MineClearanceBoom    ClearMineFieldRadius
Weapon_PPC_LBXPPC_Quicsell: 1/5
Weapon_PowerArmor_PPC: 1/8
Weapon_PPC_HEAVY: 2/15
Weapon_PPC_SNUBNOSE: 2/16
Weapon_PPC_PPC_SILLY: 3/20
Weapon_Bomb_FAE: 3/22
Weapon_Bomb_DaisyCutter: 3/23
Hand_Weapon_Grenade: 4/30
Weapon_Bomb_MOAB: 4/32
Ammo_TacNuke_Thunderbolt_TB15: 5/x
Ammunition_TBOLT15_Nuke: x/37
Weapon_Suspicious_Cargo_Nuke: 6/45

And here are the ones I changed, because I think they are not correct:
Weapon_Suspicious_Cargo: 3/25
Weapon_Tesla_Rifle: 2/2
Ammo_AmmunitionBox_Generic_LongTom: 10/x
Ammunition_LongTom: x/21
Ammo_AmmunitionBox_Generic_Sniper: 6/x
Ammunition_Sniper: x/15
Ammo_AmmunitionBox_Generic_ArrowIV: 5/x
Ammunition_ArrowIV: x/15
Ammo_AmmunitionBox_Generic_Thumper: 4/x
Ammunition_Thumper: x/15

And here the values I changed them to:
Weapon_Suspicious_Cargo: 3/24
Weapon_Tesla_Rifle: 2/15
Ammo_AmmunitionBox_Generic_LongTom: 3/x
Ammunition_LongTom: x/21
Ammo_AmmunitionBox_Generic_Sniper: 2/x
Ammunition_Sniper: x/15
Ammo_AmmunitionBox_Generic_ArrowIV: 2/x
Ammunition_ArrowIV: x/15
Ammo_AmmunitionBox_Generic_Thumper: 2/x
Ammunition_Thumper: x/15

I think the ammunition is relatively clear. The Weapon_Tesla_Rifle looks
to me like a PPC and all the PPC have similar values. The
Weapon_Suspicious_Cargo should have a MineClearanceBoom of 4 with
ClearMineFieldRadius 25 according to my table. I thought it more consistent
to reduce ClearMineFieldRadius to 24 to get inside the MineClearanceBoom 3
range.