### PR TITLE
fireworks should be fire works

### DIFF
--- a/RogueTech Core/GameTips/general.txt
+++ b/RogueTech Core/GameTips/general.txt
@@ -256,7 +256,7 @@ In any given calculation, the fault will never be placed if more than one person
 A common mistake that people make when trying to design something completely foolproof is to underestimate the ingenuity of complete fools.
 Million-to-one chances... crop up nine times out of ten.
 Professionals are predictable, it's the amateurs that are dangerous.
-The only time suppressive fireworks is when it is used on abandoned positions.
+The only time suppressive fire works is when it is used on abandoned positions.
 "They'll never expect this" really means: "I want to try something stupid."
 The size of the combat bonus is inversely proportional to the likelihood of surviving to collect it.
 Don't try to save money by conserving ammunition. Bullets cost less than ‘Mechs.


### PR DESCRIPTION
Just a small typo. `fireworks` should be `fire works`.