### PR TITLE
Rattlesnakes

### DIFF
--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_Rattlesnake_JR7-31.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_Rattlesnake_JR7-31.json
@@ -8,7 +8,7 @@
       "DropModifier": 0.98
     },
     "AssemblyVariant": {
-      "PrefabID": "jenner",
+      "PrefabID": "Rattlesnake",
       "Exclude": false,
       "Include": true
     },
@@ -20,7 +20,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Improved_Lifesupport",
+      "ComponentDefID": "Special_Rugged",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_Rattlesnake_JR7-31.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_Rattlesnake_JR7-31.json
@@ -5,7 +5,7 @@
       "RightLimit": "Upper"
     },
     "DropCostFactor": {
-      "DropModifier": 1.05
+      "DropModifier": 0.98
     },
     "AssemblyVariant": {
       "PrefabID": "jenner",
@@ -27,24 +27,24 @@
     }
   ],
   "Description": {
-    "Cost": 746997,
+    "Cost": 753637,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Rattlesnake",
-    "Id": "chassisdef_Rattlesnake_JR7-31P-HH",
-    "Name": "Rattlesnake",
-    "Details": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31P-HH was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built around a surviving Rattlesnake, the HH model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 ER Medium Lasers, 3 Medium Lasers and an ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>",
+    "Id": "chassisdef_Rattlesnake_JR7-31",
+    "Name": "Jenner",
+    "Details": "An offshoot of the Jenner, the 35 ton Rattlesnake JR7-31 was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, few Rattlesnakes were ever manufactured, with the design becoming extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium Lasers. Guardian ECM is included and the remaining tonnage devoted to additional armour.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
     "Icon": "uixTxrIcon_jenner"
   },
-  "VariantName": "JR7-31P-HH",
+  "VariantName": "JR7-31",
   "ChassisTags": {
     "items": [],
     "tagSetSourceFile": ""
   },
   "StockRole": "Striker",
-  "YangsThoughts": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31P-HH was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built around a surviving Rattlesnake, the HH model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 ER Medium Lasers, 3 Medium Lasers and an ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.",
+  "YangsThoughts": "An offshoot of the Jenner, the 35 ton Rattlesnake JR7-31 was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, few Rattlesnakes were ever manufactured, with the design becoming extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium Lasers. Guardian ECM is included and the remaining tonnage devoted to additional armour.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_jenner",
@@ -107,6 +107,10 @@
     {
       "Location": "LeftTorso",
       "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
         {
           "WeaponMountID": "Energy",
           "Omni": false

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_Rattlesnake_JR7-31P.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_Rattlesnake_JR7-31P.json
@@ -8,7 +8,7 @@
       "DropModifier": 0.98
     },
     "AssemblyVariant": {
-      "PrefabID": "jenner",
+      "PrefabID": "Rattlesnake",
       "Exclude": false,
       "Include": true
     },
@@ -20,7 +20,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Improved_Lifesupport",
+      "ComponentDefID": "Special_Rugged",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_Rattlesnake_JR7-31.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_Rattlesnake_JR7-31.json
@@ -12,11 +12,8 @@
       "unit_lance_vanguard",
       "unit_role_brawler",
       "unit_littlefriend",
-      "unit_solaris",
-      "unit_legendary",
-      "unit_hero",
-      "solaris7",
-      "locals",
+      "steiner",
+      "davion",
       "ai_heat_normal",
       "ai_dfa_low",
       "ai_melee_low",
@@ -31,20 +28,20 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_Rattlesnake_JR7-31P-HH",
+  "ChassisID": "chassisdef_Rattlesnake_JR7-31",
   "Description": {
-    "Cost": 149399,
+    "Cost": 150727,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Rattlesnake JR7-31P-HH",
-    "Id": "mechdef_Rattlesnake_JR7-31P-HH",
-    "Name": "Rattlesnake JR7-31P-HH",
-    "Details": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31P-HH was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built around a surviving Rattlesnake, the HH model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 ER Medium Lasers, 3 Medium Lasers and an ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>",
+    "UIName": "Rattlesnake JR7-31",
+    "Id": "mechdef_Rattlesnake_JR7-31",
+    "Name": "Rattlesnake JR7-31",
+    "Details": "An offshoot of the Jenner, the 35 ton Rattlesnake JR7-31 was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, few Rattlesnakes were ever manufactured, with the design becoming extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium Lasers. Guardian ECM is included and the remaining tonnage devoted to additional armour.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
     "Icon": "uixTxrIcon_jenner"
   },
-  "simGameMechPartCost": 149399,
+  "simGameMechPartCost": 150727,
   "Locations": [
     {
       "Location": "Head",
@@ -57,64 +54,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 50,
+      "CurrentArmor": 60,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 50,
+      "AssignedArmor": 60,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 50,
+      "CurrentArmor": 60,
       "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 50,
+      "AssignedArmor": 60,
       "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 75,
-      "CurrentRearArmor": 26,
+      "CurrentRearArmor": 30,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 75,
-      "AssignedRearArmor": 26,
+      "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 50,
+      "CurrentArmor": 60,
       "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 50,
+      "AssignedArmor": 60,
       "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 50,
+      "CurrentArmor": 60,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 50,
+      "AssignedArmor": 60,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -122,7 +119,7 @@
   "inventory": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+      "ComponentDefID": "emod_armorslots_standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -136,35 +133,14 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Cockpit_Generic_Small",
+      "ComponentDefID": "Gear_Cockpit_Generic_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_RCA_InstaTrac-XII",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Angel_ECM",
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Guardian_ECM",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -303,15 +279,15 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_MASC_CLAN",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
@@ -339,14 +315,14 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Laser_SmallLaserER_0-STOCK",
+      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_MediumLaserER_0-STOCK",
+      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_II_RSN-1.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_II_RSN-1.json
@@ -1,0 +1,262 @@
+{
+    "Custom": {
+        "ArmActuatorSupport": {
+            "LeftLimit": "Upper",
+            "RightLimit": "Upper"
+        },
+        "DropCostFactor": {
+            "DropModifier": 1.03
+        },
+        "AssemblyVariant": {
+            "PrefabID": "RattlesnakeII",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "CustomParts": {
+        "CustomParts": []
+    },
+    "FixedEquipment": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Special_Rugged",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "Description": {
+        "Cost": 1194451,
+        "Rarity": 2,
+        "Purchasable": true,
+        "Manufacturer": "",
+        "Model": "",
+        "UIName": "Rattlesnake",
+        "Id": "chassisdef_rattlesnake_II_RSN-1",
+        "Name": "Jenner",
+        "Details": "Based on specs from Operation Trapdoor, the 45 ton Rattlesnake II is a 10 ton upgrade of the original Rattlesnake Mech. Built by Clan Sea Fox for the AFFS during the waning years of the Dark Age, the RSN-1 is powered by a 315 rated Clan XL Engine. 8 tons of Clan Ferro Fibrous armour and a Guardian ECM suite protect the Mech while Clan MASC increases the Mechs ground speed. A pair of Clan ER Medium Lasers backed up a quartet of Medium Lasers form the bulk of the Mechs arsenal with an ER Small Laser rounding out the weapons.\n\n<b><color=#e62e00>Quirk: Improved Communications</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.03</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "VariantName": "RSN-1",
+    "ChassisTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+    },
+    "StockRole": "Striker",
+    "YangsThoughts": "Based on specs from Operation Trapdoor, the 45 ton Rattlesnake II is a 10 ton upgrade of the original Rattlesnake Mech. Built by Clan Sea Fox for the AFFS during the waning years of the Dark Age, the RSN-1 is powered by a 315 rated Clan XL Engine. 8 tons of Clan Ferro Fibrous armour and a Guardian ECM suite protect the Mech while Clan MASC increases the Mechs ground speed. A pair of Clan ER Medium Lasers backed up a quartet of Medium Lasers form the bulk of the Mechs arsenal with an ER Small Laser rounding out the weapons.",
+    "MovementCapDefID": "movedef_mediummech",
+    "PathingCapDefID": "pathingdef_medium",
+    "HardpointDataDefID": "hardpointdatadef_jenner",
+    "PrefabIdentifier": "chrPrfMech_jennerBase-001",
+    "PrefabBase": "jenner",
+    "Tonnage": 45,
+    "InitialTonnage": 4.5,
+    "weightClass": "MEDIUM",
+    "BattleValue": 4100000,
+    "Heatsinks": 0,
+    "TopSpeed": 120,
+    "TurnRadius": 90,
+    "MaxJumpjets": 20,
+    "Stability": 130,
+    "StabilityDefenses": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+    ],
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 5,
+    "PunchesWithLeftArm": true,
+    "MeleeDamage": 23,
+    "MeleeInstability": 12,
+    "MeleeToHitModifier": 0,
+    "DFADamage": 45,
+    "DFAToHitModifier": 0,
+    "DFASelfDamage": 45,
+    "DFAInstability": 23,
+    "MechPartMax": 0,
+    "MechPartCount": 0,
+    "EngageRangeModifier": 0,
+    "Locations": [
+        {
+            "Location": "Head",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 45,
+            "MaxRearArmor": -1,
+            "InternalStructure": 16
+        },
+        {
+            "Location": "LeftArm",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 70,
+            "MaxRearArmor": -1,
+            "InternalStructure": 35
+        },
+        {
+            "Location": "LeftTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "AntiPersonnel",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 110,
+            "MaxRearArmor": 55,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "CenterTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 15,
+            "MaxArmor": 140,
+            "MaxRearArmor": 70,
+            "InternalStructure": 70
+        },
+        {
+            "Location": "RightTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 110,
+            "MaxRearArmor": 55,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "RightArm",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 70,
+            "MaxRearArmor": -1,
+            "InternalStructure": 35
+        },
+        {
+            "Location": "LeftLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 110,
+            "MaxRearArmor": -1,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "RightLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 110,
+            "MaxRearArmor": -1,
+            "InternalStructure": 55
+        }
+    ],
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 14,
+            "z": 0
+        },
+        {
+            "x": 3.5,
+            "y": 13,
+            "z": 0
+        },
+        {
+            "x": -3.5,
+            "y": 13,
+            "z": 0
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 14,
+            "z": 0
+        },
+        {
+            "x": 3.5,
+            "y": 13,
+            "z": 0
+        },
+        {
+            "x": -3.5,
+            "y": 13,
+            "z": 0
+        },
+        {
+            "x": 3,
+            "y": 5,
+            "z": 0
+        },
+        {
+            "x": -3,
+            "y": 5,
+            "z": 0
+        }
+    ]
+}

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_II_RSN-2.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_II_RSN-2.json
@@ -1,0 +1,262 @@
+{
+    "Custom": {
+        "ArmActuatorSupport": {
+            "LeftLimit": "Upper",
+            "RightLimit": "Upper"
+        },
+        "DropCostFactor": {
+            "DropModifier": 1.03
+        },
+        "AssemblyVariant": {
+            "PrefabID": "RattlesnakeII",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "CustomParts": {
+        "CustomParts": []
+    },
+    "FixedEquipment": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Special_Rugged",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "Description": {
+        "Cost": 1194451,
+        "Rarity": 2,
+        "Purchasable": true,
+        "Manufacturer": "",
+        "Model": "",
+        "UIName": "Rattlesnake",
+        "Id": "chassisdef_rattlesnake_II_RSN-2",
+        "Name": "Jenner",
+        "Details": "Based on specs from Operation Trapdoor, the 45 ton Rattlesnake II is a 10 ton upgrade of the original Rattlesnake Mech. Built by Clan Sea Fox for the AFFS during the waning years of the Dark Age, the RSN-2 is powered by a 315 rated Clan XL Engine. 9 tons of Stealth Armor and a Guardian ECM suite protect the Mech. A sextet of of Medium Lasers form the bulk of the Mechs arsenal with a Small Laser rounding out the weapons.\n\n<b><color=#e62e00>Quirk: Improved Communications</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.03</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "VariantName": "RSN-2",
+    "ChassisTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+    },
+    "StockRole": "Striker",
+    "YangsThoughts": "Based on specs from Operation Trapdoor, the 45 ton Rattlesnake II is a 10 ton upgrade of the original Rattlesnake Mech. Built by Clan Sea Fox for the AFFS during the waning years of the Dark Age, the RSN-2 is powered by a 315 rated Clan XL Engine. 9 tons of Stealth Armor and a Guardian ECM suite protect the Mech. A sextet of of Medium Lasers form the bulk of the Mechs arsenal with a Small Laser rounding out the weapons.",
+    "MovementCapDefID": "movedef_mediummech",
+    "PathingCapDefID": "pathingdef_medium",
+    "HardpointDataDefID": "hardpointdatadef_jenner",
+    "PrefabIdentifier": "chrPrfMech_jennerBase-001",
+    "PrefabBase": "jenner",
+    "Tonnage": 45,
+    "InitialTonnage": 4.5,
+    "weightClass": "MEDIUM",
+    "BattleValue": 4100000,
+    "Heatsinks": 0,
+    "TopSpeed": 120,
+    "TurnRadius": 90,
+    "MaxJumpjets": 20,
+    "Stability": 130,
+    "StabilityDefenses": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+    ],
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 5,
+    "PunchesWithLeftArm": true,
+    "MeleeDamage": 23,
+    "MeleeInstability": 12,
+    "MeleeToHitModifier": 0,
+    "DFADamage": 45,
+    "DFAToHitModifier": 0,
+    "DFASelfDamage": 45,
+    "DFAInstability": 23,
+    "MechPartMax": 0,
+    "MechPartCount": 0,
+    "EngageRangeModifier": 0,
+    "Locations": [
+        {
+            "Location": "Head",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 45,
+            "MaxRearArmor": -1,
+            "InternalStructure": 16
+        },
+        {
+            "Location": "LeftArm",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 70,
+            "MaxRearArmor": -1,
+            "InternalStructure": 35
+        },
+        {
+            "Location": "LeftTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "AntiPersonnel",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 110,
+            "MaxRearArmor": 55,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "CenterTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Special",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "SpecialMelee",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 15,
+            "MaxArmor": 140,
+            "MaxRearArmor": 70,
+            "InternalStructure": 70
+        },
+        {
+            "Location": "RightTorso",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 110,
+            "MaxRearArmor": 55,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "RightArm",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 12,
+            "MaxArmor": 70,
+            "MaxRearArmor": -1,
+            "InternalStructure": 35
+        },
+        {
+            "Location": "LeftLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 110,
+            "MaxRearArmor": -1,
+            "InternalStructure": 55
+        },
+        {
+            "Location": "RightLeg",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 6,
+            "MaxArmor": 110,
+            "MaxRearArmor": -1,
+            "InternalStructure": 55
+        }
+    ],
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 14,
+            "z": 0
+        },
+        {
+            "x": 3.5,
+            "y": 13,
+            "z": 0
+        },
+        {
+            "x": -3.5,
+            "y": 13,
+            "z": 0
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 14,
+            "z": 0
+        },
+        {
+            "x": 3.5,
+            "y": 13,
+            "z": 0
+        },
+        {
+            "x": -3.5,
+            "y": 13,
+            "z": 0
+        },
+        {
+            "x": 3,
+            "y": 5,
+            "z": 0
+        },
+        {
+            "x": -3,
+            "y": 5,
+            "z": 0
+        }
+    ]
+}

--- a/Eras/DarkAge3131-/Base/mech/mechdef_rattlesnake_II_RSN-1.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_rattlesnake_II_RSN-1.json
@@ -1,0 +1,453 @@
+{
+    "MechTags": {
+        "items": [
+            "unit_jumpOK",
+            "unit_release",
+            "unit_mech",
+            "unit_medium",
+            "unit_lance_assassin",
+            "unit_lance_vanguard",
+            "unit_role_sniper",
+            "unit_bracket_med",
+            "unit_advanced",
+            "davion",
+            "locals",
+            "ai_heat_normal",
+            "ai_dfa_normal",
+            "ai_melee_normal",
+            "ai_flank_normal",
+            "ai_lance_normal",
+            "ai_lethalself_normal",
+            "ai_move_normal",
+            "ai_priority_normal",
+            "ai_reserve_normal",
+            "ai_shooting_low",
+            "ai_surrounded_normal"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "chassisdef_rattlesnake_II_RSN-1",
+    "Description": {
+        "Cost": 238890,
+        "Rarity": 2,
+        "Purchasable": false,
+        "Manufacturer": null,
+        "Model": null,
+        "UIName": "Rattlesnake II RSN-1",
+        "Id": "mechdef_rattlesnake_II_RSN-1",
+        "Name": "Rattlesnake II RSN-1",
+        "Details": "Based on specs from Operation Trapdoor, the 45 ton Rattlesnake II is a 10 ton upgrade of the original Rattlesnake Mech. Built by Clan Sea Fox for the AFFS during the waning years of the Dark Age, the RSN-1 is powered by a 315 rated Clan XL Engine. 8 tons of Clan Ferro Fibrous armour and a Guardian ECM suite protect the Mech while Clan MASC increases the Mechs ground speed. A pair of Clan ER Medium Lasers backed up a quartet of Medium Lasers form the bulk of the Mechs arsenal with an ER Small Laser rounding out the weapons.\n\n<b><color=#e62e00>Quirk: Improved Communications</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.03</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "simGameMechPartCost": 238890,
+    "Locations": [
+        {
+            "Location": "Head",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 16,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftArm",
+            "CurrentArmor": 70,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 70,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftTorso",
+            "CurrentArmor": 85,
+            "CurrentRearArmor": 30,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 85,
+            "AssignedRearArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "CenterTorso",
+            "CurrentArmor": 110,
+            "CurrentRearArmor": 34,
+            "CurrentInternalStructure": 70,
+            "AssignedArmor": 110,
+            "AssignedRearArmor": 34,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightTorso",
+            "CurrentArmor": 85,
+            "CurrentRearArmor": 30,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 85,
+            "AssignedRearArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightArm",
+            "CurrentArmor": 70,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 70,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftLeg",
+            "CurrentArmor": 110,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 110,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightLeg",
+            "CurrentArmor": 110,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 110,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_armorslots_clanferrosfibrous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_structureslots_endosteel",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Cockpit_Generic_Small",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_FCS_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Sensors_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Gyro_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_315",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_engineslots_cxl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_Heatsinks_2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_kit_cdhs",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_MASC_CLAN",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Eras/DarkAge3131-/Base/mech/mechdef_rattlesnake_II_RSN-2.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_rattlesnake_II_RSN-2.json
@@ -1,0 +1,495 @@
+{
+    "MechTags": {
+        "items": [
+            "unit_jumpOK",
+            "unit_release",
+            "unit_mech",
+            "unit_medium",
+            "unit_lance_assassin",
+            "unit_lance_vanguard",
+            "unit_role_sniper",
+            "unit_bracket_med",
+            "unit_advanced",
+            "unit_stealth",
+            "davion",
+            "locals",
+            "ai_heat_normal",
+            "ai_dfa_normal",
+            "ai_melee_normal",
+            "ai_flank_normal",
+            "ai_lance_normal",
+            "ai_lethalself_normal",
+            "ai_move_normal",
+            "ai_priority_normal",
+            "ai_reserve_normal",
+            "ai_shooting_low",
+            "ai_surrounded_normal"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "chassisdef_rattlesnake_II_RSN-2",
+    "Description": {
+        "Cost": 238890,
+        "Rarity": 2,
+        "Purchasable": false,
+        "Manufacturer": null,
+        "Model": null,
+        "UIName": "Rattlesnake II RSN-2",
+        "Id": "mechdef_rattlesnake_II_RSN-2",
+        "Name": "Rattlesnake II RSN-2",
+        "Details": "Based on specs from Operation Trapdoor, the 45 ton Rattlesnake II is a 10 ton upgrade of the original Rattlesnake Mech. Built by Clan Sea Fox for the AFFS during the waning years of the Dark Age, the RSN-2 is powered by a 315 rated Clan XL Engine. 9 tons of Stealth Armor and a Guardian ECM suite protect the Mech. A sextet of of Medium Lasers form the bulk of the Mechs arsenal with a Small Laser rounding out the weapons.\n\n<b><color=#e62e00>Quirk: Improved Communications</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.03</color></b>",
+        "Icon": "uixTxrIcon_jenner"
+    },
+    "simGameMechPartCost": 238890,
+    "Locations": [
+        {
+            "Location": "Head",
+            "CurrentArmor": 45,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 16,
+            "AssignedArmor": 45,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftArm",
+            "CurrentArmor": 70,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 70,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftTorso",
+            "CurrentArmor": 80,
+            "CurrentRearArmor": 25,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 80,
+            "AssignedRearArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "CenterTorso",
+            "CurrentArmor": 110,
+            "CurrentRearArmor": 35,
+            "CurrentInternalStructure": 70,
+            "AssignedArmor": 110,
+            "AssignedRearArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightTorso",
+            "CurrentArmor": 80,
+            "CurrentRearArmor": 25,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 80,
+            "AssignedRearArmor": 25,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightArm",
+            "CurrentArmor": 70,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 35,
+            "AssignedArmor": 70,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "LeftLeg",
+            "CurrentArmor": 110,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 110,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "RightLeg",
+            "CurrentArmor": 110,
+            "CurrentRearArmor": 0,
+            "CurrentInternalStructure": 55,
+            "AssignedArmor": 110,
+            "AssignedRearArmor": 0,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_armorslots_stealth",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Linked_stealth",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Linked_stealth",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Linked_stealth",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Linked_stealth",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "Linked_stealth",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "Linked_stealth",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_structureslots_endosteel",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Cockpit_Generic_Small",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_FCS_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Gear_Sensors_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Gyro_Generic_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_315",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_engineslots_cxl_center",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "emod_engineslots_size2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_Engine_Heatsinks_2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "emod_kit_cdhs",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_shoulder",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "emod_arm_part_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_hip",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_upper",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_lower",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightLeg",
+            "ComponentDefID": "emod_leg_foot",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Head",
+            "ComponentDefID": "Weapon_Laser_SmallLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 2,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightArm",
+            "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_Guardian_ECM",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "CenterTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+            "ComponentDefType": "JumpJet",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "LeftTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "RightTorso",
+            "ComponentDefID": "Gear_HeatSink_Generic_Double_Clan",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "IsFixed": false,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Eras/Republic3081-3130/Uniques/chassis/chassisdef_Rattlesnake_JR7-31P-HH.json
+++ b/Eras/Republic3081-3130/Uniques/chassis/chassisdef_Rattlesnake_JR7-31P-HH.json
@@ -8,7 +8,7 @@
       "DropModifier": 1.05
     },
     "AssemblyVariant": {
-      "PrefabID": "jenner",
+      "PrefabID": "Rattlesnake",
       "Exclude": false,
       "Include": true
     },
@@ -20,7 +20,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Special_Improved_Lifesupport",
+      "ComponentDefID": "Special_Rugged",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Uniques/chassis/chassisdef_Rattlesnake_JR7-31P-HH.json
+++ b/Eras/Republic3081-3130/Uniques/chassis/chassisdef_Rattlesnake_JR7-31P-HH.json
@@ -5,7 +5,7 @@
       "RightLimit": "Upper"
     },
     "DropCostFactor": {
-      "DropModifier": 0.98
+      "DropModifier": 1.05
     },
     "AssemblyVariant": {
       "PrefabID": "jenner",
@@ -27,24 +27,24 @@
     }
   ],
   "Description": {
-    "Cost": 753637,
+    "Cost": 746997,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
     "UIName": "Rattlesnake",
-    "Id": "chassisdef_Rattlesnake_JR7-31P",
+    "Id": "chassisdef_Rattlesnake_JR7-31P-HH",
     "Name": "Jenner",
-    "Details": "An offshoot of the Jenner, the 35 ton Rattlesnake JR7-31P was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, few Rattlesnakes were ever manufactured, with the design becoming extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium Lasers. A C3 Slave is included and the remaining tonnage devoted to additional armour.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
+    "Details": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31R was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built from a Rattlesnake JR7-37, the 37R model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 Clan ER Medium Lasers, 3 Medium Lasers and a Clan ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>",
     "Icon": "uixTxrIcon_jenner"
   },
-  "VariantName": "JR7-31P",
+  "VariantName": "JR7-31R",
   "ChassisTags": {
     "items": [],
     "tagSetSourceFile": ""
   },
   "StockRole": "Striker",
-  "YangsThoughts": "An offshoot of the Jenner, the 35 ton Rattlesnake JR7-31P was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, few Rattlesnakes were ever manufactured, with the design becoming extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium Lasers. A C3 Slave is included and the remaining tonnage devoted to additional armour.",
+  "YangsThoughts": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31R was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built from a Rattlesnake JR7-37, the 37R model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 Clan ER Medium Lasers, 3 Medium Lasers and a Clan ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
   "HardpointDataDefID": "hardpointdatadef_jenner",
@@ -83,7 +83,12 @@
   "Locations": [
     {
       "Location": "Head",
-      "Hardpoints": [],
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 6,
       "MaxArmor": 45,
@@ -107,10 +112,6 @@
     {
       "Location": "LeftTorso",
       "Hardpoints": [
-        {
-          "WeaponMountID": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMountID": "Energy",
           "Omni": false
@@ -159,10 +160,6 @@
     {
       "Location": "RightTorso",
       "Hardpoints": [
-        {
-          "WeaponMountID": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMountID": "Energy",
           "Omni": false

--- a/Eras/Republic3081-3130/Uniques/mech/mechdef_Rattlesnake_JR7-31P-HH.json
+++ b/Eras/Republic3081-3130/Uniques/mech/mechdef_Rattlesnake_JR7-31P-HH.json
@@ -11,10 +11,12 @@
       "unit_lance_assassin",
       "unit_lance_vanguard",
       "unit_role_brawler",
-      "unit_predator",
       "unit_littlefriend",
-      "steiner",
-      "davion",
+      "unit_solaris",
+      "unit_legendary",
+      "unit_hero",
+      "solaris7",
+      "locals",
       "ai_heat_normal",
       "ai_dfa_low",
       "ai_melee_low",
@@ -29,20 +31,20 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_Rattlesnake_JR7-31P",
+  "ChassisID": "chassisdef_Rattlesnake_JR7-31P-HH",
   "Description": {
-    "Cost": 150727,
+    "Cost": 149399,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Rattlesnake JR7-31P",
-    "Id": "mechdef_Rattlesnake_JR7-31P",
-    "Name": "Rattlesnake JR7-31P",
-    "Details": "An offshoot of the Jenner, the 35 ton Rattlesnake JR7-31P was developed as part of the joint MIIO-LIC Trapdoor Project during the early years of the Clan Invasion. Meant primarily as a disinformation campaign targeted at House Kurita, few Rattlesnakes were ever manufactured, with the design becoming extinct within 30 years. Built around a 245 rated XL Engine and 7 Jump Jets, the Rattlesnake mounts 7 Medium Lasers. A C3 Slave is included and the remaining tonnage devoted to additional armour.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.98</color></b>",
+    "UIName": "Rattlesnake JR7-31R",
+    "Id": "mechdef_Rattlesnake_JR7-31P-HH",
+    "Name": "Rattlesnake JR7-31R",
+    "Details": "A one of a kind Rattlesnake developed by Headhunter Stables of Solaris 7; the Rattlesnake JR7-31R was piloted by Gideon Wozniak during his arena fight with the wanted war criminal and ex ROM agent, Victor Reskov. Built from a Rattlesnake JR7-37, the 37R model upgrades the Mech with Clan made Ferro Fibrous armour and MASC. 2 Clan ER Medium Lasers, 3 Medium Lasers and a Clan ER Small Laser form the Mechs armament; with Angel ECM and a Clan made Targeting Computer enhancing the Mechs effectiveness.\n\n<b><color=#e62e00>Quirk: Improved Lifesupport</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>",
     "Icon": "uixTxrIcon_jenner"
   },
-  "simGameMechPartCost": 150727,
+  "simGameMechPartCost": 149399,
   "Locations": [
     {
       "Location": "Head",
@@ -55,64 +57,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 60,
+      "CurrentArmor": 50,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 60,
+      "AssignedArmor": 50,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 70,
-      "CurrentRearArmor": 30,
+      "CurrentArmor": 50,
+      "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 70,
-      "AssignedRearArmor": 30,
+      "AssignedArmor": 50,
+      "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 85,
-      "CurrentRearArmor": 30,
+      "CurrentArmor": 75,
+      "CurrentRearArmor": 26,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 85,
-      "AssignedRearArmor": 30,
+      "AssignedArmor": 75,
+      "AssignedRearArmor": 26,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 70,
-      "CurrentRearArmor": 30,
+      "CurrentArmor": 50,
+      "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 70,
-      "AssignedRearArmor": 30,
+      "AssignedArmor": 50,
+      "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 60,
+      "CurrentArmor": 50,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 60,
+      "AssignedArmor": 50,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 75,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 80,
+      "AssignedArmor": 75,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 75,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 80,
+      "AssignedArmor": 75,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -120,7 +122,7 @@
   "inventory": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "emod_armorslots_standard",
+      "ComponentDefID": "emod_armorslots_clanferrosfibrous",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -134,14 +136,35 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Cockpit_Generic_Standard",
+      "ComponentDefID": "Gear_Cockpit_Generic_Small",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_AdvancedTC_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_RCA_InstaTrac-XII",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_C3",
+      "ComponentDefID": "Gear_Angel_ECM",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -280,6 +303,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_MASC_CLAN",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
       "ComponentDefType": "Weapon",
@@ -288,14 +318,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
@@ -309,14 +332,14 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+      "ComponentDefID": "Weapon_Laser_MediumLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Weapon_Laser_SmallLaserER_CLAN",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"


### PR DESCRIPTION
Added the Rattlesnake II's from Shrapnel #9. Moved the unique Rattlesnake to the correct folder (Republic base - Republic uniques). Tweaks to bring Rattlesnakes in line with specs and added a new Rattlesnake. Changed prefabid so Rattlesnake now longer combines with the Jenner