### PR TITLE
Tweaked Savior RV and swapped J27/J37 to spam ammo and added to shops

### DIFF
--- a/Base 3061/vehicle/apc/vehicledef_J-27_ARMOR.json
+++ b/Base 3061/vehicle/apc/vehicledef_J-27_ARMOR.json
@@ -149,13 +149,6 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_HeavyFlamer",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
@@ -225,14 +218,21 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/vehicle/apc/vehicledef_J-27_FUSION.json
+++ b/Base 3061/vehicle/apc/vehicledef_J-27_FUSION.json
@@ -107,13 +107,6 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
       "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
@@ -169,14 +162,21 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/vehicle/apc/vehicledef_J-27_KILLJOY.json
+++ b/Base 3061/vehicle/apc/vehicledef_J-27_KILLJOY.json
@@ -159,7 +159,7 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Base 3061/vehicle/apc/vehicledef_SAVIOR.json
+++ b/Base 3061/vehicle/apc/vehicledef_SAVIOR.json
@@ -145,35 +145,35 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArmorRepair",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArmorRepair",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArmorRepair",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArmorRepair",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArmorRepair",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_shopItems_mining.csv
+++ b/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_shopItems_mining.csv
@@ -1,4 +1,5 @@
 itemCollection_shopItems_mining,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_CHASSEUR,Mech,1,7
 vehicledef_CHASSEUR_ORIG,Mech,1,8
 vehicledef_PO,Mech,1,8

--- a/DynamicShops/data/RT_CLAN_Tanks.csv
+++ b/DynamicShops/data/RT_CLAN_Tanks.csv
@@ -1,4 +1,5 @@
 RT_CLAN_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_CARRIER_LRM_CLAN,Mech,1,5
 vehicledef_CARRIER_LRM_2_CLAN,Mech,1,5
 vehicledef_CARRIER_UAC5,Mech,1,5

--- a/DynamicShops/data/RT_Circinus_Tanks.csv
+++ b/DynamicShops/data/RT_Circinus_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Taurian_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_PLAINSMAN_LRM,Mech,1,8
 vehicledef_ZHUKOV,Mech,1,6
 vehicledef_DRILLSON,Mech,1,8

--- a/DynamicShops/data/RT_Comstar_Tanks.csv
+++ b/DynamicShops/data/RT_Comstar_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Comstar_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_MARKSMAN,Mech,1,2
 vehicledef_MANTICORE,Mech,1,5
 vehicledef_BURKE,Mech,1,5

--- a/DynamicShops/data/RT_Davion_Tanks.csv
+++ b/DynamicShops/data/RT_Davion_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Davion_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_ROMMEL,Mech,1,5
 vehicledef_PATTON,Mech,1,5
 vehicledef_DRILLSON,Mech,1,7

--- a/DynamicShops/data/RT_FRR_Tanks.csv
+++ b/DynamicShops/data/RT_FRR_Tanks.csv
@@ -1,4 +1,5 @@
 RT_FRR_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_GOBLIN_SRM,Mech,1,9
 vehicledef_GOBLIN_LRM,Mech,1,9
 vehicledef_GOBLIN_MG,Mech,1,9

--- a/DynamicShops/data/RT_Kurita_Tanks.csv
+++ b/DynamicShops/data/RT_Kurita_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Kurita_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_ZHUKOV,Mech,1,9
 vehicledef_SHILLELAGH,Mech,1,8
 vehicledef_HARASSER,Mech,1,8

--- a/DynamicShops/data/RT_Liao_Tanks.csv
+++ b/DynamicShops/data/RT_Liao_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Liao_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_BEHEMOTHF,Mech,1,4
 vehicledef_BEHEMOTHA,Mech,1,4
 vehicledef_BRUTUS_LRM,Mech,1,5

--- a/DynamicShops/data/RT_Magistracy_Tanks.csv
+++ b/DynamicShops/data/RT_Magistracy_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Outworlds_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_PO,Mech,1,6
 vehicledef_PLAINSMAN_LRM,Mech,1,8
 vehicledef_ZHUKOV,Mech,1,6

--- a/DynamicShops/data/RT_Marian_Tanks.csv
+++ b/DynamicShops/data/RT_Marian_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Marian_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_PLAINSMAN_LRM,Mech,1,8
 vehicledef_DRILLSON,Mech,1,8
 vehicledef_DRILLSON_SRM,Mech,1,8

--- a/DynamicShops/data/RT_Marik_Tanks.csv
+++ b/DynamicShops/data/RT_Marik_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Marik_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_CONDOR,Mech,1,8
 vehicledef_MANTICORE_LASER,Mech,1,5
 vehicledef_MANTICORE_BLAZER,Mech,1,5

--- a/DynamicShops/data/RT_Outworlds_Tanks.csv
+++ b/DynamicShops/data/RT_Outworlds_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Outworlds_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_PO,Mech,1,6
 vehicledef_PLAINSMAN_LRM,Mech,1,8
 vehicledef_ZHUKOV,Mech,1,6

--- a/DynamicShops/data/RT_Periphery_Tanks.csv
+++ b/DynamicShops/data/RT_Periphery_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Periphery_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_PLAINSMAN_LRM,Mech,1,8
 vehicledef_ZHUKOV,Mech,1,6
 vehicledef_DRILLSON,Mech,1,8

--- a/DynamicShops/data/RT_Pirate_Tanks.csv
+++ b/DynamicShops/data/RT_Pirate_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Outworlds_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_PO,Mech,1,6
 vehicledef_PLAINSMAN_LRM,Mech,1,8
 vehicledef_ZHUKOV,Mech,1,6

--- a/DynamicShops/data/RT_RepairVehicle.csv
+++ b/DynamicShops/data/RT_RepairVehicle.csv
@@ -1,2 +1,3 @@
 RT_RepairVehicle,,,
+vehicledef_J-27_FUSION,Mech,1,1
 vehicledef_SAVIOR,Mech,1,1

--- a/DynamicShops/data/RT_StIves_Tanks.csv
+++ b/DynamicShops/data/RT_StIves_Tanks.csv
@@ -1,4 +1,5 @@
 RT_StIves_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_DRILLSON,Mech,1,8
 vehicledef_DRILLSON_SRM,Mech,1,8
 vehicledef_CONDOR,Mech,1,8

--- a/DynamicShops/data/RT_Steiner_Tanks.csv
+++ b/DynamicShops/data/RT_Steiner_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Steiner_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_ROMMEL,Mech,1,5
 vehicledef_PATTON_BLAZER,Mech,1,5
 vehicledef_PATTON,Mech,1,5

--- a/DynamicShops/data/RT_Taurian_Tanks.csv
+++ b/DynamicShops/data/RT_Taurian_Tanks.csv
@@ -1,4 +1,5 @@
 RT_Taurian_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_PLAINSMAN_LRM,Mech,1,8
 vehicledef_GLADIUS,Mech,1,8
 vehicledef_ZHUKOV,Mech,1,6

--- a/DynamicShops/data/RT_WoB_Tanks.csv
+++ b/DynamicShops/data/RT_WoB_Tanks.csv
@@ -1,4 +1,5 @@
 RT_WoB_Tanks,,,
+vehicledef_J-27_FUSION,Mech,1,8
 vehicledef_CARRIER_UAC5,Mech,1,5
 vehicledef_CARRIER_LBX,Mech,1,5
 vehicledef_CARRIER_AC20,Mech,1,5

--- a/Jihad 3068-3080/vehicle/vehicledef_J-37.json
+++ b/Jihad 3068-3080/vehicle/vehicledef_J-37.json
@@ -154,41 +154,6 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_AntiMissile",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Mortar",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
       "ComponentDefID": "Tank_CrewCompartment",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -230,28 +195,56 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Vehicle_Munitions",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_SPAMMY",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"


### PR DESCRIPTION
J27 now have a chance to spawn on mining worlds, in basic faction lists and in the IS faction stores (added to the Savior list). Swapped ammo loads on the J27/J37 and altered Savior loadout to run 15 tons of armour, 5 tons of ammo to emphasise it's repair role 