### PR TITLE
Pirate ams nerf

### DIFF
--- a/Core/RogueModuleTech/AMS/Weapon_AMS_ADV_Pirate.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_ADV_Pirate.json
@@ -17,12 +17,10 @@
         "AdvAMS",
         "AMSMULTI",
         "AMSDmg: 1",
-        "AMSAcc: 80%",
+        "AMSAcc: 65% to 80%",
         "AMSShots: 8 to 48",
         "AMSHeat: 2 to 12",
-        "JamChanceMode1: 10%, x4",
-        "JamChanceMode2: 20%, x5",
-        "JamChanceMode3: 30%, x6"
+        "WeaponJAMFlatShotBase: 7%"
       ]
     },
     "Flags": {
@@ -32,9 +30,6 @@
     },
     "InventorySorter": {
       "SortKey": "00025"
-    },
-    "IBLS": {
-      "StorageSize": 5
     }
   },
   "Auras": [
@@ -120,7 +115,7 @@
       "IsAAMS": true,
       "AMSDamage": 0,
       "ShotsWhenFired": 8,
-      "AMSHitChance": 0.8,
+      "AMSHitChance": 0.65,
       "HeatGenerated": -10
     },
     {
@@ -133,7 +128,10 @@
       "IsAAMS": true,
       "AMSDamage": 0,
       "ShotsWhenFired": 16,
-      "AMSHitChance": 0.8,
+      "AMSHitChance": 0.68,
+      "FlatJammingChance": 0.07,
+      "GunneryJammingMult": 0.01,
+      "GunneryJammingBase": 1,
       "HeatGenerated": -8
     },
     {
@@ -146,7 +144,10 @@
       "IsAAMS": true,
       "AMSDamage": 0,
       "ShotsWhenFired": 24,
-      "AMSHitChance": 0.8,
+      "AMSHitChance": 0.71,
+      "FlatJammingChance": 0.14,
+      "GunneryJammingMult": 0.01,
+      "GunneryJammingBase": 1,
       "HeatGenerated": -6
     },
     {
@@ -159,8 +160,8 @@
       "IsAAMS": true,
       "AMSDamage": 0,
       "ShotsWhenFired": 32,
-      "AMSHitChance": 0.8,
-      "FlatJammingChance": 0.1,
+      "AMSHitChance": 0.74,
+      "FlatJammingChance": 0.21,
       "GunneryJammingMult": 0.01,
       "GunneryJammingBase": 1,
       "HeatGenerated": -4
@@ -175,8 +176,8 @@
       "IsAAMS": true,
       "AMSDamage": 0,
       "ShotsWhenFired": 40,
-      "AMSHitChance": 0.8,
-      "FlatJammingChance": 0.2,
+      "AMSHitChance": 0.77,
+      "FlatJammingChance": 0.28,
       "GunneryJammingMult": 0.01,
       "GunneryJammingBase": 1,
       "HeatGenerated": -2
@@ -192,7 +193,7 @@
       "AMSDamage": 0,
       "ShotsWhenFired": 48,
       "AMSHitChance": 0.8,
-      "FlatJammingChance": 0.3,
+      "FlatJammingChance": 0.35,
       "GunneryJammingMult": 0.01,
       "GunneryJammingBase": 1,
       "HeatGenerated": 0

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_ADV_Pirate.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_ADV_Pirate.json
@@ -30,6 +30,9 @@
     },
     "InventorySorter": {
       "SortKey": "00025"
+    },
+    "IBLS": {
+      "StorageSize": 5
     }
   },
   "Auras": [


### PR DESCRIPTION
Redbat pointed out that the lower firing modes of the Adv. AMS (P) were just about as good as normal firing mode of the Adv. AMS, which did not meet the design goal of being worse in every way except ammo consumption.