### PR TITLE
Cockpit bonus descriptions improvements

### DIFF
--- a/RogueModuleTech/Cockpit/CockpitWeapon/Weapon_FCS_TAG.json
+++ b/RogueModuleTech/Cockpit/CockpitWeapon/Weapon_FCS_TAG.json
@@ -15,7 +15,8 @@
         "WpnAccuracy: +2",
         "Painter: +1",
         "PainterSensors: 25%",
-        "PainterVisibility: 25%"
+        "PainterVisibility: 25%",
+        "FCS"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/Cockpit/Other/Gear_Cockpit_Cripple.json
+++ b/RogueModuleTech/Cockpit/Other/Gear_Cockpit_Cripple.json
@@ -27,13 +27,14 @@
       "Bonuses": [
         "AcePilot",
         "Breaching",
-        "CalledShot: 15%",
+        "CalledShot: 10%",
         "SkillGunnery: 2",
         "SkillPiloting: 2",
         "SkillGuts: 2",
         "SkillTactics: 2",
         "EvaMax: +2",
         "EvaPips: +1",
+        "FCS",
         "IsCockpit",
         "BleedReduction: 50%"
       ]

--- a/RogueModuleTech/Cockpit/Sensors/Gear_Cockpit_VR_POD.json
+++ b/RogueModuleTech/Cockpit/Sensors/Gear_Cockpit_VR_POD.json
@@ -10,7 +10,7 @@
     ],
     "BonusDescriptions": {
       "Bonuses": [
-        "Initiative: +1",
+        "Initiative: +2",
         "EvaMax: +2",
         "EvaPips: +2",
         "AdvancedSensors: 2",

--- a/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_BAP.json
+++ b/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_BAP.json
@@ -15,7 +15,7 @@
         "IsProbe: 2",
         "AdvancedSensors: 3",
         "NightVision",
-        "DetectMine: 90"
+        "DetectMine: 150"
       ]
     },
     "Flags": {

--- a/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EWS.json
+++ b/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EWS.json
@@ -27,7 +27,7 @@
       "Bonuses": [
         "CockpitEWS",
         "ActiveEWS: 1, 2, 120",
-        "EWSSelf: 1, 1",
+        "EWSSelf: 1, 2",
         "EWSProbe: 5%, 1, 1, 120",
         "UAV: 310, 2, 15"
       ]


### PR DESCRIPTION
Added missing 'FCS' bonus to items in category CockpitFCS:
- Weapon_FCS_TAG
- Gear_Cockpit_Cripple
Fixed called shot bonus: Gear_Cockpit_Cripple
Fixed initiative bonus: Gear_Cockpit_VR_POD
Fixed detect mine range bonus: Gear_Sensors_BAP
Fixed jamming reduction value in EWSSelf: Gear_Sensors_EWS