### PR TITLE
Large MMS FNF accuracy

### DIFF
--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Weapons.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Weapons.json
@@ -544,7 +544,7 @@
       "Bonus": "MMSFireAndForget",
       "Short": "FNF",
       "Long": "Fire and Forget",
-      "Full": "Fire and Forget Mode fires {0} More Missiles with {1} extra Heat and reduced Accuracy."
+      "Full": "Fire and Forget Mode fires {0} More Missiles with {1} extra Heat and {2} Accuracy."
     },
     {
       "Bonus": "MRM",

--- a/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.csv
+++ b/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.csv
@@ -10415,7 +10415,7 @@ Once the camera is off, Sumire says, «There's no way they push you on this. Too
 "MechEngineer.MMSDamage.Full";"{0} Micro Missile damage";"Урон от микро ракет: {0}";;"#000000";"#FFFFFF"
 "MechEngineer.MMSDamage.Long";"{0} MMS Damage";"{0} MMS урон";;"#000000";"#FFFFFF"
 "MechEngineer.MMSDamage.Short";"{0} MMS Dmg";"{0} MMS урон";;"#000000";"#FFFFFF"
-"MechEngineer.MMSFireAndForget.Full";"Fire and Forget Mode fires {0} More Missiles with {1} extra Heat.";"Режим «Запустил и забыл» выстреливает на {0} больше ракет с доп. нагревом {1}";;"#000000";"#FFFFFF"
+"MechEngineer.MMSFireAndForget.Full";"Fire and Forget Mode fires {0} More Missiles with {1} extra Heat and {2} Accuracy.";"Режим «Запустил и забыл» выстреливает на {0} больше ракет с доп. нагревом {1} и {2} точности";;"#000000";"#FFFFFF"
 "MechEngineer.MMSFireAndForget.Long";"Fire and Forget";"Запустил и забыл";;"#000000";"#FFFFFF"
 "MechEngineer.MMSFireAndForget.Short";"FNF";"Зиз";;"#000000";"#FFFFFF"
 "MechEngineer.MMSTargetLock.Full";"Target Lock Mode has {0} Evasion Ignore and {1} Accuracy. Fires as Streak.";"Режим «Захват цели» игнорирует {0} укл. и даёт {1} точности. Стреляет как Streak.";;"#000000";"#FFFFFF"

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_10.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_10.json
@@ -13,7 +13,7 @@
         "MicroMissile",
         "MMSTargetLock: +1, +1",
         "Streak",
-        "MMSFireAndForget: 10, 7"
+        "MMSFireAndForget: 10, 7, -1"
       ]
     },
     "Flags": {

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_20.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_20.json
@@ -13,7 +13,7 @@
         "MicroMissile",
         "MMSTargetLock: +1, +1",
         "Streak",
-        "MMSFireAndForget: 20, 14"
+        "MMSFireAndForget: 20, 14, -1"
       ]
     },
     "Flags": {

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_30.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_30.json
@@ -13,7 +13,7 @@
         "MicroMissile",
         "MMSTargetLock: +1, +1",
         "Streak",
-        "MMSFireAndForget: 30, 21"
+        "MMSFireAndForget: 30, 21, -2"
       ]
     },
     "Flags": {
@@ -109,7 +109,7 @@
       "HitGenerator": "Individual",
       "HeatGenerated": 21,
       "ShotsWhenFired": 30,
-      "AccuracyModifier": 2,
+      "AccuracyModifier": 3,
       "EvasivePipsIgnored": -1
     }
   ],

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_40.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MicroMissileSystem_40.json
@@ -13,7 +13,7 @@
         "MicroMissile",
         "MMSTargetLock: +1, +1",
         "Streak",
-        "MMSFireAndForget: 40, 28"
+        "MMSFireAndForget: 40, 28, -2"
       ]
     },
     "Flags": {
@@ -109,7 +109,7 @@
       "HitGenerator": "Individual",
       "HeatGenerated": 28,
       "ShotsWhenFired": 40,
-      "AccuracyModifier": 2,
+      "AccuracyModifier": 3,
       "EvasivePipsIgnored": -1
     }
   ],


### PR DESCRIPTION
Increase FNF accuracy penalty on large MMS systems and add the accuracy penalty to the traits.

All MMS systems turned out to already have -1 accuracy; increased this to -2 for MMS30/40 per LA's direction. Probably more noticeable will be that this value is actually in the traits now.