### PR TITLE
Fix CPH-PRIME

### DIFF
--- a/RogueTech Core/tagRestrictions/TagRestrictions_MechEngineer.json
+++ b/RogueTech Core/tagRestrictions/TagRestrictions_MechEngineer.json
@@ -493,8 +493,6 @@
       ],
       "IncompatibleTags": [
         "InternalRepairSystem",
-        "ModularArmor",
-        "ModularRearArmor",
         "emod_kit_lhs",
         "Gear_HeatSink_Generic_Laser_Clan"
       ]


### PR DESCRIPTION
Remove lore-breaking incompatibilities (CPH mounts modular armor with CLPS(S) ).

NOTE: This is pointing directly to master because the bug is on master and it's about to be an issue. Make sure to pull master into dev after merging this, or cherry-pick onto dev.