### PR TITLE
A few fixes

### DIFF
--- a/DLC/RogueFlashPointModule/flashpoints/fp_SiegeAttackPanzer.json
+++ b/DLC/RogueFlashPointModule/flashpoints/fp_SiegeAttackPanzer.json
@@ -52,6 +52,6 @@
   "RewardCollectionID": "RT_FP_ThreeRogueItemsG",
   "UnitDropTonnageHint": "None",
   "LanceDropTonnageHint": "None",
-  "FlashpointShortDescription": "A Potential Contract has arrived on our com center station, They are looking for a Group of mercs to siege a dropship platform, cuttiong off reinforcements.",
+  "FlashpointShortDescription": "A Potential Contract has arrived on our com center station, They are looking for a Group of mercs to siege a dropship platform, cutting off reinforcements.",
   "FlashpointDescriberCastDefId": "castDef_DariusDefault"
 }

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK_HOVER.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK_HOVER.json
@@ -112,7 +112,7 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "vehiclechassisdef_COOLANT_TRUCK",
+  "ChassisID": "vehiclechassisdef_COOLANT_TRUCK_HOVER",
   "Description": {
     "Cost": 588320,
     "Rarity": 0,

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_COOLANT_TRUCK_HOVER.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_COOLANT_TRUCK_HOVER.json
@@ -21,7 +21,7 @@
     "Rarity": 0,
     "Purchasable": false,
     "UIName": "Coolant Truck 135-KH",
-    "Id": "vehiclechassisdef_COOLANT_HOVER",
+    "Id": "vehiclechassisdef_COOLANT_TRUCK_HOVER",
     "Name": "Coolant Truck",
     "Details": "Originally developed in 2588 during the Reunification War, the now ubiqitous Coolant Truck doubled the effective range of SLDF BattleMechs on water-poor Periphery worlds, serving a similar purpose with the depleted heat sink technology of the Succession Wars era. Coolant trucks station themselves close to the battlefield, where they can be hooked up to overheated 'Mechs for the purpose of flushing away the excess heat with super-cold liquid nitrogen and/or liquid oxygen.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 8/12 Hex: 240/360 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       120     15\n<b>Left</b>          140     15\n<b>Right</b>        140     15\n<b>Rear</b>         100     15\n<b>Turret</b>      60     15\n\n<b>Total</b>      560     75</color>\n\n<color=#ff0000>Quirk: Rugged</color>",
     "Icon": "CoolantTruck"

--- a/Optionals/RISCtech/Base/Items/Upgrade/Gear_armorslots_RISC.json
+++ b/Optionals/RISCtech/Base/Items/Upgrade/Gear_armorslots_RISC.json
@@ -133,7 +133,7 @@
   "PrefabIdentifier": "",
   "BattleValue": 0,
   "InventorySize": 3,
-  "Tonnage": 1,
+  "Tonnage": 7,
   "AllowedLocations": "CenterTorso",
   "DisallowedLocations": "All",
   "CriticalComponent": false,

--- a/Optionals/RISCtech/Base/Items/Upgrade/Linked_RISC_Hardened.json
+++ b/Optionals/RISCtech/Base/Items/Upgrade/Linked_RISC_Hardened.json
@@ -94,7 +94,7 @@
   "PrefabIdentifier": "",
   "BattleValue": 0,
   "InventorySize": 2,
-  "Tonnage": 1,
+  "Tonnage": 0,
   "AllowedLocations": "All",
   "DisallowedLocations": "All",
   "CriticalComponent": false,


### PR DESCRIPTION
Fixed an issue with the new Hover coolant truck.

Per Rogueticket#7458: Made change to the tonnage on Hardened Ferro - moved all tonnage to main item and removed weight from the linked items so there are no longer any hidden costs and the tooltip shows correct weight in mechbay.

Fixed typo in flashpoint description fp_SiegeAttackPanzer