### PR TITLE
CC2.1 Mech Fixes

### DIFF
--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5A.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5A.json
@@ -82,7 +82,7 @@
     "UIName": "Hunchback HBK-5A",
     "Id": "mechdef_hunchback_HBK-5A",
     "Name": "Hunchback HBK-5A",
-    "Details": "Developed during the Clan Invasion, the 5A takes advantage of the newly reintroduced Arrow IV and an Artemis IV FCS. Intended to operate in support of a lance or as part of a dedicated battery, the 5A carries a mix of homing missiles and utility ammo; enabling it to bombard targets that have been tagged by supporting forces or deploying FASCAM and other speciality ammo as and when needed. Guardian ECM confuses and blinds enemy sensors, vastly reducing the chances of accurate counter battery fire, whilst the use of CASE protects against catastrophic ammunition explosions. Sold to any interested buyer as part of Kali Yama’s contribution to the war effort, the design has been seen all across the Inner Sphere and is increasingly found in the Periphery, where reliable and cheap Artillery assets are in high demand. \n\n<b><color=#e62e00>Quirk: Battle Fists</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.04</color></b>",
+    "Details": "Developed during the Clan Invasion, the 5A takes advantage of the newly reintroduced Arrow IV. Intended to operate in support of a lance or as part of a dedicated battery, the 5A carries a mix of homing missiles and utility ammo; enabling it to bombard targets that have been tagged by supporting forces or deploying FASCAM and other speciality ammo as and when needed. Guardian ECM confuses and blinds enemy sensors, vastly reducing the chances of accurate counter battery fire, whilst the use of CASE protects against catastrophic ammunition explosions. Sold to any interested buyer as part of Kali Yama’s contribution to the war effort, the design has been seen all across the Inner Sphere and is increasingly found in the Periphery, where reliable and cheap Artillery assets are in high demand. \n\n<b><color=#e62e00>Quirk: Battle Fists</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.04</color></b>",
     "Icon": "uixTxrIcon_hunchback"
   },
   "simGameMechPartCost": 291010,
@@ -175,7 +175,7 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
+      "ComponentDefID": "Gear_FCS_Improved",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -264,6 +264,14 @@
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_ArrowIV_Guided",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_ArrowIV_Inferno",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5J.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5J.json
@@ -97,7 +97,7 @@
     "UIName": "Hunchback HBK-5J",
     "Id": "mechdef_hunchback_HBK-5J",
     "Name": "Hunchback HBK-5J",
-    "Details": "A field upgrade kit for the popular 4J model, the 5J is a set of simple upgrades enhancing the effectiveness of the aging design. The addition of double heatsinks enables the removal of 3 heat sinks, whilst still running cooler than the original design. This free weight is used to upgrade the LRM's to the Artemis IV Fire Control system and to replace a pair of medium lasers with pulse variants. The small laser is removed to allow for the addition of CASE , preventing lethal ammo explosions.\n\n<b><color=#e62e00>Quirk: Battle Fists</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.04</color></b>",
+    "Details": "A field upgrade kit for the popular 4J model, the 5J is a set of simple upgrades enhancing the effectiveness of the aging design. The addition of double heatsinks enables the removal of 2 heat sinks, whilst still running cooler than the original design. This free weight is used to upgrade the LRM's to fire Artemis guided missiles. The small laser is removed to allow for the addition of CASE, preventing lethal ammo explosions.\n\n<b><color=#e62e00>Quirk: Battle Fists</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.04</color></b>",
     "Icon": "uixTxrIcon_hunchback"
   },
   "simGameMechPartCost": 295764,
@@ -178,14 +178,6 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_200",
       "ComponentDefType": "HeatSink",
@@ -211,7 +203,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_Laser_Pulse_Medium",
+      "ComponentDefID": "Weapon_Laser_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "IsFixed": false,
@@ -230,6 +222,22 @@
       "ComponentDefID": "Weapon_LRM_10",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 3,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
       "IsFixed": false,
       "DamageLevel": "Functional"
     },
@@ -259,7 +267,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Weapon_Laser_Pulse_Medium",
+      "ComponentDefID": "Weapon_Laser_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "IsFixed": false,
@@ -285,6 +293,14 @@
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "IsFixed": false,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5S.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5S.json
@@ -55,7 +55,7 @@
     "UIName": "Hunchback HBK-5S",
     "Id": "mechdef_hunchback_HBK-5S",
     "Name": "Hunchback HBK-5S",
-    "Details": "Originally a refit line converted to full production, the -5S is a complete overhaul of the Hunchback design developed by Norse-Storm BattleMechs in 3058. The structure has been modified to use Endo Steel construction techniques, the engine has been upgraded to a Light Fusion Engine, and four Jump Jets were added for increased mobility. The 'Mech carries, as its primary weapon, an LB-X Autocannon/20 with CASE-protected ammunition supported by two medium pulse lasers and a single small laser.\n\n<b><color=#e62e00>Quirk: Battle Fists</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.04</color></b>",
+    "Details": "Originally a refit line converted to full production, the -5S is a complete overhaul of the Hunchback design developed by Norse-Storm BattleMechs in 3058. The structure has been modified to use Endo Steel construction techniques, the engine has been upgraded to a Light Fusion Engine, and four Jump Jets were added for increased mobility. The 'Mech carries, as its primary weapon, an LB-X Autocannon/20 with CASE-protected ammunition, supported by two medium pulse lasers and a single small laser.\n\n<b><color=#e62e00>Quirk: Battle Fists</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.04</color></b>",
     "Icon": "uixTxrIcon_hunchback"
   },
   "simGameMechPartCost": 291010,
@@ -157,14 +157,6 @@
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Ballistic",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Recoil",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -284,7 +276,7 @@
     },
     {
       "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Gear_JumpJet_Standard_Standard",
+      "ComponentDefID": "Gear_JumpJet_Improved_Standard",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -292,7 +284,7 @@
     },
     {
       "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Gear_JumpJet_Standard_Standard",
+      "ComponentDefID": "Gear_JumpJet_Improved_Standard",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -300,7 +292,7 @@
     },
     {
       "MountedLocation": "RightLeg",
-      "ComponentDefID": "Gear_JumpJet_Standard_Standard",
+      "ComponentDefID": "Gear_JumpJet_Improved_Standard",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -308,7 +300,7 @@
     },
     {
       "MountedLocation": "RightLeg",
-      "ComponentDefID": "Gear_JumpJet_Standard_Standard",
+      "ComponentDefID": "Gear_JumpJet_Improved_Standard",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "IsFixed": false,


### PR DESCRIPTION
Start fixing hunchbacks. Small PR for quick review since I'm new at this.

- HBK-5A: [custom] Replace Artemis IV FCS with improved fcs and extra ammo box for the arrow
- HBK-5J: [custom] Downgrade pulse lasers to standard, add extra heatsink and replace ArtIV FCS with 2x ArtIV attachments
- HBK-5S: [slightly custom?] total slots issue here; removed a BC that isn't on the record sheet and regained the weight by buffing the jump jet quality. Alternate fix would keep the recoil BC and use a small cockpit to gain the slot, but dropping the BC felt closer to the source.