### PR TITLE
NavMap Faction colour fixes

### DIFF
--- a/Core/RogueTechCore/Factions/faction_ClanStoneLion.json
+++ b/Core/RogueTechCore/Factions/faction_ClanStoneLion.json
@@ -100,5 +100,5 @@
   "factionID": "ClanStoneLion",
   "icon": "uixTxrLogo_ClanStoneLion",
   "factionMapBorderOverrideColor": "rgba(0,0,0,1.0)",
-  "factionMapColor": "rgba(255,153,0,1.0)"
+  "factionMapColor": "rgba(102,102,153,1.0)"
 }

--- a/Core/RogueTechCore/Factions/faction_ClanWolfInExile.json
+++ b/Core/RogueTechCore/Factions/faction_ClanWolfInExile.json
@@ -100,5 +100,5 @@
   "factionID": "ClanWolfInExile",
   "icon": "uixTxrLogo_ClanWolfinExile",
   "factionMapBorderOverrideColor": "rgba(0,0,0,1.0)",
-  "factionMapColor": "rgba(102,102,153,1.0)"
+  "factionMapColor": "rgba(153,51,0,0.4)"
 }

--- a/Core/RogueTechCore/Factions/faction_FroncReaches.json
+++ b/Core/RogueTechCore/Factions/faction_FroncReaches.json
@@ -100,5 +100,5 @@
   "factionID": "FroncReaches",
   "icon": "uixTxrLogo_FroncReaches",
   "factionMapBorderOverrideColor": "rgba(0,0,0,1.0)",
-  "factionMapColor": "rgba(102,102,102,1.0)"
+  "factionMapColor": "rgba(51,204,0,0.4)"
 }


### PR DESCRIPTION
Change WiE back to match Clan Wolf colour; Change Stone Lion to WiE's previous colour (future proofing IS/Republic clash); Changed FroncReaches to be different than Duchy of Andurian colour