### PR TITLE
Update itemCollection_soldier_ammo_LRM.csv

### DIFF
--- a/Core/RogueBackgrounds/itemcollection/itemCollection_soldier_ammo_LRM.csv
+++ b/Core/RogueBackgrounds/itemcollection/itemCollection_soldier_ammo_LRM.csv
@@ -1,5 +1,4 @@
 itemCollection_soldier_ammo_LRM,,,
-Ammo_AmmunitionBox_ArtemisIV_LRM,AmmunitionBox,1,6
 Ammo_AmmunitionBox_Chaff_LRM,AmmunitionBox,1,7
 Ammo_AmmunitionBox_Clearance_LRM,AmmunitionBox,1,8
 Ammo_AmmunitionBox_Clearance_LRM_half,AmmunitionBox,1,8


### PR DESCRIPTION
 Removing artemis ammo from the soldier background's LRM ammo list.  
 Reason: the soldier background doesn't provide the FCS required to use it