### PR TITLE
Fix PRAC20 refire trait

### DIFF
--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_Rotary_Autocannon_20_JuryRigged.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_Rotary_Autocannon_20_JuryRigged.json
@@ -12,7 +12,7 @@
       "Bonuses": [
         "Rotary",
         "WpnRecoil: 3",
-        "WpnRecoilShot: -1",
+        "WpnRecoilShot: +1",
         "VariableDmg: 8",
         "BracetoFirePerShot: 15%, 3, 12.5",
         "MisfireChancePerShot: 5%",


### PR DESCRIPTION
actual behavior in modes is definitely +1 per shot, just trait was wrong (as you would expect)