### PR TITLE
Grammar fix

### DIFF
--- a/CustomUnits/Localization/CU/Localization.json
+++ b/CustomUnits/Localization/CU/Localization.json
@@ -35,7 +35,7 @@
     "FileName": "",
     "Name": "PILOT.CANT_PILOT_MESSAGE",
     "Localization": {
-      "CULTURE_EN_US": "To pilot {0} {1} should have {2} expertise.\n\nTo understand which piloting expertise pilot has, hover cursor over icons left to callsign",
+      "CULTURE_EN_US": "To pilot {0} {1} should have {2} expertise.\n\nTo understand which piloting expertise this pilot has, hover cursor over icons to the right of their callsign",
       "CULTURE_RU_RU": "Что бы пилотировать {0} {1} должен уметь водить {2}\n\nЧто бы понять, что может водить данный пилот, наведите курсор на иконки слева от портета"
     }
   },


### PR DESCRIPTION
Location of expertise is to the right of the callsign not the left.