### PR TITLE
fix Reserved/EngineReserved bonuses

### DIFF
--- a/RogueModuleTech/LAM/Armor/LAM_Aluminium_Lamellor.json
+++ b/RogueModuleTech/LAM/Armor/LAM_Aluminium_Lamellor.json
@@ -19,7 +19,7 @@
         "DamageTaken: -10%",
         "StructureProtection: +10%",
         "TACImmune",
-        "Reserved: 10",
+        "Reserved: 12",
         "ArmorTPCost: 90%",
         "ArmorCBCost: 120%",
         "CASE",

--- a/RogueModuleTech/Pirate/Engine/Gear_Engine_Pirate.json
+++ b/RogueModuleTech/Pirate/Engine/Gear_Engine_Pirate.json
@@ -26,7 +26,7 @@
         "FailCritSelf",
         "FailReducPilot",
         "EngineWeight: -15%",
-        "EngineReserved: 6",
+        "EngineReserved: 4",
         "CoolantCost: 3",
         "CoolantCostMulti: 3%"
       ]

--- a/RogueModuleTech/Pirate/Engine/emod_Pirate_FuelCell.json
+++ b/RogueModuleTech/Pirate/Engine/emod_Pirate_FuelCell.json
@@ -23,6 +23,7 @@
     "BonusDescriptions": {
       "Bonuses": [
         "EngineWeight: X1.4",
+        "EngineReserved: 4",
         "HeatGenerated: -80%",
         "CoolantCost: 3",
         "CoolantCostMulti: -30%"

--- a/RogueModuleTech/Quirks/Heatsink/Quirk_300_Compact_Engine.json
+++ b/RogueModuleTech/Quirks/Heatsink/Quirk_300_Compact_Engine.json
@@ -23,7 +23,7 @@
     "BonusDescriptions": {
       "Bonuses": [
         "EngineHSCap: 2",
-        "EngineReserved: 4",
+        "EngineReserved: 6",
         "CoolantCost: 3",
         "CoolantCostMulti: 3%"
       ]

--- a/RogueModuleTech/Quirks/Heatsink/emod_engineslots_xl_proto.json
+++ b/RogueModuleTech/Quirks/Heatsink/emod_engineslots_xl_proto.json
@@ -19,7 +19,6 @@
         "EngineWeight: -50%",
         "HeatGenerated: +20%",
         "HeatPerTurn: +10",
-        "EngineReserved: 4",
         "CoolantCost: 3",
         "CoolantCostMulti: 2%"
       ]

--- a/RogueModuleTech/Upgrade/Gear_Industrial_TSM.json
+++ b/RogueModuleTech/Upgrade/Gear_Industrial_TSM.json
@@ -13,7 +13,7 @@
     },
     "BonusDescriptions": {
       "Bonuses": [
-        "Reserved: 6",
+        "Reserved: 5",
         "CarryWeight: X3"
       ]
     },

--- a/RogueModuleTech/Upgrade/Gear_Myomer_TSM.json
+++ b/RogueModuleTech/Upgrade/Gear_Myomer_TSM.json
@@ -17,7 +17,7 @@
         "DeActivateHeatLevel: 24",
         "ActiveMelee: X1.5",
         "ActiveWalkSpeed: +60m",
-        "Reserved: 6",
+        "Reserved: 5",
         "CarryWeight: X2"
       ]
     },


### PR DESCRIPTION
Gear_Industrial_TSM and Gear_Myomer_TSM have only 5 instead of 6
reserved slots
LAM_Aluminium_Lamellor has 12 instead of 10 reserved slots
Quirk_300_Compact_Engine uses 6 instead of 4 side torso slots
Gear_Engine_Pirate only uses 4 instead of 6 side torso slots
emod_Pirate_FuelCell uses 4 side torso slots
emod_engineslots_xl_proto uses no side torso slots