### PR TITLE
Fix items with wrong category id w/s/m/pa

### DIFF
--- a/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER10.json
+++ b/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER10.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/pa"
+        "CategoryID": "w/m/s/rl"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER15.json
+++ b/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER15.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/pa"
+        "CategoryID": "w/m/s/rl"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER20.json
+++ b/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER20.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/pa"
+        "CategoryID": "w/m/s/rl"
       },
       {
         "CategoryID": "CritsRockets2"

--- a/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER5.json
+++ b/RogueModuleTech/Primitive/Weapons/Weapon_MINE_DISPENSER5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/pa"
+        "CategoryID": "w/m/s/rl"
       }
     ],
     "BonusDescriptions": {

--- a/RogueModuleTech/Quirks/Weapon/Weapon_HEAVYAOE_ROCKETLAUNCHER20_Corsair.json
+++ b/RogueModuleTech/Quirks/Weapon/Weapon_HEAVYAOE_ROCKETLAUNCHER20_Corsair.json
@@ -8,7 +8,7 @@
         "CategoryID": "ArmUpperActuator"
       },
       {
-        "CategoryID": "w/s/m/pa"
+        "CategoryID": "w/m/s/rl"
       },
       {
         "CategoryID": "CritsRockets6"

--- a/RogueModuleTech/Quirks/Weapon/Weapon_MRM_20_Corsair.json
+++ b/RogueModuleTech/Quirks/Weapon/Weapon_MRM_20_Corsair.json
@@ -8,7 +8,7 @@
         "CategoryID": "ArmUpperActuator"
       },
       {
-        "CategoryID": "w/s/m/pa"
+        "CategoryID": "w/m/s/mrm"
       },
       {
         "CategoryID": "CritsMRM4"


### PR DESCRIPTION
As far as I can tell the category w/s/m/pa is for PowerArmour items.
And the following items are all Rockets except Weapon_MRM_20_Corsair
which is a MRM.