### PR TITLE
Rattlesnake from Battletechnology/Shrapnel #7 and slot fix for Archer Wolf

### DIFF
--- a/Base 3061/chassis/chassisdef_Rattlesnake_JR7-31P.json
+++ b/Base 3061/chassis/chassisdef_Rattlesnake_JR7-31P.json
@@ -1,0 +1,259 @@
+{
+    "Custom": {
+        "ArmActuatorSupport": {
+            "LeftLimit": "Upper",
+            "RightLimit": "Upper"
+        },
+        "DropCostFactor": {
+            "DropModifier": 0.98
+        },
+        "AssemblyVariant": {
+            "PrefabID": "jenner",
+            "Exclude": false,
+            "Include": true
+        },
+        "ChassisDefaults": []
+    },
+    "CustomParts": {
+        "CustomParts": []
+    },
+    "FixedEquipment": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Special_Improved_Lifesupport",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "Description": {
+        "Cost": 650000,
+        "Rarity": 1,
+        "Purchasable": true,
+        "Manufacturer": "",
+        "Model": "",
+        "UIName": "Rattlesnake",
+        "Id": "chassisdef_Rattlesnake_JR7-31P",
+        "Name": "Rattlesnake",
+        "Details": "An offshoot of the Jenner, the 35 ton Rattlesnake was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, very few Rattlesnakes were ever manufactured, with the design becoming more or less extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium lasers and a Small Laser. A C3 Slave is included and the remaining tonnage devoted to additional armour.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "VariantName": "JR7-31P",
+    "ChassisTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+    },
+    "StockRole": "Striker",
+    "YangsThoughts": "An offshoot of the Jenner, the 35 ton Rattlesnake was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, very few Rattlesnakes were ever manufactured, with the design becoming more or less extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium lasers and a Small Laser. A C3 Slave is included and the remaining tonnage devoted to additional armour.",
+    "MovementCapDefID": "movedef_lightmech",
+    "PathingCapDefID": "pathingdef_light",
+    "HardpointDataDefID": "hardpointdatadef_jenner",
+    "PrefabIdentifier": "chrPrfMech_jennerBase-001",
+    "PrefabBase": "jenner",
+    "Tonnage": 35,
+    "InitialTonnage": 3.5,
+    "weightClass": "LIGHT",
+    "BattleValue": 3762000,
+    "Heatsinks": 0,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "MaxJumpjets": 20,
+    "Stability": 100,
+    "StabilityDefenses": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+    ],
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "PunchesWithLeftArm": false,
+    "MeleeDamage": 18,
+    "MeleeInstability": 9,
+    "MeleeToHitModifier": 0,
+    "DFADamage": 35,
+    "DFAToHitModifier": 0,
+    "DFASelfDamage": 35,
+    "DFAInstability": 18,
+    "Locations": [
+        {
+            "Location": "Head",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 45,
+            "MaxRearArmor": -1,
+            "InternalStructure": 16
+        },
+        {
+            "Location": "LeftArm",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 60,
+            "MaxRearArmor": -1,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "LeftTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "AntiPersonnel",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 80,
+            "MaxRearArmor": 40,
+            "InternalStructure": 40
+        },
+        {
+            "Location": "CenterTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 15,
+            "MaxArmor": 110,
+            "MaxRearArmor": 55,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "RightTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 80,
+            "MaxRearArmor": 40,
+            "InternalStructure": 40
+        },
+        {
+            "Location": "RightArm",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 60,
+            "MaxRearArmor": -1,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "LeftLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 80,
+            "MaxRearArmor": -1,
+            "InternalStructure": 40
+        },
+        {
+            "Location": "RightLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 80,
+            "MaxRearArmor": -1,
+            "InternalStructure": 40
+        }
+    ],
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 10,
+            "z": 0.5
+        },
+        {
+            "x": -3,
+            "y": 9,
+            "z": -0.5
+        },
+        {
+            "x": 3,
+            "y": 9,
+            "z": -0.5
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 10,
+            "z": 0.5
+        },
+        {
+            "x": -3,
+            "y": 9,
+            "z": -0.5
+        },
+        {
+            "x": 3,
+            "y": 9,
+            "z": -0.5
+        },
+        {
+            "x": -2.5,
+            "y": 3,
+            "z": 0.5
+        },
+        {
+            "x": 2.5,
+            "y": 3,
+            "z": 0.5
+        }
+    ]
+}

--- a/Base 3061/mech/mechdef_Rattlesnake_JR7-31P.json
+++ b/Base 3061/mech/mechdef_Rattlesnake_JR7-31P.json
@@ -1,0 +1,453 @@
+{
+    "MechTags": {
+        "items": [
+            "unit_advanced",
+            "unit_bracket_med",
+            "unit_jumpOK",
+            "unit_release",
+            "unit_mech",
+            "unit_light",
+            "unit_ready",
+            "unit_lance_assassin",
+            "unit_lance_vanguard",
+            "unit_role_brawler",
+            "unit_predator",
+            "unit_littlefriend",
+            "steiner",
+            "davion",
+            "ai_heat_normal",
+            "ai_dfa_low",
+            "ai_melee_low",
+            "ai_flank_normal",
+            "ai_lance_normal",
+            "ai_lethalself_high",
+            "ai_move_normal",
+            "ai_priority_normal",
+            "ai_reserve_normal",
+            "ai_shooting_normal",
+            "ai_surrounded_normal"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "chassisdef_Rattlesnake_JR7-31P",
+    "Description": {
+        "Cost": 130000,
+        "Rarity": 1,
+        "Purchasable": true,
+        "Manufacturer": null,
+        "Model": null,
+        "UIName": "Rattlesnake JR7-31P",
+        "Id": "mechdef_Rattlesnake_JR7-31P",
+        "Name": "Rattlesnake JR7-31P",
+        "Details": "An offshoot of the Jenner, the 35 ton Rattlesnake was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, very few Rattlesnakes were ever manufactured, with the design becoming more or less extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium lasers and a Small Laser. A C3 Slave is included and the remaining tonnage devoted to additional armour.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "simGameMechPartCost": 130000,
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Head",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 16,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftArm",
+            "CurrentArmor": 60,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 60,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftTorso",
+            "CurrentArmor": 60,
+            "CurrentRearArmor": 25,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 60,
+            "AssignedRearArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "CenterTorso",
+            "CurrentArmor": 75,
+            "CurrentRearArmor": 30,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 75,
+            "AssignedRearArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightTorso",
+            "CurrentArmor": 60,
+            "CurrentRearArmor": 25,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 60,
+            "AssignedRearArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightArm",
+            "CurrentArmor": 60,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 60,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftLeg",
+            "CurrentArmor": 80,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 80,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightLeg",
+            "CurrentArmor": 80,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 80,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Cockpit_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_C3",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Gyro_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_245",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_engineslots_xl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_Heatsinks",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_kit_dhs",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base HeavyMetal Unique/chassis/chassisdef_archer_ARC-WLF_wolf.json
+++ b/Base HeavyMetal Unique/chassis/chassisdef_archer_ARC-WLF_wolf.json
@@ -89,7 +89,7 @@
         }
       ],
       "Tonnage": 0,
-      "InventorySlots": 7,
+      "InventorySlots": 6,
       "MaxArmor": 45,
       "MaxRearArmor": -1,
       "InternalStructure": 16

--- a/Republic 3081-3130/chassis/chassisdef_Rattlesnake_JR7-31P-HH.json
+++ b/Republic 3081-3130/chassis/chassisdef_Rattlesnake_JR7-31P-HH.json
@@ -1,0 +1,251 @@
+{
+    "Custom": {
+        "ArmActuatorSupport": {
+            "LeftLimit": "Upper",
+            "RightLimit": "Upper"
+        },
+        "DropCostFactor": {
+            "DropModifier": 0.98
+        },
+        "AssemblyVariant": {
+            "PrefabID": "jenner",
+            "Exclude": false,
+            "Include": true
+        },
+        "ChassisDefaults": []
+    },
+    "CustomParts": {
+        "CustomParts": []
+    },
+    "FixedEquipment": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Special_Improved_Lifesupport",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "Description": {
+        "Cost": 650000,
+        "Rarity": 1,
+        "Purchasable": true,
+        "Manufacturer": "",
+        "Model": "",
+        "UIName": "Rattlesnake",
+        "Id": "chassisdef_Rattlesnake_JR7-31P-HH",
+        "Name": "Rattlesnake",
+        "Details": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31P-HH was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built around a surviving Rattlesnake, the HH model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 ER Medium Lasers, 3 Medium Lasers and an ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "VariantName": "JR7-31P-HH",
+    "ChassisTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+    },
+    "StockRole": "Striker",
+    "YangsThoughts": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31P-HH was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built around a surviving Rattlesnake, the HH model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 ER Medium Lasers, 3 Medium Lasers and an ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.",
+    "MovementCapDefID": "movedef_lightmech",
+    "PathingCapDefID": "pathingdef_light",
+    "HardpointDataDefID": "hardpointdatadef_jenner",
+    "PrefabIdentifier": "chrPrfMech_jennerBase-001",
+    "PrefabBase": "jenner",
+    "Tonnage": 35,
+    "InitialTonnage": 3.5,
+    "weightClass": "LIGHT",
+    "BattleValue": 3762000,
+    "Heatsinks": 0,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "MaxJumpjets": 20,
+    "Stability": 100,
+    "StabilityDefenses": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+    ],
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "PunchesWithLeftArm": false,
+    "MeleeDamage": 18,
+    "MeleeInstability": 9,
+    "MeleeToHitModifier": 0,
+    "DFADamage": 35,
+    "DFAToHitModifier": 0,
+    "DFASelfDamage": 35,
+    "DFAInstability": 18,
+    "Locations": [
+        {
+            "Location": "Head",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 45,
+            "MaxRearArmor": -1,
+            "InternalStructure": 16
+        },
+        {
+            "Location": "LeftArm",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 60,
+            "MaxRearArmor": -1,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "LeftTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "AntiPersonnel",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 80,
+            "MaxRearArmor": 40,
+            "InternalStructure": 40
+        },
+        {
+            "Location": "CenterTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 15,
+            "MaxArmor": 110,
+            "MaxRearArmor": 55,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "RightTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 80,
+            "MaxRearArmor": 40,
+            "InternalStructure": 40
+        },
+        {
+            "Location": "RightArm",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 60,
+            "MaxRearArmor": -1,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "LeftLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 80,
+            "MaxRearArmor": -1,
+            "InternalStructure": 40
+        },
+        {
+            "Location": "RightLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 80,
+            "MaxRearArmor": -1,
+            "InternalStructure": 40
+        }
+    ],
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 10,
+            "z": 0.5
+        },
+        {
+            "x": -3,
+            "y": 9,
+            "z": -0.5
+        },
+        {
+            "x": 3,
+            "y": 9,
+            "z": -0.5
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 10,
+            "z": 0.5
+        },
+        {
+            "x": -3,
+            "y": 9,
+            "z": -0.5
+        },
+        {
+            "x": 3,
+            "y": 9,
+            "z": -0.5
+        },
+        {
+            "x": -2.5,
+            "y": 3,
+            "z": 0.5
+        },
+        {
+            "x": 2.5,
+            "y": 3,
+            "z": 0.5
+        }
+    ]
+}

--- a/Republic 3081-3130/mech/mechdef_Rattlesnake_JR7-31P-HH.json
+++ b/Republic 3081-3130/mech/mechdef_Rattlesnake_JR7-31P-HH.json
@@ -1,0 +1,471 @@
+{
+    "MechTags": {
+        "items": [
+            "unit_advanced",
+            "unit_bracket_med",
+            "unit_jumpOK",
+            "unit_release",
+            "unit_mech",
+            "unit_light",
+            "unit_ready",
+            "unit_lance_assassin",
+            "unit_lance_vanguard",
+            "unit_role_brawler",
+            "unit_littlefriend",
+            "unit_solaris",
+            "unit_legendary",
+            "unit_hero",
+            "solaris7",
+            "locals",
+            "ai_heat_normal",
+            "ai_dfa_low",
+            "ai_melee_low",
+            "ai_flank_normal",
+            "ai_lance_normal",
+            "ai_lethalself_high",
+            "ai_move_normal",
+            "ai_priority_normal",
+            "ai_reserve_normal",
+            "ai_shooting_normal",
+            "ai_surrounded_normal"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "chassisdef_Rattlesnake_JR7-31P-HH",
+    "Description": {
+        "Cost": 130000,
+        "Rarity": 1,
+        "Purchasable": true,
+        "Manufacturer": null,
+        "Model": null,
+        "UIName": "Rattlesnake JR7-31P-HH",
+        "Id": "mechdef_Rattlesnake_JR7-31P-HH",
+        "Name": "Rattlesnake JR7-31P-HH",
+        "Details": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31P-HH was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built around a surviving Rattlesnake, the HH model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 ER Medium Lasers, 3 Medium Lasers and an ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "simGameMechPartCost": 130000,
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Head",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 16,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftArm",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftTorso",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": 25,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "CenterTorso",
+            "CurrentArmor": 75,
+            "CurrentRearArmor": 26,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 75,
+            "AssignedRearArmor": 26,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightTorso",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": 25,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightArm",
+            "CurrentArmor": 50,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 50,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftLeg",
+            "CurrentArmor": 75,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 75,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightLeg",
+            "CurrentArmor": 75,
+            "CurrentRearArmor": -1,
+            "CurrentInternalStructure": 40,
+            "AssignedArmor": 75,
+            "AssignedRearArmor": -1,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Cockpit_Generic_Small",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Angel_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Gyro_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_245",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_engineslots_xl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "emod_engineslots_size3",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "SimGameUID": "",
+            "GUID": null,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_Heatsinks",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_kit_dhs",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "SimGameUID": "",
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_RCA_InstaTrac-XII",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_MASC_CLAN",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "hasPrefabName": false,
+            "DamageLevel": "Functional"
+        }
+    ]
+}


### PR DESCRIPTION
Added the Rattlesnake now it's been effectively recanonised in Shrapnel #7. Both the original model and the upgraded custom from 3084. Fixed head on the Archer Wolf - was 7 inventory slots, should be 6