### PR TITLE
Incorrect Scope for SCN and TRT options; Pain Shunt missing exclusions

### DIFF
--- a/Core/EIEIOH/events/event_co_CantFeelThis.json
+++ b/Core/EIEIOH/events/event_co_CantFeelThis.json
@@ -540,13 +540,16 @@
             },
             "RequirementList" : [
                 {
-                    "Scope" : "Company",
+                    "Scope" : "SecondaryMechWarrior",
                     "RequirementTags" : {
                         "items" : [],
                         "tagSetSourceFile" : ""
                     },
                     "ExclusionTags" : {
-                        "items" : [],
+                        "items" : [
+                            "pilot_painshunt",
+                            "pilot_cantfeelthis"
+                        ],
                         "tagSetSourceFile" : ""
                     },
                     "RequirementComparisons" : [
@@ -951,13 +954,16 @@
             },
             "RequirementList" : [
                 {
-                    "Scope" : "Company",
+                    "Scope" : "TertiaryMechWarrior",
                     "RequirementTags" : {
                         "items" : [],
                         "tagSetSourceFile" : ""
                     },
                     "ExclusionTags" : {
-                        "items" : [],
+                        "items" : [
+                            "pilot_painshunt",
+                            "pilot_cantfeelthis"
+                        ],
                         "tagSetSourceFile" : ""
                     },
                     "RequirementComparisons" : [

--- a/Core/EIEIOH/events/event_co_EIEIOH.json
+++ b/Core/EIEIOH/events/event_co_EIEIOH.json
@@ -483,7 +483,7 @@
             },
             "RequirementList" : [
                 {
-                    "Scope" : "Company",
+                    "Scope" : "SecondaryMechWarrior",
                     "RequirementTags" : {
                         "items" : [],
                         "tagSetSourceFile" : ""
@@ -840,7 +840,7 @@
             },
             "RequirementList" : [
                 {
-                    "Scope" : "Company",
+                    "Scope" : "TertiaryMechWarrior",
                     "RequirementTags" : {
                         "items" : [],
                         "tagSetSourceFile" : ""


### PR DESCRIPTION
Pilot checks incorrectly assigned to COMPANY instead of SecondaryMechWarrior and TertiaryMechWarrior.

Added missing exclusionTags for Pain Shunt event