### PR TITLE
Wrong tag values

### DIFF
--- a/RogueModulePilots/pilot/pilot_Idget.json
+++ b/RogueModulePilots/pilot/pilot_Idget.json
@@ -33,13 +33,13 @@
     "items": [
       "BLACKLISTED",
       "pilot_bookish",
-      "pilot_Jinxed",
+      "pilot_jinxed",
       "pilot_lucky",
       "pilot_cautious",
       "pilot_dependable",
       "pilot_honest",
       "pilot_mechwarrior",
-      "pilot_technician",
+      "pilot_tech",
       "pilot_comstar",
       "pilot_lostech"
     ],


### PR DESCRIPTION
Pilot had `pilot_Jinxed` (capital J) and `pilot_technician` (which isn't found anywhere else)
Idget noticed this when someone was showing his pilot, quick check found the mistakes.
Changes should put the tags in-line with the known tags in use.
No idea on how this will impact current pilots though.