### PR TITLE
Fix Weapon_Laser_BeholderStare

### DIFF
--- a/RogueModuleTech/Quirks/Weapon/Weapon_Laser_BeholderStare.json
+++ b/RogueModuleTech/Quirks/Weapon/Weapon_Laser_BeholderStare.json
@@ -21,14 +21,14 @@
         "VariableDmg: 20",
         "WpnRecoil: 2",
         "DmgFallOff: 10%",
-        "Painter: +1",
+        "Painter: +2",
         "PainterSensors: 25%",
         "PainterVisibility: 25%",
-        "Bombast",
+        "IsLaser",
         "Initiative: +1",
         "Tacticon: +1",
         "LanceSight3: 50",
-        "LanceResolve: 1",
+        "LanceResolve2: 2",
         "AdvancedSensors: 1",
         "IsCockpit"
       ]
@@ -46,7 +46,7 @@
   },
   "Category": "Energy",
   "Type": "Laser",
-  "WeaponSubType": "LargeLaserPulse",
+  "WeaponSubType": "LargeLaser",
   "MinRange": 0,
   "MaxRange": 510,
   "RangeSplit": [
@@ -80,7 +80,7 @@
   "ProjectilesPerShot": 1,
   "AttackRecoil": 1,
   "Instability": 10,
-  "WeaponEffectID": "WeaponEffect-Weapon_LaserPulse_Large",
+  "WeaponEffectID": "WeaponEffect-Weapon_Laser_Large",
   "Description": {
     "Cost": 755000,
     "Rarity": 99,
@@ -90,7 +90,7 @@
     "UIName": "Beholder",
     "Id": "Weapon_Laser_BeholderStare",
     "Name": "Death Stare",
-    "Details": "This 'was' a Large Pulse Laser, and someone hotwired a TAG straight into the system, overloaded the capacitators and then managed to break the focusing system anyway.",
+    "Details": "This 'was' a Large Laser, and someone hotwired a TAG straight into the system, overloaded the capacitators and then managed to break the focusing system anyway.",
     "Icon": "TAG"
   },
   "BonusValueA": "",


### PR DESCRIPTION
The Weapon has no aura therefore the bonus description should be
LanceResolve2 instead of LanceResolve. Also, the values for Painter
and LanceResolve2 are 2 instead of 1.

Now to the more controversial side of my change. The bonus
description indicated, that the weapon was a Bombast Laser but the
weapon has no Modes at all. The weapon description indicated, that
the weapon derived from a Large Pulse Laser but the weapon has
neither an accuracy or evasion pip ignore bonus nor multiple shots
when fired. As the weapon is, as far as I can tell, in line with
a Large Laser, so I changed everything accordingly.