### PR TITLE
fix EWSProbe bonuses

### DIFF
--- a/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_AR14.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_AR14.json
@@ -30,7 +30,7 @@
       "Bonuses": [
         "CockpitEWS",
         "EWSSelf: 6, 6",
-        "EWSProbe: 15%, 2, 2, 180",
+        "EWSProbe: 15%, 2, 2, 200",
         "UAV: 310, 2, 15"
       ]
     },

--- a/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_Transband.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_Transband.json
@@ -27,7 +27,7 @@
       "Bonuses": [
         "CockpitEWS",
         "EWSSelf: 2, 3",
-        "EWSProbe: 1, 15%, 1, 300",
+        "EWSProbe: 15%, 1, 1, 300",
         "C3Sytem: 1, 20%, 6%, 4%, 300"
       ]
     },


### PR DESCRIPTION
On Gear_Sensors_Transband the second and third parameter got switched
and on Gear_Sensors_AR14 the aura range is 200 instead of 180.