### PR TITLE
fix category ids of Weapon_Laser_Raventurret

### DIFF
--- a/RogueModuleTech/Quirks/Weapon/Weapon_Laser_Raventurret.json
+++ b/RogueModuleTech/Quirks/Weapon/Weapon_Laser_Raventurret.json
@@ -5,13 +5,16 @@
         "CategoryID": "ECM"
       },
       {
+        "CategoryID": "AdvECM"
+      },
+      {
         "CategoryID": "Probe"
       },
       {
         "CategoryID": "Turret"
       },
       {
-        "CategoryID": "w/e/l/laser"
+        "CategoryID": "w/e/l/pulse"
       },
       {
         "CategoryID": "CritsLaser2"


### PR DESCRIPTION
The item has the bonuses Pulse and MultiLaser therfore it should be in
the category w/e/l/pulse instead of w/e/l/laser. And the bonus EWSytem
indicates as far as I can tell, that the item should also be in the
category AdvECM.