### PR TITLE
fix lance mates related bonus descriptions

### DIFF
--- a/RogueModuleTech/Quirks/Upgrade/Gear_Cockpit_Zeus_C.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_Cockpit_Zeus_C.json
@@ -16,9 +16,9 @@
     },
     "BonusDescriptions": {
       "Bonuses": [
-        "LanceResolve: 2",
+        "LanceResolve2: 2",
         "Initiative: 1",
-        "Tacticon: +1",
+        "Tacticon: +2",
         "LanceSight3: 75",
         "Health: 3",
         "IsCockpit",

--- a/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_Echidnae.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_Echidnae.json
@@ -16,7 +16,7 @@
     },
     "BonusDescriptions": {
       "Bonuses": [
-        "LanceResolve: +1",
+        "LanceResolve2: +1",
         "LanceAcc: +1",
         "Tacticon: +1",
         "AllLanceSensors: +5%",

--- a/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_Totem.json
+++ b/RogueModuleTech/Quirks/Upgrade/Gear_Sensors_Totem.json
@@ -7,7 +7,7 @@
     ],
     "BonusDescriptions": {
       "Bonuses": [
-        "LanceResolve: +1",
+        "LanceResolve2: +1",
         "AdvancedSensors: 1",
         "Sharer"
       ]

--- a/RogueModuleTech/Quirks/Weapon/Weapon_FCS_Command_C3.json
+++ b/RogueModuleTech/Quirks/Weapon/Weapon_FCS_Command_C3.json
@@ -31,6 +31,8 @@
         "PainterVisibility: 25%",
         "Initiative: +1",
         "Tacticon: +1",
+        "LanceResolve2: 2",
+        "AdvancedSensors: 5",
         "Health: 2",
         "IsCockpit",
         "FCS",

--- a/RogueModuleTech/Tanks/carquirks/Gear_Tank_DroneController.json
+++ b/RogueModuleTech/Tanks/carquirks/Gear_Tank_DroneController.json
@@ -12,7 +12,7 @@
         "Sight: +150%",
         "Sensors: +150%",
         "AdvancedSensors: 1",
-        "SkillTactics: +1"
+        "ComGearTac: +1"
       ]
     },
     "ActivatableComponent": {


### PR DESCRIPTION
Gear_Cockpit_Zeus_C, Gear_Sensors_Echidnae, Gear_Sensors_Totem: No Aura
therefore LanceResolve2 instead of LanceResolve
Gear_Cockpit_Zeus_C: The initiative bonus to lancemates is 2 instead of 1
Weapon_FCS_Command_C3: Missing bonus LanceResolve2 and AdvancedSensors
Gear_Tank_DroneController: Tactics bonus affects all lancemates therefore
ComGearTac instead of SkillTactics