### PR TITLE
Tweaks to Cloud Cobra/Fronc Reaches

### DIFF
--- a/Core/RogueTechCore/Factions/faction_ClanCloudCobra.json
+++ b/Core/RogueTechCore/Factions/faction_ClanCloudCobra.json
@@ -78,7 +78,7 @@
   "factionID": "ClanCloudCobra",
   "icon": "uixTxrLogo_ClanCloudCobra",
   "factionMapBorderOverrideColor": "rgba(0,0,0,1.0)",
-  "factionMapColor": "rgba(102,102,255,1.0)",
+  "factionMapColor": "rgba(51,204,0,1.0)",
   "DefaultCombatLeaderCastDefId": "castDef_ClanCloudCobra",
   "DefaultRepresentativeCastDefId": "castDef_ClanCloudCobra",
   "HeraldryDefId": "heraldrydef_ClanCloudCobra",

--- a/Core/RogueTechCore/Factions/faction_FroncReaches.json
+++ b/Core/RogueTechCore/Factions/faction_FroncReaches.json
@@ -100,5 +100,5 @@
   "factionID": "FroncReaches",
   "icon": "uixTxrLogo_FroncReaches",
   "factionMapBorderOverrideColor": "rgba(0,0,0,1.0)",
-  "factionMapColor": "rgba(51,204,0,0.4)"
+  "factionMapColor": "rgba(0,0,204,0.4)"
 }


### PR DESCRIPTION
Colour shifts to Cloud Cobra and Fronc Reaches for better player visability until proximity to similar colours requires another shift.