### PR TITLE
Albatross prefab swap and Merc II/Coyotl size tweak

### DIFF
--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_albatross_ALB-4U.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_albatross_ALB-4U.json
@@ -40,16 +40,18 @@
   },
   "VariantName": "ALB-4U",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-1.15"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Juggernaut",
   "YangsThoughts": "The 4U variant of the Albatross is a basic upgrade of the design. The 'Mech replaces the Medium Lasers with a pair of ER Medium Lasers. The 'Mech also replaces the LB-X Autocannon/10 with a Light Gauss Rifle. The SRM-6 launcher has also been replaced with a Streak SRM-6launcher.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_hellbringer",
-  "PrefabIdentifier": "chrprfmech_hellbringerbase-001",
-  "PrefabBase": "hellbringer",
+  "HardpointDataDefID": "hardpointdatadef_lelialbatross",
+  "PrefabIdentifier": "chrprfmech_lelialbatrossbase-001",
+  "PrefabBase": "lelialbatross",
   "Tonnage": 95,
   "InitialTonnage": 9.5,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_albatross_ALB-3U.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_albatross_ALB-3U.json
@@ -40,16 +40,18 @@
   },
   "VariantName": "ALB-3U",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-1.15"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Juggernaut",
   "YangsThoughts": "The Albatross does not specialize in one role and is more of a workhorse design than anything else. The 'Mech carries an Irian Weapons Works V7 LRM-15 launcher which gives it long range and indirect fire support capabilities. This is backed up by an Oriente Model O LB-X Autocannon/10 and a Diverse Optics Sunbeam ER Large Laser which give the 'Mech a powerful long-range punch. The 'Mech carries a Tronel PPL-20 Large Pulse Laser which allows the 'Mech to engage an enemy at the edge of the medium to long-range envelope. Finally, for close combat, the 'Mech has an Irian Weapons Works 60mm SRM-6 and two Irian Weapons Works Super 6 Medium Lasers.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_hellbringer",
-  "PrefabIdentifier": "chrprfmech_hellbringerbase-001",
-  "PrefabBase": "hellbringer",
+  "HardpointDataDefID": "hardpointdatadef_lelialbatross",
+  "PrefabIdentifier": "chrprfmech_lelialbatrossbase-001",
+  "PrefabBase": "lelialbatross",
   "Tonnage": 95,
   "InitialTonnage": 9.5,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_coyotl_CYTL-A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_coyotl_CYTL-A.json
@@ -87,7 +87,7 @@
     "items": [
       "ClanMech",
       "OmniMech",
-      "mr-resize-0.7"
+      "mr-resize-0.75"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_coyotl_CYTL-B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_coyotl_CYTL-B.json
@@ -87,7 +87,7 @@
     "items": [
       "ClanMech",
       "OmniMech",
-      "mr-resize-0.7"
+      "mr-resize-0.75"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_coyotl_CYTL-Prime.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_coyotl_CYTL-Prime.json
@@ -87,7 +87,7 @@
     "items": [
       "ClanMech",
       "OmniMech",
-      "mr-resize-0.7"
+      "mr-resize-0.75"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_mercury_ii_MCY-100.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_mercury_ii_MCY-100.json
@@ -41,7 +41,7 @@
   "ChassisTags": {
     "items": [
       "SLDFMech",
-      "mr-resize-0.7"
+      "mr-resize-0.75"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_coyotl_CYTL-C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_coyotl_CYTL-C.json
@@ -87,7 +87,7 @@
     "items": [
       "ClanMech",
       "OmniMech",
-      "mr-resize-0.7"
+      "mr-resize-0.75"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_coyotl_CYTL-D.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_coyotl_CYTL-D.json
@@ -87,7 +87,7 @@
     "items": [
       "ClanMech",
       "OmniMech",
-      "mr-resize-0.7"
+      "mr-resize-0.75"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_albatross_ALB-3Ur.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_albatross_ALB-3Ur.json
@@ -40,16 +40,18 @@
   },
   "VariantName": "ALB-3Ur",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-1.15"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Juggernaut",
   "YangsThoughts": "The Albatross was designed by the Free Worlds League in 3053 with an eye toward a possible future conflict with the then advancing Clans. The 'Mech is built using a Hermes 380 XL Engine to minimize weight and maximize free tonnage for its weapon loadout. The Albatross also uses a variety of weapons in an attempt to make the 'Mech effective at any range. The 'Mech has average mobility with a maximum speed of 64.8 kph and makes use of double heat sinks for their greater heat dissipation capability.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_hellbringer",
-  "PrefabIdentifier": "chrprfmech_hellbringerbase-001",
-  "PrefabBase": "hellbringer",
+  "HardpointDataDefID": "hardpointdatadef_lelialbatross",
+  "PrefabIdentifier": "chrprfmech_lelialbatrossbase-001",
+  "PrefabBase": "lelialbatross",
   "Tonnage": 95,
   "InitialTonnage": 9.5,
   "weightClass": "ASSAULT",

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_albatross_ALB-5W.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_albatross_ALB-5W.json
@@ -41,7 +41,8 @@
   "VariantName": "ALB-5W",
   "ChassisTags": {
     "items": [
-      "HeroMech"
+      "HeroMech",
+      "mr-resize-1.15"
     ],
     "tagSetSourceFile": ""
   },
@@ -49,9 +50,9 @@
   "YangsThoughts": "Precentor Dantalion of the 49th Shadow Division equipped his personal 'Mech with some experimental equipment. A Small Cockpit allows a Laser AMS to be mounted in the head, while a Heavy-Duty Gyro and Light Engine make the 'Mech harder to kill. Protection was upgraded as well, using Heavy Ferro-Fibrous armor. Finally, a Guardian ECM Suiteprotects against enemy electronics. Offensively, Dantalion's custom Albatross uses an ER PPC with PPC Capacitor in the left arm, balanced by a Large VSP Laser in the right. For close combat, the left and right torso each get an ER Medium Laser and Medium Pulse Laser, and the right torso mounts a single ER Small Laser. In addition, the 'Mech is equipped with Triple Strength Myomer, making it a deadly foe in melee combat.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_hellbringer",
-  "PrefabIdentifier": "chrprfmech_hellbringerbase-001",
-  "PrefabBase": "hellbringer",
+  "HardpointDataDefID": "hardpointdatadef_lelialbatross",
+  "PrefabIdentifier": "chrprfmech_lelialbatrossbase-001",
+  "PrefabBase": "lelialbatross",
   "Tonnage": 95,
   "InitialTonnage": 9.5,
   "weightClass": "ASSAULT",


### PR DESCRIPTION
Swapped Mercury II and Coyotl to a .75 resize from a .7 on BD's recomendation. Swapped Albatross to the new prefab