### PR TITLE
Fixes for Isorla Event Bondsman issues

### DIFF
--- a/Core/Isorla/events/event_co_Isorla_Medium.json
+++ b/Core/Isorla/events/event_co_Isorla_Medium.json
@@ -1,345 +1,240 @@
 {
-  "Description": {
-    "Id": "event_co_Isorla_Medium",
-    "Name": "Isorla Medium",
-    "Details": "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
-    "Icon": "uixTxrSpot_Isorla.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "items": [],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_co_Isorla_Medium",
+        "Name" : "Isorla Medium",
+        "Details" : "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": "Tags/CompanyTags"
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
     },
-    "RequirementComparisons": []
-  },
-  "AdditionalRequirements": [
-    {
-      "Scope": "StarSystem",
-      "RequirementTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "ExclusionTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "RequirementComparisons": []
-    }
-  ],
-  "AdditionalObjects": [],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
-        "Details": "Non Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
         {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "Reject Niles",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Commander Niles, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
+                "Details" : "Non Participation Option",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Reject MechWarrior",
+                        "Details" : "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         },
         {
-          "Description": {
-            "Id": "outcome_0_1",
-            "Name": "Reject Erin",
-            "Details": "You turn from Darius to look at your former opponent.  \"Point Commander Erin, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_2",
-            "Name": "Reject Lateekah",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Commander Lateekah, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_3",
-            "Name": "Reject Dante",
-            "Details": "You turn from Darius to look at your former opponent.  \"Mechwarrior Dante, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
+                "Details" : "Claim bondsman",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_N",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_E",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_L",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_D",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
-        "Details": "Claim bondsman",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "Bondsref",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot.",
-            "Icon": null
-          },
-          "Weight": 80,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Take Bondsman Niles",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Commander Niles, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Niles's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Niles is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 5,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Niles"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Niles"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Niles_Mid",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Take Bondsman Erin",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Point Commander Erin, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Point Commander Erin's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Point Commander Erin is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 5,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Erin"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Erin"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Erin_Mid",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Take Bondsman Lateekah",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Commander Lateekah, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Lateekah's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Lateekah is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 5,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Lateekah"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Lateekah"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Lateekah_Mid",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_4",
-            "Name": "Take Bondsman Dante",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly MechWarrior Dante, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Dante's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Dante is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 5,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Dante"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Dante"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Dante_Mid",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "UNSELECTABLE",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [
-      "BLACKLISTED"
     ],
-    "tagSetSourceFile": "tags/EventTags"
-  }
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
 }

--- a/Core/Isorla/events/event_co_Isorla_Medium_D.json
+++ b/Core/Isorla/events/event_co_Isorla_Medium_D.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Medium_D",
+        "Name" : "Isorla Medium: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondsman_Dante"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondsman_Dante"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Dante, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Dante's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Dante will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Dante"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Dante_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Dante, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Dante's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Dante will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Dante"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Dante_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_5",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Dante, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Dante's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Dante will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Dante"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Dante_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Dante, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Dante's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Dante will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Dante"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Dante_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Medium_E.json
+++ b/Core/Isorla/events/event_co_Isorla_Medium_E.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Medium_E",
+        "Name" : "Isorla Medium: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondswoman_Erin"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondswoman_Erin"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Point Commander Erin, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Point Commander Erin's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Point Commander Erin will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Erin"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Erin_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Point Commander Erin, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Point Commander Erin's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Point Commander Erin will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Erin"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Erin_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_5",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Point Commander Erin, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Point Commander Erin's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Point Commander Erin will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Erin"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Erin_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Point Commander Erin, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Point Commander Erin's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Point Commander Erin will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Erin"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Erin_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Medium_L.json
+++ b/Core/Isorla/events/event_co_Isorla_Medium_L.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Medium_L",
+        "Name" : "Isorla Medium: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondswoman_Lateekah"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondswoman_Lateekah"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Lateekah, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Lateekah's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Lateekah will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Lateekah"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Lateekah_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Lateekah, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Lateekah's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Lateekah will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Lateekah"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Lateekah_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_5",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Lateekah, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Lateekah's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Lateekah will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Lateekah"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Lateekah_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Lateekah, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Lateekah's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Lateekah will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Lateekah"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Lateekah_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Medium_N.json
+++ b/Core/Isorla/events/event_co_Isorla_Medium_N.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Medium_N",
+        "Name" : "Isorla Medium: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondsman_Niles"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondsman_Niles"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Niles, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Niles' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Niles will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Niles"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Niles_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Niles, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Niles' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Niles will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Niles"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Niles_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_5",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Niles, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Niles' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Niles will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Niles"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Niles_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Niles, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Niles' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Niles will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Niles"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Niles_Mid",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Mild.json
+++ b/Core/Isorla/events/event_co_Isorla_Mild.json
@@ -1,345 +1,240 @@
 {
-  "Description": {
-    "Id": "event_co_Isorla_Mild",
-    "Name": "Isorla Mild",
-    "Details": "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
-    "Icon": "uixTxrSpot_Isorla.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "items": [],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_co_Isorla_Mild",
+        "Name" : "Isorla Mild",
+        "Details" : "The Trial is over and you have proven yourself in the ways of the Clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": "Tags/CompanyTags"
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
     },
-    "RequirementComparisons": []
-  },
-  "AdditionalRequirements": [
-    {
-      "Scope": "StarSystem",
-      "RequirementTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "ExclusionTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "RequirementComparisons": []
-    }
-  ],
-  "AdditionalObjects": [],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
-        "Details": "Non Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
         {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "Reject Fergus",
-            "Details": "You turn from Darius to look at your former opponent.  \"Mechwarrior Fergus, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
+                "Details" : "Non Participation Option",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Reject MechWarrior",
+                        "Details" : "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         },
         {
-          "Description": {
-            "Id": "outcome_0_1",
-            "Name": "Reject Mychel",
-            "Details": "You turn from Darius to look at your former opponent.  \"Mechwarrior Mychel, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_2",
-            "Name": "Reject Synthia",
-            "Details": "You turn from Darius to look at your former opponent.  \"Mechwarrior Synthia, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_3",
-            "Name": "Reject Tyler",
-            "Details": "You turn from Darius to look at your former opponent.  \"Mechwarrior Tyler, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
+                "Details" : "Claim bondsman",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_F",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_T",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_S",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
-        "Details": "Claim bondsman",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "Bondsref",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot.",
-            "Icon": null
-          },
-          "Weight": 60,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Take Bondsman Fergus",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly MechWarrior Fergus, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Fergus's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Fergus is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 10,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Fergus"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Fergus"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Fergus_Low",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Take Bondsman Mychel",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly MechWarrior Mychel, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Mychel's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Mychel is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 10,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Mychel"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Mychel"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Mychel_Low",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Take Bondsman Synthia",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly MechWarrior Synthia, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Synthia's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Synthia is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 10,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Synthia"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Synthia"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Synthia_Low",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_4",
-            "Name": "Take Bondsman Tyler",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly MechWarrior Tyler, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Tyler's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Tyler is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 10,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_Tyler"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_Tyler"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_Tyler_Low",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "UNSELECTABLE",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [
-      "BLACKLISTED"
     ],
-    "tagSetSourceFile": "tags/EventTags"
-  }
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
 }

--- a/Core/Isorla/events/event_co_Isorla_Mild_F.json
+++ b/Core/Isorla/events/event_co_Isorla_Mild_F.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Mild_F",
+        "Name" : "Isorla Mild: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary.",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondsman_Fergus"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary.",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondsman_Fergus"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Fergus, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Fergus' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Fergus will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Fergus"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Fergus_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Fergus, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Fergus' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Fergus will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Fergus"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Fergus_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Fergus, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Fergus' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Fergus will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Fergus"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Fergus_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Fergus, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Fergus' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Fergus will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Fergus"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Fergus_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Mild_M.json
+++ b/Core/Isorla/events/event_co_Isorla_Mild_M.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Mild_M",
+        "Name" : "Isorla Mild: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondswoman_Mychel"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary.",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondswoman_Mychel"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Mychel, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Mychel's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Mychel will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Mychel"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Mychel_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Mychel, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Mychel's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Mychel will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Mychel"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Mychel_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Mychel, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Mychel's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Mychel will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Mychel"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Mychel_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Mychel, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Mychel's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Mychel will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Mychel"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Mychel_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Mild_S.json
+++ b/Core/Isorla/events/event_co_Isorla_Mild_S.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Mild_S",
+        "Name" : "Isorla Mild: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary.",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondswoman_Synthia"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary.",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondswoman_Synthia"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Synthia, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Synthia's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Synthia will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Synthia"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Synthia_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Synthia, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Synthia's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Synthia will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Synthia"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Synthia_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Synthia, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Synthia's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Synthia will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Synthia"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Synthia_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Synthia, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Synthia's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Synthia will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_Synthia"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Synthia_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Mild_T.json
+++ b/Core/Isorla/events/event_co_Isorla_Mild_T.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Mild_T",
+        "Name" : "Isorla Mild: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary.",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondsman_Tyler"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary.",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondsman_Tyler"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Tyler, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Tyler's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Tyler will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Tyler"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Tyler_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Tyler, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Tyler's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Tyler will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Tyler"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Tyler_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Tyler, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Tyler's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Tyler will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Tyler"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Tyler_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly MechWarrior Tyler, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to MechWarrior Tyler's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>MechWarrior Tyler will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_Tyler"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_Tyler_Low",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Spicy.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy.json
@@ -1,465 +1,314 @@
 {
-  "Description": {
-    "Id": "event_co_Isorla_Spicy",
-    "Name": "Isorla Spicy",
-    "Details": "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
-    "Icon": "uixTxrSpot_Isorla.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "items": [],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy",
+        "Name" : "Isorla Spicy",
+        "Details" : "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": "Tags/CompanyTags"
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
     },
-    "RequirementComparisons": []
-  },
-  "AdditionalRequirements": [
-    {
-      "Scope": "StarSystem",
-      "RequirementTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "ExclusionTags": {
-        "items": [],
-        "tagSetSourceFile": "Tags/PlanetTags"
-      },
-      "RequirementComparisons": []
-    }
-  ],
-  "AdditionalObjects": [],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
-        "Details": "Non Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
         {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "Reject MytchHoff",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Captain Mytch Hoff, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 23,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
+                "Details" : "Non Participation Option",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Reject MechWarrior",
+                        "Details" : "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         },
         {
-          "Description": {
-            "Id": "outcome_0_1",
-            "Name": "Reject HolliJones",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Commander Holli Jones, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 23,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_2",
-            "Name": "Reject PheonaOReilly",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Captain Pheona O'Reilly, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 23,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_3",
-            "Name": "Reject AlekYanev",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Commander Alek Yanev, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 23,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_4",
-            "Name": "Reject Lukas Furey",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Captain Lukas Furey, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 4,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_0_5",
-            "Name": "Reject Lumen Furey",
-            "Details": "You turn from Darius to look at your former opponent.  \"Star Captain Lumen Furey, you failed the Trial, and failed to impress me.  I have no need of one such as you within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 4,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
+                "Details" : "Claim bondsman",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_H",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_P",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_A",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LM",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_5",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LF",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
-        "Details": "Claim bondsman",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "Bondsref",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot.",
-            "Icon": null
-          },
-          "Weight": 90,
-          "Results": []
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Take Bondsman MytchHoff",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Captain Mytch Hoff, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Mytch Hoff's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Mytch Hoff is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 2,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_MytchHoff"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_MytchHoff"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_MytchHoff_BN",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Take Bondsman HolliJones",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Commander Holli Jones, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Holli Jones's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Holli Jones is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 2,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_HolliJones"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_HolliJones"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_HolliJones_BN",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Take Bondsman PheonaOReilly",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Captain Pheona O'Reilly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Pheona O'Reilly's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Pheona O'Reilly is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 2,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_PheonaOReilly"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_PheonaOReilly"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_PheonaOReilly_BN",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_4",
-            "Name": "Take Bondsman AlekYanev",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Commander Alek Yanev, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Alek Yanev's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Alek Yanev is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 2,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_AlekYanev"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_AlekYanev"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_AlekYanev_BN",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_5",
-            "Name": "Take Bondsman Lukas Furey",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Captain Lukas Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lukas Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lukas Furey is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_LukasFurey"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_LukasFurey"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_LukasFurey_EI",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_6",
-            "Name": "Take Bondsman Lumen Furey",
-            "Details": "You look your former opponent in the eyes, \"You fought valiantly Star Captain Lumen Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lumen Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lumen Furey is in the barracks.</color></b>",
-            "Icon": null
-          },
-          "Weight": 1,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": {
-                "Scope": "Company",
-                "RequirementTags": {
-                  "items": [],
-                  "tagSetSourceFile": ""
-                },
-                "ExclusionTags": {
-                  "items": [
-                    "Bondsman_LumenFurey"
-                  ],
-                  "tagSetSourceFile": ""
-                },
-                "RequirementComparisons": []
-              },
-              "AddedTags": {
-                "items": [
-                  "Bondsman_LumenFurey"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": [
-                {
-                  "Type": "MechWarrior_AddRoster",
-                  "value": "pilot_LumenFurey_EI",
-                  "valueConstant": null,
-                  "additionalValues": null
-                }
-              ],
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "UNSELECTABLE",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [
-      "BLACKLISTED"
     ],
-    "tagSetSourceFile": "tags/EventTags"
-  }
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
 }

--- a/Core/Isorla/events/event_co_Isorla_Spicy_A.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy_A.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy_A",
+        "Name" : "Isorla Spicy: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondsman_AlekYanev"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondsman_AlekYanev"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Alek Yanev, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Alek Yanev's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Alek Yanev will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_AlekYanev"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_AlekYanev_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Alek Yanev, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Alek Yanev's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Alek Yanev will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_AlekYanev"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_AlekYanev_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Alek Yanev, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Alek Yanev's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Alek Yanev will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_AlekYanev"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_AlekYanev_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Alek Yanev, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Alek Yanev's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Alek Yanev will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_AlekYanev"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_AlekYanev_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Spicy_H.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy_H.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy_H",
+        "Name" : "Isorla Spicy: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondswoman_HolliJones"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondswoman_HolliJones"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Holli Jones, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Holli Jones' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Holli Jones will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_HolliJones"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_HolliJones_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Holli Jones, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Holli Jones' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Holli Jones will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_HolliJones"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_HolliJones_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Holli Jones, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Holli Jones' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Holli Jones will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_HolliJones"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_HolliJones_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Commander Holli Jones, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Commander Holli Jones' right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Commander Holli Jones will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_HolliJones"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_HolliJones_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Spicy_LF.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy_LF.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy_LF",
+        "Name" : "Isorla Spicy: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondswoman_LumenFurey"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondswoman_LumenFurey"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lumen Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lumen Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lumen Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_LumenFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LumenFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lumen Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lumen Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lumen Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_LumenFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LumenFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lumen Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lumen Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lumen Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_LumenFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LumenFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lumen Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lumen Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lumen Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_LumenFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LumenFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Spicy_LM.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy_LM.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy_LM",
+        "Name" : "Isorla Spicy: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondsman_LukasFurey"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondsman_LukasFurey"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lukas Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lukas Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lukas Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_LukasFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LukasFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lukas Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lukas Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lukas Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_LukasFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LukasFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lukas Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lukas Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lukas Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_LukasFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LukasFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 24,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Lukas Furey, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Lukas Furey's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Lukas Furey will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_LukasFurey"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_LukasFurey_EI",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Spicy_M.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy_M.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy_M",
+        "Name" : "Isorla Spicy: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondsman_MytchHoff"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondsman_MytchHoff"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Mytch Hoff, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Mytch Hoff's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Mytch Hoff will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_MytchHoff"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_MytchHoff_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Mytch Hoff, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Mytch Hoff's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Mytch Hoff will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_MytchHoff"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_MytchHoff_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Mytch Hoff, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Mytch Hoff's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Mytch Hoff will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_MytchHoff"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_MytchHoff_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Mytch Hoff, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Mytch Hoff's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Mytch Hoff will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondsman_MytchHoff"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_MytchHoff_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/Isorla/events/event_co_Isorla_Spicy_P.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy_P.json
@@ -1,0 +1,310 @@
+{
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy_P",
+        "Name" : "Isorla Spicy: the Result",
+        "Details" : "Darius approaches, \"Commander, if you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]], we will need to head over to the Infirmary.\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
+    },
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "Bondswoman_PheonaOReilly"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Pilot succumbed to Injuries",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"I regret to inform you, but that pilot succumbed to their injuries,\"\r\n\r\nYou address the nurse, \"Any chance I can pay my respects to the deceased?\"\r\n\r\nThe nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Behind a windowed wall is the body of your opponent, covered by a sheet.  You stare through the window at the body of your former opponent,  \"We mourn your passing, MechWarrior.  You fought bravely.\"\r\n\r\nYou and Darius then exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Head over to the Infirmary",
+                "Details" : "Investigate",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [
+                            "Bondswoman_PheonaOReilly"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Pheona O'Reilly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Pheona O'Reilly's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Pheona O'Reilly will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_PheonaOReilly"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_PheonaOReilly_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Pheona O'Reilly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Pheona O'Reilly's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Pheona O'Reilly will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_PheonaOReilly"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_PheonaOReilly_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Pheona O'Reilly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Pheona O'Reilly's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Pheona O'Reilly will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_PheonaOReilly"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_PheonaOReilly_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Bondsref",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nAs you reach forward to place the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] on the MechWarrior's wrist, they pull their arm behind them, \"My honour will not allow me to become a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]].  I claim my right of refusal.\"\r\n\r\nYou nod assent, \"As you wish, MechWarrior.\"\r\n\r\nYou feel saddened at the loss of a potentially great pilot as you and Darius exit the building to head back to the <i>Argo</i>",
+                        "Icon" : null
+                    },
+                    "Weight" : 23,
+                    "Results" : []
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You and Darius head over to the Infirmary, where you are stopped by a nurse outside the entrance, \"May I assist you?,\" the nurse asks.\r\n\r\nDarius steps forward, \"My Commander was one of the combatants in that duel, and wished to speak with the opponent he faced.\"\r\n\r\nThe nurse types in some information into the computer, \"Yes, they are in exam room C.\"  The nurse points at the palm scanner, \"Place your hand there to sign in, then go through the doors to the 3rd room on the left.\"\r\n\r\nYou follow the directions given and arrive with Darius at the room.  Seated on the exam table is the MechWarrior you fought with freshly applied bandages covering parts of their body.\r\n\r\nYou look your former opponent in the eyes, \"You fought valiantly Star Captain Pheona O'Reilly, and I now claim you as my [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].  You will wear this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] until you have sufficently demonstrated all three virtues: combat talent, integrity and loyalty.\"\r\n\r\nYou reach foward and attach the [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]] to Star Captain Pheona O'Reilly's right wrist, \"With this [[DM.BaseDescriptionDefs[LoreBondcord],bondcord]], I claim you as [[DM.BaseDescriptionDefs[LoreBondswoman],bondswoman]].\"\r\n\r\n<b><color=#ff9900>Star Captain Pheona O'Reilly will meet you in the barracks.</color></b>",
+                        "Icon" : null
+                    },
+                    "Weight" : 2,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "Bondswoman_PheonaOReilly"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : [
+                                {
+                                    "Type" : "MechWarrior_AddRoster",
+                                    "value" : "pilot_PheonaOReilly_BN",
+                                    "valueConstant" : null,
+                                    "additionalValues" : null
+                                }
+                            ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}


### PR DESCRIPTION
This "should" fix the issues with missing bondsmen, duplicate bondsmen messages and hopefully non-firing events after a valid duel contract.
Events will now properly check tags for bondsman and if present allow a generic pilot unavailable event to trigger.