### PR TITLE
Mech fixes

### DIFF
--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_thunderbolt_TDR-8S.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_thunderbolt_TDR-8S.json
@@ -143,7 +143,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_PPCCapacitator",
+      "ComponentDefID": "Gear_Attachment_PPCCapacitor",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -166,6 +166,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Attachment_PPCCapacitor",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_JumpJet_Standard_Heavy",
       "ComponentDefType": "JumpJet",
@@ -199,14 +207,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Double",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_HeatSink_Double",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_thunderbolt_TDR-5Sb.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_thunderbolt_TDR-5Sb.json
@@ -81,64 +81,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 90,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 90,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 110,
+      "CurrentArmor": 120,
       "CurrentRearArmor": 30,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 110,
+      "AssignedArmor": 120,
       "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 140,
-      "CurrentRearArmor": 45,
+      "CurrentRearArmor": 55,
       "CurrentInternalStructure": 105,
       "AssignedArmor": 140,
-      "AssignedRearArmor": 45,
+      "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 110,
+      "CurrentArmor": 120,
       "CurrentRearArmor": 30,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 110,
+      "AssignedArmor": 120,
       "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 90,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 90,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 85,
+      "CurrentArmor": 140,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 85,
+      "AssignedArmor": 140,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 85,
+      "CurrentArmor": 140,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 85,
+      "AssignedArmor": 140,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -152,15 +152,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_275",
+      "ComponentDefID": "Gear_EngineCore_260",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -216,7 +209,14 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_4_Irian",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_2_Streak",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "DamageLevel": "Functional"
@@ -244,7 +244,14 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Artemis",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Streak_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-3C.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-3C.json
@@ -98,28 +98,28 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 70,
+      "CurrentArmor": 50,
       "CurrentRearArmor": 25,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 70,
+      "AssignedArmor": 50,
       "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 110,
+      "CurrentArmor": 100,
       "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 110,
+      "AssignedArmor": 100,
       "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 70,
+      "CurrentArmor": 50,
       "CurrentRearArmor": 25,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 70,
+      "AssignedArmor": 50,
       "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
@@ -134,19 +134,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 65,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 80,
+      "AssignedArmor": 65,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 65,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 80,
+      "AssignedArmor": 65,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -155,14 +155,6 @@
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_EndoSteel",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -234,6 +226,13 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
@@ -254,6 +253,13 @@
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-6X.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-6X.json
@@ -158,13 +158,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_CASE2",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_CASE2",
       "ComponentDefType": "Upgrade",
@@ -179,6 +172,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
@@ -186,14 +186,21 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
@@ -236,13 +243,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Single",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_HeatSink_Single",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/mech/mechdef_toro_TR-A-11.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_toro_TR-A-11.json
@@ -74,10 +74,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 75,
-      "CurrentRearArmor": 30,
+      "CurrentRearArmor": 27,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 75,
-      "AssignedRearArmor": 30,
+      "AssignedRearArmor": 27,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1B.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1B.json
@@ -57,64 +57,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 100,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 100,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 130,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 130,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 130,
-      "CurrentRearArmor": 35,
+      "CurrentArmor": 145,
+      "CurrentRearArmor": 50,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 130,
-      "AssignedRearArmor": 35,
+      "AssignedArmor": 145,
+      "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 130,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 130,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 100,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 100,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 125,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 110,
+      "AssignedArmor": 125,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 125,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 110,
+      "AssignedArmor": 125,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -138,7 +138,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_ECM_Guardian",
+      "ComponentDefID": "Gear_C3i",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1C.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1C.json
@@ -58,20 +58,20 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 120,
+      "CurrentArmor": 115,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 120,
+      "AssignedArmor": 115,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 160,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 120,
+      "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 160,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 120,
+      "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
@@ -85,37 +85,37 @@
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 160,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 120,
+      "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 160,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 120,
+      "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 120,
+      "CurrentArmor": 115,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 120,
+      "AssignedArmor": 115,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 140,
+      "CurrentArmor": 145,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
+      "AssignedArmor": 145,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 140,
+      "CurrentArmor": 145,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
+      "AssignedArmor": 145,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -234,6 +234,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_Laser_VSPL_Medium",
       "ComponentDefType": "Weapon",
@@ -259,7 +267,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -267,7 +275,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -275,7 +283,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-1.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-1.json
@@ -74,10 +74,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 80,
-      "CurrentRearArmor": 25,
+      "CurrentRearArmor": 31,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 80,
-      "AssignedRearArmor": 25,
+      "AssignedRearArmor": 31,
       "DamageLevel": "Functional"
     },
     {
@@ -100,19 +100,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -155,7 +155,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_245",
+      "ComponentDefID": "Gear_EngineCore_250",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -288,13 +288,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_HeatSink_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_HeatSink_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-2.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-2.json
@@ -74,10 +74,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 80,
-      "CurrentRearArmor": 25,
+      "CurrentRearArmor": 31,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 80,
-      "AssignedRearArmor": 25,
+      "AssignedRearArmor": 31,
       "DamageLevel": "Functional"
     },
     {
@@ -100,19 +100,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -155,7 +155,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_245",
+      "ComponentDefID": "Gear_EngineCore_250",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -288,13 +288,6 @@
     },
     {
       "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Gear_HeatSink_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_HeatSink_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XB.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XB.json
@@ -71,28 +71,28 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 150,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 100,
       "AssignedArmor": 150,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 205,
-      "CurrentRearArmor": 55,
+      "CurrentRearArmor": 50,
       "CurrentInternalStructure": 150,
       "AssignedArmor": 205,
-      "AssignedRearArmor": 55,
+      "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
       "CurrentArmor": 150,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 100,
       "AssignedArmor": 150,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
@@ -237,8 +237,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Double",
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XH.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XH.json
@@ -58,10 +58,10 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
@@ -94,28 +94,28 @@
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -131,6 +131,13 @@
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_Composite",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Gyro_Compact",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -194,13 +201,6 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Heavy",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Heavy_Double",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XJ.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XJ.json
@@ -77,10 +77,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 250,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 51,
       "CurrentInternalStructure": 150,
       "AssignedArmor": 250,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 51,
       "DamageLevel": "Functional"
     },
     {
@@ -199,7 +199,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XL.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XL.json
@@ -57,10 +57,10 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 180,
+      "AssignedArmor": 185,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
@@ -75,11 +75,11 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 230,
-      "CurrentRearArmor": 50,
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 55,
       "CurrentInternalStructure": 150,
-      "AssignedArmor": 230,
-      "AssignedRearArmor": 50,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
       "AssignedArmor": 180,
@@ -102,7 +102,7 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
       "AssignedArmor": 180,
@@ -111,7 +111,7 @@
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
       "AssignedArmor": 180,
@@ -159,6 +159,13 @@
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double",
       "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Gyro_Compact",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
@@ -233,13 +240,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Plasma",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Cluster",
       "ComponentDefType": "AmmunitionBox",
@@ -248,7 +248,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Slug",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Cluster_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Uniques/mech/mechdef_tiburon_TBR-1-J.json
+++ b/Eras/Republic3081-3130/Uniques/mech/mechdef_tiburon_TBR-1-J.json
@@ -75,10 +75,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 80,
-      "CurrentRearArmor": 25,
+      "CurrentRearArmor": 31,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 80,
-      "AssignedRearArmor": 25,
+      "AssignedRearArmor": 31,
       "DamageLevel": "Functional"
     },
     {
@@ -101,19 +101,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -184,7 +184,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_245",
+      "ComponentDefID": "Gear_EngineCore_250",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -331,13 +331,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_HeatSink_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_HeatSink_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/PirateTech/Base/Looted/chassis/chassisdef_uller_KF-P.json
+++ b/Optionals/PirateTech/Base/Looted/chassis/chassisdef_uller_KF-P.json
@@ -29,7 +29,7 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Kit Fox",
-    "Id": "chassisdef_ullr_KF-P",
+    "Id": "chassisdef_uller_KF-P",
     "Name": "Kit Fox",
     "Details": "The Uller aptly named for a god of archery sports long range weapons and agility\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.99</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Right Upper</color>\\n\\n",
     "Icon": "uixTxrIcon_kitfox"

--- a/Optionals/PirateTech/Base/Looted/mech/mechdef_uller_KF-P.json
+++ b/Optionals/PirateTech/Base/Looted/mech/mechdef_uller_KF-P.json
@@ -38,15 +38,15 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_ullr_KF-P",
+  "ChassisID": "chassisdef_uller_KF-P",
   "Description": {
     "Cost": 76429,
     "Rarity": 5,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Ullr KF-P",
-    "Id": "mechdef_ullr_KF-P",
+    "UIName": "Uller KF-P",
+    "Id": "mechdef_uller_KF-P",
     "Name": "Kit Fox P",
     "Details": "The Uller aptly named for a god of archery sports long range weapons and agility\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.99</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Right Upper</color>\\n\\n",
     "Icon": "uixTxrIcon_kitfox"
@@ -74,10 +74,10 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 45,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 24,
       "CurrentInternalStructure": 35,
       "AssignedArmor": 45,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 24,
       "DamageLevel": "Functional"
     },
     {
@@ -92,10 +92,10 @@
     {
       "Location": "RightTorso",
       "CurrentArmor": 45,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 24,
       "CurrentInternalStructure": 35,
       "AssignedArmor": 45,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 24,
       "DamageLevel": "Functional"
     },
     {

--- a/Optionals/PirateTech/HeavyMetal/KillTeams/mech/mechdef_tommy_ANH-TOM.json
+++ b/Optionals/PirateTech/HeavyMetal/KillTeams/mech/mechdef_tommy_ANH-TOM.json
@@ -76,11 +76,11 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 283,
-      "CurrentRearArmor": 105,
+      "CurrentArmor": 282,
+      "CurrentRearArmor": 100,
       "CurrentInternalStructure": 155,
-      "AssignedArmor": 283,
-      "AssignedRearArmor": 105,
+      "AssignedArmor": 282,
+      "AssignedRearArmor": 100,
       "DamageLevel": "Functional"
     },
     {
@@ -143,13 +143,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Range_Extreme",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Indirect",
       "ComponentDefType": "Upgrade",
@@ -171,7 +164,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_Probe_Active_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/RogueElites/Base/mech/mechdef_toro_TR-S-7.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_toro_TR-S-7.json
@@ -45,10 +45,10 @@
   "Locations": [
     {
       "Location": "Head",
-      "CurrentArmor": 43,
+      "CurrentArmor": 45,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 16,
-      "AssignedArmor": 43,
+      "AssignedArmor": 45,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
@@ -64,28 +64,28 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 60,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
       "AssignedArmor": 60,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 70,
+      "CurrentArmor": 75,
       "CurrentRearArmor": 30,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 70,
+      "AssignedArmor": 75,
       "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
       "CurrentArmor": 60,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
       "AssignedArmor": 60,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
@@ -218,7 +218,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_175",
+      "ComponentDefID": "Gear_EngineCore_200",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -294,13 +294,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_HeatSink_Double",
       "ComponentDefType": "HeatSink",
@@ -309,13 +302,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Double",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_HeatSink_Double",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanlord_UBL-77.json
+++ b/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanlord_UBL-77.json
@@ -135,10 +135,10 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 180,
+      "CurrentArmor": 179,
       "CurrentRearArmor": 65,
       "CurrentInternalStructure": 110,
-      "AssignedArmor": 180,
+      "AssignedArmor": 179,
       "AssignedRearArmor": 65,
       "DamageLevel": "Functional"
     },
@@ -162,19 +162,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 130,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 130,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 130,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 130,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -210,7 +210,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_280",
+      "ComponentDefID": "Gear_EngineCore_275",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"


### PR DESCRIPTION
Completed fixes for Thunderbolts, Trebuchets, Toros, Toyamas, Tiburons, Trebarunas, Urbanlord, Annihilator Tommy, and Kit Fox Uller.

Kit Fox Uller - Renamed chassisdef and mechdef to fix typo in unit name 'Ullr' as the description and external sources provided context that it should be 'Uller' 