### PR TITLE
Seraph prefab swap and tank stuff

### DIFF
--- a/Base 3061/VTOL/MediumVTOL/vehicledef_Cobra.json
+++ b/Base 3061/VTOL/MediumVTOL/vehicledef_Cobra.json
@@ -141,7 +141,7 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Tank_CargoCompartment",
+      "ComponentDefID": "Tank_InfantryCompartment",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 1,
       "DamageLevel": "Functional"

--- a/Base 3061/VTOL/MediumVTOL/vehicledef_Cobra_Combat.json
+++ b/Base 3061/VTOL/MediumVTOL/vehicledef_Cobra_Combat.json
@@ -1,0 +1,159 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-0.75",
+            "unit_vehicle",
+            "unit_medium",
+            "unit_vtol",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_generic",
+            "unit_bracket_low",
+            "unit_noconvoy",
+            "republic",
+            "comstar",
+            "wordofblake"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_Cobra_Combat",
+    "Description": {
+        "Cost": 1282000,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Cobra Transport VTOL",
+        "Id": "vehicledef_Cobra_Combat",
+        "Name": "Cobra Transport VTOL",
+        "Details": "A fast unit, the Light VTOL is not designed for protracted combat. Intended as a scout or vanguard unit, the Light VTOL is constantly on the move, probing ahead of the rest of the troops.\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        60     15\n<b>Left</b>          60     15\n<b>Right</b>        60     15\n<b>Rear</b>         50     15\n\n<b>Total</b>      240     75\n",
+        "Icon": "Anhur"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 90,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 90,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 10,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 10,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Gear_VTOL",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_100",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/VTOL/vehiclechassis/vehiclechassisdef_Cobra.json
+++ b/Base 3061/VTOL/vehiclechassis/vehiclechassisdef_Cobra.json
@@ -7,7 +7,7 @@
     },
     "CustomWeights": [
       {
-        "ComponentDefID": "Tank_CargoCompartment",
+        "ComponentDefID": "Tank_InfantryCompartment",
         "Tonnage": 10
       }
     ]

--- a/Base 3061/VTOL/vehiclechassis/vehiclechassisdef_Cobra_Combat.json
+++ b/Base 3061/VTOL/vehiclechassis/vehiclechassisdef_Cobra_Combat.json
@@ -1,0 +1,156 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "CobraVTOL",
+            "Exclude": false,
+            "Include": true
+        },
+        "CustomWeights": [
+            {
+                "ComponentDefID": "Tank_InfantryCompartment",
+                "Tonnage": 10
+            }
+        ]
+    },
+    "CustomParts": {
+        "AOEHeight": 55,
+        "FiringArc": 50,
+        "Unaffected": {
+            "DesignMasks": "true",
+            "Pathing": "true",
+            "Fire": "true",
+            "Landmines": "true",
+            "MoveCostBiome": "true",
+            "MoveClamp": 0.5,
+            "AllowPartialMovement": false
+        },
+        "MoveCostModPerBiome": {
+            "DesignMaskBiomeMartianVacuum": 2,
+            "DesignMaskBiomeLunarVacuum": 3
+        },
+        "NullifyBodyMesh": true,
+        "TieToGroundOnDeath": "true",
+        "CrewLocation": "None"
+    },
+    "Description": {
+        "Cost": 1282000,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Cobra Transport VTOL",
+        "Id": "vehiclechassisdef_Cobra_Combat",
+        "Name": "Cobra",
+        "Details": "A fast unit, the Light VTOL is not designed for protracted combat. Intended as a scout or vanguard unit, the Light VTOL is constantly on the move, probing ahead of the rest of the troops.\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        60     15\n<b>Left</b>          60     15\n<b>Right</b>        60     15\n<b>Rear</b>         50     15\n\n<b>Total</b>      240     75\n",
+        "Icon": "Anhur"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_8-12cv",
+    "movementType": "Wheeled",
+    "PathingCapDefID": "pathingdef_vtol",
+    "HardpointDataDefID": "hardpointdatadef_curedkite",
+    "PrefabIdentifier": "chrprfmech_redkite_vtol",
+    "PrefabBase": "curedkite",
+    "Tonnage": 30,
+    "weightClass": "LIGHT",
+    "BattleValue": 564,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 3,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 54,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 52,
+            "z": 3.5
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 54,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 52,
+            "z": 3.5
+        },
+        {
+            "x": -2,
+            "y": 52,
+            "z": 0
+        },
+        {
+            "x": 2,
+            "y": 52,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 52,
+            "z": -4.5
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 90,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 10,
+            "InternalStructure": 15
+        }
+    ]
+}

--- a/Base 3061/vehicle/heavy/vehicledef_MANTICORE_CHEM.json
+++ b/Base 3061/vehicle/heavy/vehicledef_MANTICORE_CHEM.json
@@ -1,0 +1,242 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_heavy",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_tank",
+            "unit_indirectFire",
+            "unit_generic",
+            "unit_bracket_med",
+            "locals",
+            "marian",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "jarnfolk",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "hanse",
+            "castile",
+            "tortuga",
+            "auriganpirates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_MANTICORE_CHEM",
+    "Description": {
+        "Cost": 2648000,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Manticore Heavy Tank",
+        "Id": "vehicledef_MANTICORE_CHEM",
+        "Name": "Manticore Heavy Tank",
+        "Details": "The Manticore is one of the best-designed and most powerful heavy tanks ever created, built to combat BattleMechs in support of infantry formations. Although the Manticore mounts a variety of weapons to handle a variety of combat roles and ranges, and is heavily armored for a vehicle of its weight, it is not equipped to deal with the raw firepower of Assault weight vehicles such as the Demolisher or the Behemoth. Despite this, the popularity of the Manticore has remained high, even during the Succession Wars era with its use of an expensive and rare Fusion Engine. Originally developed by TechniCorp during the Reunification War, the destruction of the company's head office on Terra during the Amaris Coup spread the Manticore across the Inner Sphere as other manufacturers absorbed their facilities.\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       230     30\n<b>Left</b>         165     30\n<b>Right</b>       165     30\n<b>Rear</b>        130     30\n<b>Turret</b>      210     30\n\n<b>Total</b>      900    150\n",
+        "Icon": "Manticore"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 230,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 230,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 165,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 165,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 165,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 165,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 130,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 130,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 210,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 210,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_LRM_LRM10_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_PPC_PPC_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM6_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium_half",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Tracked_Gearbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_240",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_std_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Generic_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/light/vehicledef_PEGASUS_CHEM.json
+++ b/Base 3061/vehicle/light/vehicledef_PEGASUS_CHEM.json
@@ -1,0 +1,230 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_release",
+            "unit_lance_tank",
+            "unit_lance_assassin",
+            "unit_hover",
+            "unit_generic",
+            "unit_bracket_med",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "locals",
+            "marian",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "jarnfolk",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "hanse",
+            "castile",
+            "tortuga",
+            "auriganpirates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_PEGASUS_CHEM",
+    "Description": {
+        "Cost": 844475,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Pegasus",
+        "Id": "vehicledef_PEGASUS_CHEM",
+        "Name": "Pegasus",
+        "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Trading speed or weapons for armor, the Light Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       170     20\n<b>Left</b>         103     20\n<b>Right</b>       103     20\n<b>Rear</b>         95     20\n<b>Turret</b>      125     20\n\n<b>Total</b>      596    100\n",
+        "Icon": "Pegasus"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 170,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 170,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 103,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 103,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 103,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 103,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 95,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 95,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 125,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 125,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM6_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_SRM_SRM6_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium_half",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Special_Improved_Comms",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Hover_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Hover_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Hover_Gearbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_105",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/medium/vehicledef_GOBLIN_CHEM.json
+++ b/Base 3061/vehicle/medium/vehicledef_GOBLIN_CHEM.json
@@ -1,0 +1,257 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.58",
+            "unit_vehicle",
+            "unit_medium",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_tank",
+            "unit_generic",
+            "unit_vehicle_apc",
+            "unit_bracket_low",
+            "NoBiome_lunarVacuum",
+            "locals",
+            "marian",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "jarnfolk",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "hanse",
+            "castile",
+            "tortuga",
+            "auriganpirates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_GOBLIN_CHEM",
+    "Description": {
+        "Cost": 607552,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Goblin Medium Tank",
+        "Id": "vehicledef_GOBLIN_CHEM",
+        "Name": "Goblin Medium Tank",
+        "Details": "A jack of all trades, the Medium tank is the generic stereotype of a tank. Trading speed or weapons for armor, the Medium Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       170     25\n<b>Left</b>         120     25\n<b>Right</b>       120     25\n<b>Rear</b>        100     25\n<b>Turret</b>      150     25\n\n<b>Total</b>      660    125\n",
+        "Icon": "Goblin"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 175,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 175,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 135,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 135,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 135,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 135,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 175,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 175,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_LRM_LRM5_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_half",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Tracked_Gearbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_InfantryCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicle/medium/vehicledef_VEDETTE_CHEM.json
+++ b/Base 3061/vehicle/medium/vehicledef_VEDETTE_CHEM.json
@@ -1,0 +1,243 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_medium",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_vanguard",
+            "unit_generic",
+            "unit_bracket_low",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "locals",
+            "marian",
+            "outworld",
+            "elysia",
+            "oberon",
+            "valkyrate",
+            "jarnfolk",
+            "circinus",
+            "illyrian",
+            "lothian",
+            "aurigandirectorate",
+            "auriganrestoration",
+            "hanse",
+            "castile",
+            "tortuga",
+            "auriganpirates"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_VEDETTE_CHEM",
+    "Description": {
+        "Cost": 680375,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Vedette (Laser)",
+        "Id": "vehicledef_VEDETTE_CHEM",
+        "Name": "Vedette (Laser)",
+        "Details": "A Periphery take on the Laser Vedette fielded by House Liao, the Vedette (Chemical) Laser replaces the 2 Medium Lasers with 4 Chemical Medium Lasers and 5 tons of ammo.\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       124     25\n<b>Left</b>          95     25\n<b>Right</b>        95     25\n<b>Rear</b>        100     25\n<b>Turret</b>      110     25\n\n<b>Total</b>      524    125\n",
+        "Icon": "Vedette"
+    },
+    "Version": 1,
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 124,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 124,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 95,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 95,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 95,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 95,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 110,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 110,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_Chemical",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_MachineGun_MachineGun_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_double",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Generic_Chem_Medium",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_CrewCompartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_FCS_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Tank_Sensors_Generic",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "emod_structureslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Tracked_Gearbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_armorslots_standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Tank_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_250",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "emod_engineslots_ICE_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Tank_Coolant_System",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_GOBLIN_CHEM.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_GOBLIN_CHEM.json
@@ -1,0 +1,153 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Goblin",
+            "Exclude": false,
+            "Include": true
+        },
+        "CustomWeights": [
+            {
+                "ComponentDefID": "Tank_InfantryCompartment",
+                "Tonnage": 3
+            }
+        ]
+    },
+    "CustomParts": {
+        "CustomParts": [],
+        "CrewLocation": "None"
+    },
+    "Description": {
+        "Cost": 607552,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Goblin Medium Tank",
+        "Id": "vehiclechassisdef_GOBLIN_CHEM",
+        "Name": "Goblin",
+        "Details": "A jack of all trades, the Medium tank is the generic stereotype of a tank. Trading speed or weapons for armor, the Medium Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       170     25\n<b>Left</b>         120     25\n<b>Right</b>       120     25\n<b>Rear</b>        100     25\n<b>Turret</b>      150     25\n\n<b>Total</b>      660    125\n",
+        "Icon": "Goblin"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_4-6cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_medium_tracked",
+    "HardpointDataDefID": "hardpointdatadef_goblin",
+    "PrefabIdentifier": "chrprfvhcl_goblinbase",
+    "PrefabBase": "goblin",
+    "Tonnage": 45,
+    "weightClass": "MEDIUM",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 2.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": 3
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 2.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": 3
+        },
+        {
+            "x": -2,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 2,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": -4.5
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Ballistic",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 175,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 135,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 135,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 175,
+            "InternalStructure": 25
+        }
+    ]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_MANTICORE_CHEM.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_MANTICORE_CHEM.json
@@ -1,0 +1,147 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Manticore",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "CustomParts": {
+        "CustomParts": [],
+        "CrewLocation": "None"
+    },
+    "Description": {
+        "Cost": 2648000,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Manticore Heavy Tank",
+        "Id": "vehiclechassisdef_MANTICORE_CHEM",
+        "Name": "Manticore",
+        "Details": "The Manticore is one of the best-designed and most powerful heavy tanks ever created, built to combat BattleMechs in support of infantry formations. Although the Manticore mounts a variety of weapons to handle a variety of combat roles and ranges, and is heavily armored for a vehicle of its weight, it is not equipped to deal with the raw firepower of Assault weight vehicles such as the Demolisher or the Behemoth. Despite this, the popularity of the Manticore has remained high, even during the Succession Wars era with its use of an expensive and rare Fusion Engine. Originally developed by TechniCorp during the Reunification War, the destruction of the company's head office on Terra during the Amaris Coup spread the Manticore across the Inner Sphere as other manufacturers absorbed their facilities.\n\n <b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n <b><color=#ffcc00>Movement: 4/6 Hex: 120/180 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       230     30\n<b>Left</b>         165     30\n<b>Right</b>       165     30\n<b>Rear</b>        130     30\n<b>Turret</b>      210     30\n\n<b>Total</b>      900    150\n",
+        "Icon": "Manticore"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_4-6cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_heavy_tracked",
+    "HardpointDataDefID": "hardpointdatadef_manticore",
+    "PrefabIdentifier": "chrPrfVhcl_manticore",
+    "PrefabBase": "manticore",
+    "Tonnage": 60,
+    "weightClass": "HEAVY",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        },
+        {
+            "x": -3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 3,
+            "z": -4
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 230,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 165,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 165,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 130,
+            "InternalStructure": 30
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Missile",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 210,
+            "InternalStructure": 30
+        }
+    ]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_PEGASUS_CHEM.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_PEGASUS_CHEM.json
@@ -1,0 +1,141 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Pegasus",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "MoveCost": "Hover",
+    "Unaffected": {
+      "MoveClamp": 0.5
+    },
+    "CrewLocation": "None"
+  },
+  "Description": {
+    "Cost": 844475,
+    "Rarity": 0,
+    "Purchasable": false,
+    "UIName": "Pegasus",
+    "Id": "vehiclechassisdef_PEGASUS_CHEM",
+    "Name": "Pegasus",
+    "Details": "Fast and versatile, the Light Tank is poorly suited to direct combat but has a variety of other uses. Trading speed or weapons for armor, the Light Tank can soak up a surprisingly heavy level of fire power.\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       170     20\n<b>Left</b>         103     20\n<b>Right</b>       103     20\n<b>Rear</b>         95     20\n<b>Turret</b>      125     20\n\n<b>Total</b>      596    100\n",
+    "Icon": "Pegasus"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_8-12cv",
+  "movementType": "Wheeled",
+  "PathingCapDefID": "pathingdef_light_hover",
+  "HardpointDataDefID": "hardpointdatadef_pegasus",
+  "PrefabIdentifier": "chrprfvhcl_pegasusbase",
+  "PrefabBase": "pegasus",
+  "Tonnage": 35,
+  "weightClass": "LIGHT",
+  "BattleValue": 993,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1.25,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1.25,
+  "Signature": 1,
+  "Radius": 4,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3,
+      "z": -0.5
+    },
+    {
+      "x": 0.0,
+      "y": 1.5,
+      "z": 3.5
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3,
+      "z": -0.5
+    },
+    {
+      "x": 0.0,
+      "y": 1.5,
+      "z": 3.5
+    },
+    {
+      "x": -2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 0.0,
+      "y": 1.6,
+      "z": -4.0
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 170,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 103,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 103,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 95,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 125,
+      "InternalStructure": 20
+    }
+  ]
+}

--- a/Base 3061/vehicleChassis/vehiclechassisdef_VEDETTE_CHEM.json
+++ b/Base 3061/vehicleChassis/vehiclechassisdef_VEDETTE_CHEM.json
@@ -1,0 +1,142 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Vedette",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "CustomParts": {
+        "CustomParts": [],
+        "CrewLocation": "None"
+    },
+    "Description": {
+        "Cost": 680375,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Vedette (Laser)",
+        "Id": "vehiclechassisdef_VEDETTE_CHEM",
+        "Name": "Vedette",
+        "Details": "A Periphery take on the Laser Vedette fielded by House Liao, the Vedette (Chemical) Laser replaces the 2 Medium Lasers with 4 Chemical Medium Lasers and 5 tons of ammo.\n\n <b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n <b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       124     25\n<b>Left</b>          95     25\n<b>Right</b>        95     25\n<b>Rear</b>        100     25\n<b>Turret</b>      110     25\n\n<b>Total</b>      524    125\n",
+        "Icon": "Vedette"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_5-8cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_medium_tracked",
+    "HardpointDataDefID": "hardpointdatadef_vedette",
+    "PrefabIdentifier": "chrprfvhcl_vedettebase",
+    "PrefabBase": "vedette",
+    "Tonnage": 50,
+    "weightClass": "MEDIUM",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 2.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": 3
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 2.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": 3
+        },
+        {
+            "x": -2,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 2,
+            "y": 2.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 1.5,
+            "z": -4.5
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 124,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 95,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 95,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMount": "Ballistic",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMount": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 110,
+            "InternalStructure": 25
+        }
+    ]
+}

--- a/DynamicShops/data/RT_Periphery_Tanks.csv
+++ b/DynamicShops/data/RT_Periphery_Tanks.csv
@@ -20,6 +20,10 @@ vehicledef_Warrior_H7P,Mech,1,5
 vehicledef_SCORPION_CL,Mech,1,9
 vehicledef_BULLDOG_PERIPHERY,Mech,1,6
 vehicledef_VEDETTE_PERIPHERY,Mech,1,9
+vehicledef_MANTICORE_CHEM,Mech,1,6
+vehicledef_GOBLIN_CHEM,Mech,1,9
+vehicledef_VEDETTE_CHEM,Mech,1,9
+vehicledef_PEGASUS_CHEM,Mech,1,9
 vehicledef_PIKE_PERIPHERY,Mech,1,6
 vehicledef_CONDOR_PERIPHERY,Mech,1,8
 vehicledef_GALLEON_PERIPHERY,Mech,1,9

--- a/ExperimentalWeapons_RISCcompat/chassis/chassisdef_seraph_C-SRP-O_arcqiel.json
+++ b/ExperimentalWeapons_RISCcompat/chassis/chassisdef_seraph_C-SRP-O_arcqiel.json
@@ -146,7 +146,7 @@
   "VariantName": "C-SRP-O-A",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -155,9 +155,9 @@
   "YangsThoughts": " Boss... This mech is based on Seraph, however version is fully packed with experimental technologies. I don't know where you got it, but I smell troubles.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/ExperimentalWeapons_RISCcompat/chassis/chassisdef_seraph_C-SRP-O_orssos.json
+++ b/ExperimentalWeapons_RISCcompat/chassis/chassisdef_seraph_C-SRP-O_orssos.json
@@ -162,7 +162,7 @@
   "VariantName": "C-SRP-O-O",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -171,9 +171,9 @@
   "YangsThoughts": "Boss... This mech is based on Seraph, however this version is fully packed with experimental technologies. I don't know where you got it, but I smell troubles.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OA_dominus.json
+++ b/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OA_dominus.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-OA",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -108,9 +108,9 @@
   "YangsThoughts": "The light assault 'Mech of the Celestial series of OmniMechs, the Seraph is somewhat slow for its weight, but it attempts to make up for that with the inclusion of Triple-Strength Myomer that enables the 'Mech to speed up to 64 kph when it runs hot. Like the other Celestials, the Seraph makes use of a light fusion engine and a small cockpit, though other newer technologies are present only in its weaponry. As with the other Celestials, a C3i Computer is included. This variant uses a Heavy PPC to deliver a strong punch, and a Plasma Rifle to deal both damage and heat. An ER Medium Laser and a Medium Pulse Laser provide close support, while the Target Acquisition Gear threatens opponents with homing artillery. A Targeting Computer helps these weapons find their mark, and Improved Jump Jets allow the Seraph Dominus to move up to a hundred fifty meters at a time.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OB_infernus.json
+++ b/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OB_infernus.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-OB",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -108,9 +108,9 @@
   "YangsThoughts": "The light assault 'Mech of the Celestial series of OmniMechs, the Seraph is somewhat slow for its weight, but it attempts to make up for that with the inclusion of Triple-Strength Myomer that enables the 'Mech to speed up to 64 kph when it runs hot. Like the other Celestials, the Seraph makes use of a light fusion engine and a small cockpit, though other newer technologies are present only in its weaponry. As with the other Celestials, a C3i Computer is included. Vicious up close or at range, this variant  up close it can use its LB-X Autocannon/20, while farther out, the Infernus variant makes use of a Heavy PPC. Useful at all ranges is the Snub-Nose PPC, though it deals more damage up close.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OC_comminus.json
+++ b/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OC_comminus.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-OC",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -108,9 +108,9 @@
   "YangsThoughts": "The light assault 'Mech of the Celestial series of OmniMechs, the Seraph is somewhat slow for its weight, but it attempts to make up for that with the inclusion of Triple-Strength Myomer that enables the 'Mech to speed up to 64 kph when it runs hot. Like the other Celestials, the Seraph makes use of a light fusion engine and a small cockpit, though other newer technologies are present only in its weaponry. As with the other Celestials, a C3i Computer is included. Though the Comminus variant is quite powerful against conventional units, it sacrifices little firepower against other 'Mechs. An MRM 40 is useful against either type of opponent, though it is more difficult to aim than other weapons. A Heavy PPC and two ER Medium Lasers work well against hardened targets. A Plasma Rifle deals heavy damage against enemy units, but is especially potent against infantry. Also heavily damaging to unarmored troops are the pair of Flamers. To protect the Seraph C from enemy electronics, it mounts a Guardian ECM Suite.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OD_luminos.json
+++ b/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OD_luminos.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-OD",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -108,9 +108,9 @@
   "YangsThoughts": "The light assault 'Mech of the Celestial series of OmniMechs, the Seraph is somewhat slow for its weight, but it attempts to make up for that with the inclusion of Triple-Strength Myomer that enables the 'Mech to speed up to 64 kph when it runs hot. Like the other Celestials, the Seraph makes use of a light fusion engine and a small cockpit, though other newer technologies are present only in its weaponry. As with the other Celestials, a C3i Computer is included. The Seraph D is best at medium to long range, as it carries two Heavy PPCs and one Light PPC. Like the Dominus variant, the Luminos can jump up to 150 meters using improved jump jets that enable it to get into a good sniping position. Three Medium Pulse Lasers and a Small Laser are used defensively in the event an enemy units gets inside the minimum range of the PPCs. A Flamer provides effective anti-infantry defense.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OE_eminus.json
+++ b/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OE_eminus.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-OE",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -108,9 +108,9 @@
   "YangsThoughts": "The light assault 'Mech of the Celestial series of OmniMechs, the Seraph is somewhat slow for its weight, but it attempts to make up for that with the inclusion of Triple-Strength Myomer that enables the 'Mech to speed up to 64 kph when it runs hot. Like the other Celestials, the Seraph makes use of a light fusion engine and a small cockpit, though other newer technologies are present only in its weaponry. As with the other Celestials, a C3i Computer is included. The Seraph E uses two experimental Thunderbolt 20s, though it only has enough ammunition to fire each about nine times. Backing these up is a Snub-Nose PPC.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OS_caelestis.json
+++ b/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-OS_caelestis.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-OS",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -108,9 +108,9 @@
   "YangsThoughts": "The light assault 'Mech of the Celestial series of OmniMechs, the Seraph is somewhat slow for its weight, but it attempts to make up for that with the inclusion of Triple-Strength Myomer that enables the 'Mech to speed up to 64 kph when it runs hot. Like the other Celestials, the Seraph makes use of a light fusion engine and a small cockpit, though other newer technologies are present only in its weaponry. As with the other Celestials, a C3i Computer is included. The Seraph S carries three Streak LRM-10s backed up by two Clan-made Large Pulse Lasers and Medium Pulse Lasers. How these weapons, particularly the experimental Streak LRM systems, were acquired by the Blakists isn't known. Three Jump Jets give the Caelestis some more maneuverability.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-O_invictus.json
+++ b/Jihad 3068-3080/chassis/chassisdef_seraph_C-SRP-O_invictus.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-O",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech"
     ],
     "tagSetSourceFile": ""
@@ -108,9 +108,9 @@
   "YangsThoughts": "The light assault 'Mech of the Celestial series of OmniMechs, the Seraph is somewhat slow for its weight, but it attempts to make up for that with the inclusion of Triple-Strength Myomer that enables the 'Mech to speed up to 64 kph when it runs hot. Like the other Celestials, the Seraph makes use of a light fusion engine and a small cockpit, though other newer technologies are present only in its weaponry. As with the other Celestials, a C3i Computer is included. The Seraph features an array of weapons that is useful at long to medium ranges, but becomes very strong at close range.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad Unique/chassis/chassisdef_seraph_C-SRP-O_havalah.json
+++ b/Jihad Unique/chassis/chassisdef_seraph_C-SRP-O_havalah.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-O-H",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech",
       "HeroMech"
     ],
@@ -109,9 +109,9 @@
   "YangsThoughts": "Based on the Infernus, the custom config of Opacus Venatori member Adept Havalah Cazer carries a Brandt DragonMaw Ultra AC/20 supplied with a whopping six tons of reloads supported by a Ramtech 9500V Large and 5500V Medium Variable Speed Pulse Laser. While a Targeting Computer ensures she hits what she targets, a Brandt Whipsaw Anti-Missile System wards off missile fire for as long as it single ton of reloads lasts.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Jihad Unique/chassis/chassisdef_seraph_C-SRP-O_ravana.json
+++ b/Jihad Unique/chassis/chassisdef_seraph_C-SRP-O_ravana.json
@@ -99,7 +99,7 @@
   "VariantName": "C-SRP-O-R",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.1-0.8-0.9",
+      "mr-resize-0.9",
       "OmniMech",
       "HeroMech"
     ],
@@ -109,9 +109,9 @@
   "YangsThoughts": "Customized configuration of the Manei Domini staffed Warrior House Rakshasa's house master, Precentor Ravana. This Seraph is configured with Advanced and Experimental Technology. The 'Mech is configured as intermediate fighter. It carries a SN-PPC, Thunderbolt 20 Missile Launcher and experimental Large Variable-Speed Laser for its primary armament. For defense it has an experimental Laser Anti-Missile System. It's also been given two additional Double-Heat Sinks to help handle the extra heat load.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_archangel",
-  "PrefabIdentifier": "chrprfmech_archangelbase-001",
-  "PrefabBase": "archangel",
+  "HardpointDataDefID": "hardpointdatadef_seraph",
+  "PrefabIdentifier": "chrprfmech_seraphbase-001",
+  "PrefabBase": "seraph",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",


### PR DESCRIPTION
Swapped Seraph to new CAB prefab with 0.9 resized as per #modelling. Fixed the incorrect cargo bay on the Cobra Transport vtol, now an infantry bay as per the rs. Added a combat mod of the Cobra with 3 ML and 2 extra tons of armour in place of the AMS/ammo. Added 5 custom Chem Laser tank variants for periphery spawns 