### PR TITLE
Putting the hunch back in Hunchbacks

### DIFF
--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hunchback_HBK-4E.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hunchback_HBK-4E.json
@@ -35,7 +35,9 @@
   },
   "VariantName": "HBK-4E",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "skip_hardpoint"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Fire Support",
@@ -153,7 +155,12 @@
     },
     {
       "Location": "RightTorso",
-      "Hardpoints": [],
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 120,

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hunchback_HBK-5A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hunchback_HBK-5A.json
@@ -35,7 +35,9 @@
   },
   "VariantName": "HBK-5A",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "skip_hardpoint"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Arrow IV Boat",
@@ -144,7 +146,12 @@
     },
     {
       "Location": "RightTorso",
-      "Hardpoints": [],
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 12,
       "MaxArmor": 120,


### PR DESCRIPTION
Super sad 4E and 5A didn't have any hardpoints in the hunch due to the artillery weapons moving to arms.
added an appropriate hardpoint to the right torso of each
Also included the skip_hardpoint chassis tag