### PR TITLE
Fixed MW event for EI/DNI and Pain Shunt

### DIFF
--- a/Core/EIEIOH/events/event_co_CantFeelThis.json
+++ b/Core/EIEIOH/events/event_co_CantFeelThis.json
@@ -1,1286 +1,902 @@
 {
-  "Description": {
-    "Id": "event_co_CantFeelThis",
-    "Name": "Pain Shunt... Can't Feel This!",
-    "Details": "A knock sounds on your office door and you push a button on your desk to open the door.\r\n\r\nDarius strides in with a datapad, \"Commander, the initial evaluations for candidates to undergo surgery for the [[DM.BaseDescriptionDefs[LorePainShunt],Pain Shunt procedure]] have come back.  These three volunteers have completed the assessment and meet the requirements:\r\n\r\n[[TGT_MW,{TGT_MW.Callsign}]]\r\n[[SCN_MW,{SCN_MW.Callsign}]]\r\n[[TRT_MW,{TRT_MW.Callsign}]]\r\n\r\nYou just need to sign that form on the screen and we can proceed from there.\"",
-    "Icon": "uixTxrSpot_CantFeelThis.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "tagSetSourceFile": "",
-      "items": [
-        "Do_not_fire"
-      ]
+    "Description" : {
+        "Id" : "event_co_CantFeelThis",
+        "Name" : "Pain Shunt... Can't Feel This!",
+        "Details" : "A knock sounds on your office door and you push a button on your desk to open the door.\r\n\r\nDarius strides in with a datapad, \"Commander, the initial evaluations for candidates to undergo surgery for the [[DM.BaseDescriptionDefs[LorePainShunt],Pain Shunt procedure]] have come back.  These volunteers have completed the assessment and should meet your requirements:\r\n\r\n[[SCN_MW,{SCN_MW.Callsign}]]\r\n[[TRT_MW,{TRT_MW.Callsign}]]\r\n\r\nYou just need to sign that form on the screen and we can proceed from there.\"",
+        "Icon" : "uixTxrSpot_CantFeelThis.png"
     },
-    "ExclusionTags": {
-      "tagSetSourceFile": "Tags/CompanyTags",
-      "items": []
-    },
-    "RequirementComparisons": [
-      {
-        "obj": "Funds",
-        "op": "GreaterThanOrEqual",
-        "val": 4000000,
-        "valueConstant": "4000000"
-      }
-    ]
-  },
-  "AdditionalRequirements": [
-    {
-      "Scope": "MechWarrior",
-      "RequirementTags": {
-        "tagSetSourceFile": "",
-        "items": []
-      },
-      "ExclusionTags": {
-        "tagSetSourceFile": "",
-        "items": [
-          "pilot_painshunt",
-          "pilot_cantfeelthis"
-        ]
-      },
-      "RequirementComparisons": [
-        {
-          "obj": "Injuries",
-          "op": "Equal",
-          "val": 0,
-          "valueConstant": "0"
-        }
-      ]
-    },
-    {
-      "Scope": "StarSystem",
-      "RequirementTags": {
-        "tagSetSourceFile": "Tags/PlanetTags",
-        "items": []
-      },
-      "ExclusionTags": {
-        "tagSetSourceFile": "Tags/PlanetTags",
-        "items": []
-      },
-      "RequirementComparisons": []
-    }
-  ],
-  "AdditionalObjects": [
-    {
-      "Scope": "SecondaryMechWarrior",
-      "Requirements": {
-        "Scope": "SecondaryMechWarrior",
-        "RequirementTags": {
-          "tagSetSourceFile": "",
-          "items": []
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [
+                "Do_not_fire"
+            ],
+            "tagSetSourceFile" : ""
         },
-        "ExclusionTags": {
-          "tagSetSourceFile": "",
-          "items": [
-            "pilot_painshunt",
-            "pilot_cantfeelthis"
-          ]
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
         },
-        "RequirementComparisons": [
-          {
-            "obj": "Injuries",
-            "op": "Equal",
-            "val": 0,
-            "valueConstant": "0"
-          }
-        ]
-      }
-    },
-    {
-      "Scope": "TertiaryMechWarrior",
-      "Requirements": {
-        "Scope": "TertiaryMechWarrior",
-        "RequirementTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "ExclusionTags": {
-          "tagSetSourceFile": "",
-          "items": [
-            "pilot_painshunt",
-            "pilot_cantfeelthis"
-          ]
-        },
-        "RequirementComparisons": [
-          {
-            "obj": "Injuries",
-            "op": "Equal",
-            "val": 0,
-            "valueConstant": "0"
-          }
-        ]
-      }
-    }
-  ],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "Select {TGT_MW.Callsign}",
-        "Details": "[Surgical procedure may cost up to ¢4,000,000]",
-        "Icon": null
-      },
-      "RequirementList": [
-        {
-          "Scope": "Company",
-          "RequirementTags": {
-            "tagSetSourceFile": "",
-            "items": []
-          },
-          "ExclusionTags": {
-            "tagSetSourceFile": "",
-            "items": []
-          },
-          "RequirementComparisons": [
+        "RequirementComparisons" : [
             {
-              "obj": "Funds",
-              "op": "GreaterThanOrEqual",
-              "val": 4000000,
-              "valueConstant": "4000000"
+                "obj" : "Funds",
+                "op" : "GreaterThanOrEqual",
+                "val" : 4000000,
+                "valueConstant" : "4000000"
             }
-          ]
-        },
+        ]
+    },
+    "AdditionalRequirements" : [
         {
-          "Scope": "MechWarrior",
-          "RequirementTags": {
-            "tagSetSourceFile": "",
-            "items": []
-          },
-          "ExclusionTags": {
-            "tagSetSourceFile": "",
-            "items": [
-              "pilot_painshunt",
-              "pilot_cantfeelthis"
+            "Scope" : "MechWarrior",
+            "RequirementTags" : {
+                "items" : [],
+                "tagSetSourceFile" : ""
+            },
+            "ExclusionTags" : {
+                "items" : [
+                    "pilot_painshunt",
+                    "pilot_cantfeelthis"
+                ],
+                "tagSetSourceFile" : ""
+            },
+            "RequirementComparisons" : [
+                {
+                    "obj" : "Injuries",
+                    "op" : "Equal",
+                    "val" : 0,
+                    "valueConstant" : "0"
+                }
             ]
-          },
-          "RequirementComparisons": [
-            {
-              "obj": "Injuries",
-              "op": "Equal",
-              "val": 0,
-              "valueConstant": "0"
-            }
-          ]
+        },
+        {
+            "Scope" : "StarSystem",
+            "RequirementTags" : {
+                "items" : [],
+                "tagSetSourceFile" : "Tags/PlanetTags"
+            },
+            "ExclusionTags" : {
+                "items" : [],
+                "tagSetSourceFile" : "Tags/PlanetTags"
+            },
+            "RequirementComparisons" : []
         }
-      ],
-      "ResultSets": [
+    ],
+    "AdditionalObjects" : [
         {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "All Systems Go",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TGT_MW,{TGT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[TGT_MW,{TGT_MW.Callsign}]]'s implants.  {TGT_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.  It will take up to a year for them get 100% coordination back.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 60,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
+            "Scope" : "SecondaryMechWarrior",
+            "Requirements" : {
+                "Scope" : "SecondaryMechWarrior",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : [
+                    {
+                        "obj" : "Injuries",
+                        "op" : "Equal",
+                        "val" : 0,
+                        "valueConstant" : "0"
+                    }
                 ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "28",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-1000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 365
             }
-          ]
         },
         {
-          "Description": {
-            "Id": "outcome_0_1",
-            "Name": "Minor Complications",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TGT_MW,{TGT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[TGT_MW,{TGT_MW.Callsign}]]'s procedure.  {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.  It may take them 18 months to get their coordination back as well.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 30,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
+            "Scope" : "TertiaryMechWarrior",
+            "Requirements" : {
+                "Scope" : "TertiaryMechWarrior",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : [
+                    {
+                        "obj" : "Injuries",
+                        "op" : "Equal",
+                        "val" : 0,
+                        "valueConstant" : "0"
+                    }
                 ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "56",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-2000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 545
             }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_2",
-            "Name": "Near Death Experience",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TGT_MW,{TGT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[TGT_MW,{TGT_MW.Callsign}]]'s procedure.  {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.  The MedTech also suspect it will take nearly 2 years for them to regain full coordination back.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 9,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "104",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-4000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 730
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_3",
-            "Name": "Sorry for your loss",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[TGT_MW,{TGT_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[TGT_MW,{TGT_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[TGT_MW,{TGT_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[TGT_MW,{TGT_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[TGT_MW,{TGT_MW.Callsign}]]'s kin.\"",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_Kill",
-                  "value": "1",
-                  "valueConstant": null,
-                  "additionalValues": [
-                    "killed during a medical bio-enhancement procedure"
-                  ]
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-500000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "ExclusionTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "Select {SCN_MW.Callsign}",
-        "Details": "[Surgical procedure may cost up to ¢4,000,000]",
-        "Icon": null
-      },
-      "RequirementList": [
+    ],
+    "Options" : [
         {
-          "Scope": "Company",
-          "RequirementTags": {
-            "tagSetSourceFile": "",
-            "items": []
-          },
-          "ExclusionTags": {
-            "tagSetSourceFile": "",
-            "items": []
-          },
-          "RequirementComparisons": [
-            {
-              "obj": "Funds",
-              "op": "GreaterThanOrEqual",
-              "val": 4000000,
-              "valueConstant": "4000000"
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Select {SCN_MW.Callsign}",
+                "Details" : "[Surgical procedure may cost up to \u00A24,000,000]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "SecondaryMechWarrior",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "pilot_painshunt",
+                            "pilot_cantfeelthis"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "All Systems Go",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[SCN_MW,{SCN_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.  It will take up to a year for them get 100% coordination back.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 60,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_painshunt"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "28",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-1000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_klutz"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 365
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_1",
+                        "Name" : "Minor Complications",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[SCN_MW,{SCN_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[SCN_MW,{SCN_MW.Callsign}]]'s procedure.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.  It may take them 18 months to get their coordination back as well.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 30,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_painshunt"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "56",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-2000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_klutz"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 545
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_2",
+                        "Name" : "Near Death Experience",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[SCN_MW,{SCN_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[SCN_MW,{SCN_MW.Callsign}]]'s procedure.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.  The MedTech also suspect it will take nearly 2 years for them to regain full coordination back.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 9,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_painshunt"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "104",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-4000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_klutz"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 730
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_3",
+                        "Name" : "Sorry for your loss",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[SCN_MW,{SCN_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[SCN_MW,{SCN_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[SCN_MW,{SCN_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[SCN_MW,{SCN_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[SCN_MW,{SCN_MW.Callsign}]]'s kin.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_Kill",
+                                    "value" : "1",
+                                    "valueConstant" : null,
+                                    "additionalValues" : [
+                                        "killed during a medical bio-enhancement procedure"
+                                    ]
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-500000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
             }
-          ]
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Select {TRT_MW.Callsign}",
+                "Details" : "[Surgical procedure may cost up to \u00A24,000,000]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "TertiaryMechWarrior",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "pilot_painshunt",
+                            "pilot_cantfeelthis"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "All Systems Go",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TRT_MW,{TRT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.  It will take up to a year for them get 100% coordination back.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 60,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_painshunt"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "28",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-1000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_klutz"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 365
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Minor Complications",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TRT_MW,{TRT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[TRT_MW,{TRT_MW.Callsign}]]'s procedure.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.  It may take them 18 months to get their coordination back as well.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 30,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_painshunt"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "56",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-2000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_klutz"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 545
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Near Death Experience",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TRT_MW,{TRT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[TRT_MW,{TRT_MW.Callsign}]]'s procedure.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.  The MedTech also suspect it will take nearly 2 years for them to regain full coordination back.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 9,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_painshunt"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "104",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-4000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_klutz"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 730
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Sorry for your loss",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[TRT_MW,{TRT_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[TRT_MW,{TRT_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[TRT_MW,{TRT_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[TRT_MW,{TRT_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[TRT_MW,{TRT_MW.Callsign}]]'s kin.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_Kill",
+                                    "value" : "1",
+                                    "valueConstant" : null,
+                                    "additionalValues" : [
+                                        "killed during a medical bio-enhancement procedure"
+                                    ]
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-500000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_2",
+                "Name" : "None of these pilots are suitable",
+                "Details" : "Non-Participation Option",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_0",
+                        "Name" : "Abort! Abort!",
+                        "Details" : "You look over the names and records of the three volunteers.  You thumb back through their files numerous times, before letting out a long sigh and closed the datapad.\r\n\r\nYou hand the pad back to Darius, \"Thanks Darius, but I do not think any of those three pilots understand the risks involved here.  See if there are any other volunteers.  We do not need to rush into this blindly.\"\r\n\r\nDarius takes the datapad, \"As you wish, Boss.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : [
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_cantfeelthis"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        },
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_cantfeelthis"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        },
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_cantfeelthis"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "All Systems Go",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[SCN_MW,{SCN_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.  It will take up to a year for them get 100% coordination back.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 60,
-          "Results": [
-            {
-              "Scope": "SecondaryMech",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "28",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-1000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 365
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Minor Complications",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[SCN_MW,{SCN_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[SCN_MW,{SCN_MW.Callsign}]]'s procedure.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.  It may take them 18 months to get their coordination back as well.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 30,
-          "Results": [
-            {
-              "Scope": "SecondaryMech",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "56",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-2000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 545
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Near Death Experience",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[SCN_MW,{SCN_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[SCN_MW,{SCN_MW.Callsign}]]'s procedure.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.  The MedTech also suspect it will take nearly 2 years for them to regain full coordination back.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 9,
-          "Results": [
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "104",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-4000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 730
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Sorry for your loss",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[SCN_MW,{SCN_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[SCN_MW,{SCN_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[SCN_MW,{SCN_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[SCN_MW,{SCN_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[SCN_MW,{SCN_MW.Callsign}]]'s kin.\"",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_Kill",
-                  "value": "1",
-                  "valueConstant": null,
-                  "additionalValues": [
-                    "killed during a medical bio-enhancement procedure"
-                  ]
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-500000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "ExclusionTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_2",
-        "Name": "Select {TRT_MW.Callsign}",
-        "Details": "[Surgical procedure may cost up to ¢4,000,000]",
-        "Icon": null
-      },
-      "RequirementList": [
-        {
-          "Scope": "Company",
-          "RequirementTags": {
-            "tagSetSourceFile": "",
-            "items": []
-          },
-          "ExclusionTags": {
-            "tagSetSourceFile": "",
-            "items": []
-          },
-          "RequirementComparisons": [
-            {
-              "obj": "Funds",
-              "op": "GreaterThanOrEqual",
-              "val": 4000000,
-              "valueConstant": "4000000"
-            }
-          ]
-        }
-      ],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_2_0",
-            "Name": "All Systems Go",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TRT_MW,{TRT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.  It will take up to a year for them get 100% coordination back.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 60,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "28",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-1000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 365
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_2_1",
-            "Name": "Minor Complications",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TRT_MW,{TRT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[TRT_MW,{TRT_MW.Callsign}]]'s procedure.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.  It may take them 18 months to get their coordination back as well.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 30,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "56",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-2000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 545
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_2_2",
-            "Name": "Near Death Experience",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the neural map for [[TRT_MW,{TRT_MW.Callsign}]].  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[TRT_MW,{TRT_MW.Callsign}]]'s procedure.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.  The MedTech also suspect it will take nearly 2 years for them to regain full coordination back.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 9,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_painshunt"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "104",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-4000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_klutz"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 730
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_2_3",
-            "Name": "Sorry for your loss",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[TRT_MW,{TRT_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[TRT_MW,{TRT_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[TRT_MW,{TRT_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[TRT_MW,{TRT_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[TRT_MW,{TRT_MW.Callsign}]]'s kin.\"",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_Kill",
-                  "value": "1",
-                  "valueConstant": null,
-                  "additionalValues": [
-                    "killed during a medical bio-enhancement procedure"
-                  ]
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-500000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "ExclusionTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_3",
-        "Name": "None of these pilots are suitable",
-        "Details": "Non-Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_3_0",
-            "Name": "Abort! Abort!",
-            "Details": "You look over the names and records of the three volunteers.  You thumb back through their files numerous times, before letting out a long sigh and closed the datapad.\r\n\r\nYou hand the pad back to Darius, \"Thanks Darius, but I do not think any of those three pilots understand the risks involved here.  See if there are any other volunteers.  We do not need to rush into this blindly.\"\r\n\r\nDarius takes the datapad, \"As you wish, Boss.\"",
-            "Icon": null
-          },
-          "Weight": 100,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_cantfeelthis"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            },
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_cantfeelthis"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            },
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "tagSetSourceFile": "",
-                "items": [
-                  "pilot_cantfeelthis"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "ExclusionTags": {
-          "tagSetSourceFile": "",
-          "items": []
-        },
-        "RequirementComparisons": []
-      }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "NORMAL",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [],
+        "tagSetSourceFile" : "tags/EventTags"
     }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "NORMAL",
-  "OneTimeEvent": false,
-  "Tags": {
-    "tagSetSourceFile": "tags/EventTags",
-    "items": []
-  }
 }

--- a/Core/EIEIOH/events/event_co_EIEIOH.json
+++ b/Core/EIEIOH/events/event_co_EIEIOH.json
@@ -1,1093 +1,788 @@
 {
-  "Description": {
-    "Id": "event_co_EIEIOH",
-    "Name": "E... I... E... I... OH, Neural Implants here we go",
-    "Details": "A knock sounds on your office door and you push a button on your desk to open the door.\r\n\r\nDarius strides in with a datapad, \"Commander, the initial evaluations for candidates to undergo surgery for [[DM.BaseDescriptionDefs[LoreNeuralImplant],Enhanced Imaging Neural Implants]] has come back.  These three volunteers have completed the assessment and meet the requirements:\r\n\r\n[[TGT_MW,{TGT_MW.Callsign}]]\r\n[[SCN_MW,{SCN_MW.Callsign}]]\r\n[[TRT_MW,{TRT_MW.Callsign}]]\r\n\r\nYou just need to sign that form on the screen and we can proceed from there.\"",
-    "Icon": "uixTxrSpot_EIEIOH.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "items": [
-        "Do_not_fire"
-      ],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_co_EIEIOH",
+        "Name" : "E... I... E... I... OH, Neural Implants here we go",
+        "Details" : "A knock sounds on your office door and you push a button on your desk to open the door.\r\n\r\nDarius strides in with a datapad, \"Commander, the initial evaluations for candidates to undergo surgery for [[DM.BaseDescriptionDefs[LoreNeuralImplant],Enhanced Imaging Neural Implants]] have come back.  These volunteers have completed the assessment and should meet your requirements:\r\n\r\n[[SCN_MW,{SCN_MW.Callsign}]]\r\n[[TRT_MW,{TRT_MW.Callsign}]]\r\n\r\nYou just need to sign that form on the screen and we can proceed from there.\"",
+        "Icon" : "uixTxrSpot_EIEIOH.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": "Tags/CompanyTags"
-    },
-    "RequirementComparisons": [
-      {
-        "obj": "Funds",
-        "op": "GreaterThanOrEqual",
-        "val": 4000000,
-        "valueConstant": "4000000"
-      }
-    ]
-  },
-  "AdditionalRequirements": [
-    {
-      "Scope": "MechWarrior",
-      "RequirementTags": {
-        "items": [],
-        "tagSetSourceFile": ""
-      },
-      "ExclusionTags": {
-        "items": [
-          "pilot_NeuralImplants",
-          "pilot_EIEIOH"
-        ],
-        "tagSetSourceFile": ""
-      },
-      "RequirementComparisons": [
-        {
-          "obj": "Injuries",
-          "op": "Equal",
-          "val": 0,
-          "valueConstant": "0"
-        }
-      ]
-    },
-    {
-      "Scope": "StarSystem",
-      "RequirementTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "ExclusionTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "RequirementComparisons": []
-    }
-  ],
-  "AdditionalObjects": [
-    {
-      "Scope": "SecondaryMechWarrior",
-      "Requirements": {
-        "Scope": "SecondaryMechWarrior",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [
+                "Do_not_fire"
+            ],
+            "tagSetSourceFile" : ""
         },
-        "ExclusionTags": {
-          "items": [
-            "pilot_NeuralImplants",
-            "pilot_EIEIOH"
-          ],
-          "tagSetSourceFile": ""
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
         },
-        "RequirementComparisons": [
-          {
-            "obj": "Injuries",
-            "op": "Equal",
-            "val": 0,
-            "valueConstant": "0"
-          }
+        "RequirementComparisons" : [
+            {
+                "obj" : "Funds",
+                "op" : "GreaterThanOrEqual",
+                "val" : 4000000,
+                "valueConstant" : "4000000"
+            }
         ]
-      }
     },
-    {
-      "Scope": "TertiaryMechWarrior",
-      "Requirements": {
-        "Scope": "TertiaryMechWarrior",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
+    "AdditionalRequirements" : [
+        {
+            "Scope" : "MechWarrior",
+            "RequirementTags" : {
+                "items" : [],
+                "tagSetSourceFile" : ""
+            },
+            "ExclusionTags" : {
+                "items" : [
+                    "pilot_NeuralImplants",
+                    "pilot_EIEIOH"
+                ],
+                "tagSetSourceFile" : ""
+            },
+            "RequirementComparisons" : [
+                {
+                    "obj" : "Injuries",
+                    "op" : "Equal",
+                    "val" : 0,
+                    "valueConstant" : "0"
+                }
+            ]
         },
-        "ExclusionTags": {
-          "items": [
-            "pilot_NeuralImplants",
-            "pilot_EIEIOH"
-          ],
-          "tagSetSourceFile": ""
+        {
+            "Scope" : "StarSystem",
+            "RequirementTags" : {
+                "items" : [],
+                "tagSetSourceFile" : "Tags/PlanetTags"
+            },
+            "ExclusionTags" : {
+                "items" : [],
+                "tagSetSourceFile" : "Tags/PlanetTags"
+            },
+            "RequirementComparisons" : []
+        }
+    ],
+    "AdditionalObjects" : [
+        {
+            "Scope" : "SecondaryMechWarrior",
+            "Requirements" : {
+                "Scope" : "SecondaryMechWarrior",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : [
+                    {
+                        "obj" : "Injuries",
+                        "op" : "Equal",
+                        "val" : 0,
+                        "valueConstant" : "0"
+                    }
+                ]
+            }
         },
-        "RequirementComparisons": [
-          {
-            "obj": "Injuries",
-            "op": "Equal",
-            "val": 0,
-            "valueConstant": "0"
-          }
-        ]
-      }
+        {
+            "Scope" : "TertiaryMechWarrior",
+            "Requirements" : {
+                "Scope" : "TertiaryMechWarrior",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : [
+                    {
+                        "obj" : "Injuries",
+                        "op" : "Equal",
+                        "val" : 0,
+                        "valueConstant" : "0"
+                    }
+                ]
+            }
+        }
+    ],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Select {SCN_MW.Callsign}",
+                "Details" : "[Implant procedure may cost up to \u00A24,000,000]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "SecondaryMechWarrior",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "pilot_NeuralImplants",
+                            "pilot_EIEIOH"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "All Systems Go",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 60,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_NeuralImplants"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "28",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-1000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_1",
+                        "Name" : "Minor Complications",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 30,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_NeuralImplants"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "56",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-2000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_2",
+                        "Name" : "Near Death Experience",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 9,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_NeuralImplants"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "104",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-4000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_3",
+                        "Name" : "Sorry for your loss",
+                        "Details" : "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[SCN_MW,{SCN_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[SCN_MW,{SCN_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[SCN_MW,{SCN_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[SCN_MW,{SCN_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[SCN_MW,{SCN_MW.Callsign}]]'s kin.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_Kill",
+                                    "value" : "1",
+                                    "valueConstant" : null,
+                                    "additionalValues" : [
+                                        "killed during a medical bio-enhancement procedure"
+                                    ]
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-500000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Select {TRT_MW.Callsign}",
+                "Details" : "[Implant procedure may cost up to \u00A24,000,000]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "TertiaryMechWarrior",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "pilot_NeuralImplants",
+                            "pilot_EIEIOH"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "All Systems Go",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 60,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_NeuralImplants"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "28",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-1000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Minor Complications",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 30,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_NeuralImplants"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "56",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-2000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Near Death Experience",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 9,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_NeuralImplants"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_SetTimeout",
+                                    "value" : "104",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-4000000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Sorry for your loss",
+                        "Details" : "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[TRT_MW,{TRT_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[TRT_MW,{TRT_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[TRT_MW,{TRT_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[TRT_MW,{TRT_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[TRT_MW,{TRT_MW.Callsign}]]'s kin.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_Kill",
+                                    "value" : "1",
+                                    "valueConstant" : null,
+                                    "additionalValues" : [
+                                        "killed during a medical bio-enhancement procedure"
+                                    ]
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Funds",
+                                    "value" : "-500000",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_2",
+                "Name" : "None of these pilots are suitable",
+                "Details" : "Non-Participation Option",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_0",
+                        "Name" : "Abort! Abort!",
+                        "Details" : "You look over the names and records of the three volunteers.  You thumb back through their files numerous times, before letting out a long sigh and closed the datapad.\r\n\r\nYou hand the pad back to Darius, \"Thanks Darius, but I do not think any of those three pilots understand the risks involved here.  See if there are any other volunteers.  We do not need to rush into this blindly.\"\r\n\r\nDarius takes the datapad, \"As you wish, Boss.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : [
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_EIEIOH"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        },
+                        {
+                            "Scope" : "SecondaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_EIEIOH"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        },
+                        {
+                            "Scope" : "TertiaryMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_EIEIOH"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "NORMAL",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [],
+        "tagSetSourceFile" : "tags/EventTags"
     }
-  ],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "Select {TGT_MW.Callsign}",
-        "Details": "[Implant procedure may cost up to ¢4,000,000]",
-        "Icon": null
-      },
-      "RequirementList": [
-        {
-          "Scope": "Company",
-          "RequirementTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "ExclusionTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RequirementComparisons": [
-            {
-              "obj": "Funds",
-              "op": "GreaterThanOrEqual",
-              "val": 4000000,
-              "valueConstant": "4000000"
-            }
-          ]
-        }
-      ],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "All Systems Go",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[TGT_MW,{TGT_MW.Callsign}]]'s implants.  {TGT_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 60,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "28",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-1000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_1",
-            "Name": "Minor Complications",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[TGT_MW,{TGT_MW.Callsign}]]'s implants.  {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 30,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "56",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-2000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_2",
-            "Name": "Near Death Experience",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[TGT_MW,{TGT_MW.Callsign}]]'s implants.  {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 9,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "104",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-4000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_3",
-            "Name": "Sorry for your loss",
-            "Details": "You place a tick next to [[TGT_MW,{TGT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TGT_MW,{TGT_MW.Callsign}]] to the MedBay and confirm {TGT_MW.SUBJ} {TGT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TGT_MW,{TGT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[TGT_MW,{TGT_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[TGT_MW,{TGT_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[TGT_MW,{TGT_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[TGT_MW,{TGT_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[TGT_MW,{TGT_MW.Callsign}]]'s kin.\"",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_Kill",
-                  "value": "1",
-                  "valueConstant": null,
-                  "additionalValues": [
-                    "killed during a medical bio-enhancement procedure"
-                  ]
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-500000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "Select {SCN_MW.Callsign}",
-        "Details": "[Implant procedure may cost up to ¢4,000,000]",
-        "Icon": null
-      },
-      "RequirementList": [
-        {
-          "Scope": "Company",
-          "RequirementTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "ExclusionTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RequirementComparisons": [
-            {
-              "obj": "Funds",
-              "op": "GreaterThanOrEqual",
-              "val": 4000000,
-              "valueConstant": "4000000"
-            }
-          ]
-        }
-      ],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "All Systems Go",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 60,
-          "Results": [
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "28",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-1000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Minor Complications",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 30,
-          "Results": [
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "56",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-2000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Near Death Experience",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[SCN_MW,{SCN_MW.Callsign}]]'s implants.  {SCN_MW.Subj_C} {SCN_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 9,
-          "Results": [
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "104",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-4000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Sorry for your loss",
-            "Details": "You place a tick next to [[SCN_MW,{SCN_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[SCN_MW,{SCN_MW.Callsign}]] to the MedBay and confirm {SCN_MW.SUBJ} {SCN_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[SCN_MW,{SCN_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[SCN_MW,{SCN_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[SCN_MW,{SCN_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[SCN_MW,{SCN_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[SCN_MW,{SCN_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[SCN_MW,{SCN_MW.Callsign}]]'s kin.\"",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_Kill",
-                  "value": "1",
-                  "valueConstant": null,
-                  "additionalValues": [
-                    "killed during a medical bio-enhancement procedure"
-                  ]
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-500000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_2",
-        "Name": "Select {TRT_MW.Callsign}",
-        "Details": "[Implant procedure may cost up to ¢4,000,000]",
-        "Icon": null
-      },
-      "RequirementList": [
-        {
-          "Scope": "Company",
-          "RequirementTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "ExclusionTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RequirementComparisons": [
-            {
-              "obj": "Funds",
-              "op": "GreaterThanOrEqual",
-              "val": 4000000,
-              "valueConstant": "4000000"
-            }
-          ]
-        }
-      ],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_2_0",
-            "Name": "All Systems Go",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that everything seems to have gone fine with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} should be up and moving in the next couple of days and by the end of the month should have enough simpod training to go out into the field.\"\r\n\r\nYou smile, and raise your glass, \"Good news indeed!  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 60,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "28",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-1000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_2_1",
-            "Name": "Minor Complications",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were minor complications with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine and should be up and moving in the next couple of weeks and in a month or two should have enough simpod training to go out into the field.  The extra time healing and training will set us back double the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 30,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "56",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-2000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_2_2",
-            "Name": "Near Death Experience",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, I just wanted to tell you that there were serious complications with [[TRT_MW,{TRT_MW.Callsign}]]'s implants.  {TRT_MW.Subj_C} {TRT_MW.Gender?NonBinary:are|Default:is} fine but it will take extended rehab and simpod training before they are ready to get back into the field.  The extra time healing and training will set us back nearly 4x the initial costs.\"\r\n\r\nYou smile, and raise your glass, \"The cost is irrelevant, I am just glad they pulled through.  Keep me posted Darius.\"",
-            "Icon": null
-          },
-          "Weight": 9,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_NeuralImplants"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_SetTimeout",
-                  "value": "104",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-4000000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_2_3",
-            "Name": "Sorry for your loss",
-            "Details": "You place a tick next to [[TRT_MW,{TRT_MW.Callsign}]]'s name on the datapad and scribble your signature.  Handing the pad to Darius as you stand up, \"Ok, lets get [[TRT_MW,{TRT_MW.Callsign}]] to the MedBay and confirm {TRT_MW.SUBJ} {TRT_MW.Gender?NonBinary:still want|Default:still wants} to do this.\r\n\r\nDarius jumps up and heads off to the barracks as you proceed to the MedBay to speak to the <i>Argo's</i> surgeon.\r\n\r\nYou arrive to find the surgeon inspecting the Neural Implant matrix.  They look up when you arrive, \"Hello, Commander.  [[TRT_MW,{TRT_MW.Callsign}]] is being prepped for surgery as we speak.\"\r\n\r\nYou nod, \"You feel comfortable performing this procedure?\"\r\n\r\nThe surgeon nods back, \"I do Commander.  I have done similar types of surgeries in my past before I hired on with your company.\"\r\n\r\nYou turn to exit the room, \"Very well, let me know how the procedure goes.\"\r\n\r\n<color=#33bbee>::::::::::::::::::::::::::::::::::::::::::::::::::</color>\r\n\r\nHours later, Darius finds you in the lounge, \"Boss, umm, well, we lost  [[TRT_MW,{TRT_MW.Callsign}]].\r\n\r\nYou lean forward in your chair, head in hands, staring at the floor, \"How? What happened.\"\r\n\r\nDarius's shoulders slump, \"Apparently [[TRT_MW,{TRT_MW.Callsign}]] had a reaction to the implants.  The doc said...\"\r\n\r\nYou look up, anger on your face, \"What the hell?!  I thought they did a full medical workup on [[TRT_MW,{TRT_MW.Callsign}]]?\"\r\n\r\nDarius sits down, \"They did.  But [[TRT_MW,{TRT_MW.Callsign}]]'s condition was one that in 99% of these types of surgeries is never an issue.  This time, it was.\"\r\n\r\nYou fall back into the chair and down the whiskey in your glass, \"Drop off the reports to my office and I will get them signed off and filed and notify [[TRT_MW,{TRT_MW.Callsign}]]'s kin.\"",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_Kill",
-                  "value": "1",
-                  "valueConstant": null,
-                  "additionalValues": [
-                    "killed during a medical bio-enhancement procedure"
-                  ]
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Funds",
-                  "value": "-500000",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_3",
-        "Name": "None of these pilots are suitable",
-        "Details": "Non-Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_3_0",
-            "Name": "Abort! Abort!",
-            "Details": "You look over the names and records of the three volunteers.  You thumb back through their files numerous times, before letting out a long sigh and closed the datapad.\r\n\r\nYou hand the pad back to Darius, \"Thanks Darius, but I do not think any of those three pilots understand the risks involved here.  See if there are any other volunteers.  We do not need to rush into this blindly.\"\r\n\r\nDarius takes the datapad, \"As you wish, Boss.\"",
-            "Icon": null
-          },
-          "Weight": 100,
-          "Results": [
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_EIEIOH"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            },
-            {
-              "Scope": "SecondaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_EIEIOH"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            },
-            {
-              "Scope": "TertiaryMechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_EIEIOH"
-                ],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "NORMAL",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [],
-    "tagSetSourceFile": "tags/EventTags"
-  }
 }


### PR DESCRIPTION
Fixed both EI/DNI and Pain Shunt events for ignoring exclusion tags on MW by removing MW from the list.  Event now fires properly for Secondary and Tertiary MW.

Fixed Pain Shunt having SecondaryMech as a scope instead of SecondaryMechwarrior.

NOTE:  Due to the way ROI calls the event, the exclusions will NOT allow player to buy an appointment if there is only 1 eligible pilot.  Needs a minimum of 2 pilots to fire the event.