### PR TITLE
fix Gear_Cockpit_LifeSupportB_Knife panic resist

### DIFF
--- a/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_LifeSupportB_Knife.json
+++ b/RogueModuleTech/Cockpit/LifeSupport/Gear_Cockpit_LifeSupportB_Knife.json
@@ -78,9 +78,7 @@
       },
       "targetingData": {
         "effectTriggerType": "Passive",
-        "specialRules": "NotSet",
-        "effectTargetType": "EnemiesWithinRange",
-        "range": 0.0,
+        "effectTargetType": "Creator",
         "showInTargetPreview": false,
         "showInStatusPanel": false
       },


### PR DESCRIPTION
The panic resist bonus should be applied to the owner and not to
the enemies. Or was that an indication that you should not bring
a knife to a mech fight? ;-)