### PR TITLE
fix EngineHSCap bonus

### DIFF
--- a/RogueModuleTech/Basic/EngineCores/Gear_Engine_405.json
+++ b/RogueModuleTech/Basic/EngineCores/Gear_Engine_405.json
@@ -16,7 +16,7 @@
     },
     "BonusDescriptions": {
       "Bonuses": [
-        "EngineHSCap: 7"
+        "EngineHSCap: 6"
       ]
     },
     "ActivatableComponent": {

--- a/RogueModuleTech/Basic/EngineCores/Gear_Engine_410.json
+++ b/RogueModuleTech/Basic/EngineCores/Gear_Engine_410.json
@@ -16,7 +16,7 @@
     },
     "BonusDescriptions": {
       "Bonuses": [
-        "EngineHSCap: 7"
+        "EngineHSCap: 6"
       ]
     },
     "ActivatableComponent": {

--- a/RogueModuleTech/Basic/EngineCores/Gear_Engine_415.json
+++ b/RogueModuleTech/Basic/EngineCores/Gear_Engine_415.json
@@ -16,7 +16,7 @@
     },
     "BonusDescriptions": {
       "Bonuses": [
-        "EngineHSCap: 7"
+        "EngineHSCap: 6"
       ]
     },
     "ActivatableComponent": {

--- a/RogueModuleTech/Basic/EngineCores/Gear_Engine_420.json
+++ b/RogueModuleTech/Basic/EngineCores/Gear_Engine_420.json
@@ -16,7 +16,7 @@
     },
     "BonusDescriptions": {
       "Bonuses": [
-        "EngineHSCap: 7"
+        "EngineHSCap: 6"
       ]
     },
     "ActivatableComponent": {


### PR DESCRIPTION
The formula for additional installable engine heat sinks is:

round_down(engine rating / 25) - 10

and I am not aware that this changes for engines above 400 and therefore
the engines with rating 405 - 420 should only have 6 instead of 7.