### PR TITLE
Add missing percent sign to mode based JAM bonuses

### DIFF
--- a/ExperimentalWeapons/weapon/Weapon_Gauss_Rotary_Gauss_Rifle.json
+++ b/ExperimentalWeapons/weapon/Weapon_Gauss_Rotary_Gauss_Rifle.json
@@ -16,7 +16,7 @@
         "WpnAccuracy: -1",
         "WpnRecoilShot: 2",
         "WeaponJAMFlatShot: 6%",
-        "MisfireChanceMode1: 55, Overload",
+        "MisfireChanceMode1: 55%, Overload",
         "WeaponGaussBoom: 125"
       ]
     },

--- a/PirateTech/Items/Weapons/Weapon_LRM_Thunderbolt30-jrig.json
+++ b/PirateTech/Items/Weapons/Weapon_LRM_Thunderbolt30-jrig.json
@@ -14,8 +14,8 @@
         "WpnAccuracy: -1",
         "AMSChance: -15%",
         "WpnRecoil: 3",
-        "MisfireChanceMode1: 15, x3",
-        "MisfireChanceMode2: 42, x6",
+        "MisfireChanceMode1: 15%, x3",
+        "MisfireChanceMode2: 42%, x6",
         "ModesCanMisfire",
         "IsThunderbolt",
         "DoesCluster"

--- a/PirateTech/Items/Weapons/Weapon_MRM_40_JuryRigged.json
+++ b/PirateTech/Items/Weapons/Weapon_MRM_40_JuryRigged.json
@@ -11,8 +11,8 @@
     "BonusDescriptions": {
       "Bonuses": [
         "WpnAccuracy: -1",
-        "MisfireChanceMode1: 25, x80",
-        "MisfireChanceMode2: 55, x120",
+        "MisfireChanceMode1: 25%, x80",
+        "MisfireChanceMode2: 55%, x120",
         "ModesCanMisfire",
         "DakkaBoom: 80",
         "MRM"

--- a/PirateTech/Items/Weapons/Weapon_PPCER_JRCAP.json
+++ b/PirateTech/Items/Weapons/Weapon_PPCER_JRCAP.json
@@ -10,7 +10,7 @@
     ],
     "BonusDescriptions": {
       "Bonuses": [
-        "MisfireChanceMode1: 20, ER & DMG",
+        "MisfireChanceMode1: 20%, ER & DMG",
         "ModesCanMisfire",
         "WpnRecoil: 1",
         "PPCDEBUFF: 1",

--- a/PirateTech/Items/Weapons/Weapon_PPC_Capacitator_JuryRigged.json
+++ b/PirateTech/Items/Weapons/Weapon_PPC_Capacitator_JuryRigged.json
@@ -10,7 +10,7 @@
     ],
     "BonusDescriptions": {
       "Bonuses": [
-        "MisfireChanceMode1: 20, RF & DMG",
+        "MisfireChanceMode1: 20%, RF & DMG",
         "ModesCanMisfire",
         "WpnRecoil: 1",
         "PPCDEBUFF: 1",

--- a/PirateTech/Items/Weapons/Weapon_PPC_HEAVY_jrig.json
+++ b/PirateTech/Items/Weapons/Weapon_PPC_HEAVY_jrig.json
@@ -10,7 +10,7 @@
     ],
     "BonusDescriptions": {
       "Bonuses": [
-        "MisfireChanceMode1: 20, FC & Scatter",
+        "MisfireChanceMode1: 20%, FC & Scatter",
         "ModesCanMisfire",
         "DmgFallOff: 55%",
         "WpnRecoil: 2",

--- a/PirateTech/Items/Weapons/Weapon_PPC_PIRATE_LIGHT.json
+++ b/PirateTech/Items/Weapons/Weapon_PPC_PIRATE_LIGHT.json
@@ -10,7 +10,7 @@
     ],
     "BonusDescriptions": {
       "Bonuses": [
-        "MisfireChanceMode1: 20, RF & DMG",
+        "MisfireChanceMode1: 20%, RF & DMG",
         "ModesCanMisfire",
         "PPCDEBUFF: 1",
         "CapacitorBoom: 40",

--- a/RISCtech/Items/Weapon/Weapon_ER_PPC_LIGHT.json
+++ b/RISCtech/Items/Weapon/Weapon_ER_PPC_LIGHT.json
@@ -13,7 +13,7 @@
         "WpnRecoil: 3",
         "PPCDEBUFF: 1",
         "MineClearanceBoom: 1",
-        "MisfireChanceMode1: 55, FIOFF"
+        "MisfireChanceMode1: 55%, FIOFF"
       ]
     },
     "Flags": {

--- a/RISCtech/Items/Weapon/Weapon_PPC_HEAVY_CAPACITATOR.json
+++ b/RISCtech/Items/Weapon/Weapon_PPC_HEAVY_CAPACITATOR.json
@@ -14,7 +14,7 @@
         "DmgFallOff: 60%",
         "WpnRecoil: 3",
         "MineClearanceBoom: 2",
-        "MisfireChanceMode1: 30, On",
+        "MisfireChanceMode1: 30%, On",
         "PiratePPCCap"
       ]
     },

--- a/RogueModuleTech/Primitive/Weapons/Weapon_PPC_Prototype.json
+++ b/RogueModuleTech/Primitive/Weapons/Weapon_PPC_Prototype.json
@@ -12,7 +12,7 @@
       "Bonuses": [
         "PPCDEBUFF: 1",
         "MineClearanceBoom: 2",
-        "MisfireChanceMode1: 50, FIOFF"
+        "MisfireChanceMode1: 50%, FIOFF"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/RISC/Weapons/Weapon_Laser_HyperLargeLaser.json
+++ b/RogueModuleTech/RISC/Weapons/Weapon_Laser_HyperLargeLaser.json
@@ -11,8 +11,8 @@
     "BonusDescriptions": {
       "Bonuses": [
         "HyperLaser: 90",
-        "MisfireChanceMode1: 20, STD",
-        "MisfireChanceMode2: 30, OC"
+        "MisfireChanceMode1: 20%, STD",
+        "MisfireChanceMode2: 30%, OC"
       ]
     },
     "ComponentExplosion": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_0-STOCK.json
@@ -13,7 +13,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Delta.json
@@ -16,7 +16,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-LongFire.json
@@ -15,7 +15,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_1-Telos.json
@@ -16,7 +16,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM10_2-Zeus.json
@@ -15,7 +15,7 @@
         "Indirect",
         "DoesCluster",
         "JamChanceMode1: 15%, STD",
-        "MisfireChanceMode2: 50, HL"
+        "MisfireChanceMode2: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_0-STOCK.json
@@ -13,7 +13,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Delta.json
@@ -16,7 +16,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-LongFire.json
@@ -15,7 +15,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_1-Telos.json
@@ -16,7 +16,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM15_2-Zeus.json
@@ -15,7 +15,7 @@
         "Indirect",
         "DoesCluster",
         "JamChanceMode1: 15%, STD",
-        "MisfireChanceMode2: 50, HL"
+        "MisfireChanceMode2: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_0-STOCK.json
@@ -13,7 +13,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Delta.json
@@ -16,7 +16,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-LongFire.json
@@ -15,7 +15,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_1-Telos.json
@@ -16,7 +16,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM20_2-Zeus.json
@@ -15,7 +15,7 @@
         "Indirect",
         "DoesCluster",
         "JamChanceMode1: 15%, STD",
-        "MisfireChanceMode2: 50, HL"
+        "MisfireChanceMode2: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_0-STOCK.json
@@ -10,7 +10,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Delta.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Delta.json
@@ -13,7 +13,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-LongFire.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-LongFire.json
@@ -12,7 +12,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Telos.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_1-Telos.json
@@ -13,7 +13,7 @@
         "IsLRM",
         "Indirect",
         "DoesCluster",
-        "MisfireChanceMode1: 50, HL"
+        "MisfireChanceMode1: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Zeus.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_LRM_LRM5_2-Zeus.json
@@ -12,7 +12,7 @@
         "Indirect",
         "DoesCluster",
         "JamChanceMode1: 15%, STD",
-        "MisfireChanceMode2: 50, HL"
+        "MisfireChanceMode2: 50%, HL"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_0-STOCK.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_0-STOCK.json
@@ -12,7 +12,7 @@
       "Bonuses": [
         "PPCDEBUFF: 1",
         "MineClearanceBoom: 2",
-        "MisfireChanceMode1: 50, FIOFF"
+        "MisfireChanceMode1: 50%, FIOFF"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Ceres_Arms.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Ceres_Arms.json
@@ -14,7 +14,7 @@
         "PPCDEBUFF: 2",
         "WpnRecoil: 1",
         "MineClearanceBoom: 2",
-        "JamChanceMode1: 50, FIOFF"
+        "JamChanceMode1: 50%, FIOFF"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Donal.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Donal.json
@@ -15,7 +15,7 @@
         "AreaOfEffect: 60",
         "WpnRecoil: 2",
         "MineClearanceBoom: 2",
-        "MisfireChanceMode1: 50, FIOFF"
+        "MisfireChanceMode1: 50%, FIOFF"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Tiegart.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_1-Tiegart.json
@@ -14,7 +14,7 @@
         "PPCDEBUFF: 1",
         "WpnRecoil: 1",
         "MineClearanceBoom: 1",
-        "MisfireChanceMode1: 50, FIOFF"
+        "MisfireChanceMode1: 50%, FIOFF"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_3-Defiance.json
+++ b/RogueModuleTech/VanillaWeapons/Weapon_PPC_PPC_3-Defiance.json
@@ -13,7 +13,7 @@
         "DefiancePPC",
         "PPCDEBUFF: 3",
         "MineClearanceBoom: 1",
-        "MisfireChanceMode1: 50, FIOFF"
+        "MisfireChanceMode1: 50%, FIOFF"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/Weapons/Weapon_PPC_HEAVY.json
+++ b/RogueModuleTech/Weapons/Weapon_PPC_HEAVY.json
@@ -13,7 +13,7 @@
         "PPCDEBUFF: 2",
         "WpnRecoil: 2",
         "MineClearanceBoom: 2",
-        "MisfireChanceMode1: 50, FIOFF"
+        "MisfireChanceMode1: 50%, FIOFF"
       ]
     },
     "Flags": {


### PR DESCRIPTION
The first parameter of the bonus descriptions JamChanceModeX and
MisfireChanceModeX has inconsistently sometimes a percent sign and
sometimes not. This change adds the percent sign where it is missing.