### PR TITLE
Mech fixes

### DIFF
--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_thunderbolt_TDR-8S.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_thunderbolt_TDR-8S.json
@@ -145,17 +145,17 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_PPCCapacitator",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
+      "ComponentDefID": "Weapon_PPC_ER",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
       "IsFixed": false,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_PPC_ER",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
+      "ComponentDefID": "Gear_Attachment_PPCCapacitor",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
       "IsFixed": false,
       "DamageLevel": "Functional"
     },
@@ -168,6 +168,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Attachment_PPCCapacitor",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_JumpJet_Standard_Heavy",
       "ComponentDefType": "JumpJet",
@@ -201,14 +209,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Double",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_HeatSink_Double",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_thunderbolt_TDR-5Sb.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_thunderbolt_TDR-5Sb.json
@@ -83,64 +83,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 90,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 90,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 110,
+      "CurrentArmor": 120,
       "CurrentRearArmor": 30,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 110,
+      "AssignedArmor": 120,
       "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 140,
-      "CurrentRearArmor": 45,
+      "CurrentRearArmor": 55,
       "CurrentInternalStructure": 105,
       "AssignedArmor": 140,
-      "AssignedRearArmor": 45,
+      "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 110,
+      "CurrentArmor": 120,
       "CurrentRearArmor": 30,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 110,
+      "AssignedArmor": 120,
       "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 90,
+      "CurrentArmor": 100,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 90,
+      "AssignedArmor": 100,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 85,
+      "CurrentArmor": 140,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 85,
+      "AssignedArmor": 140,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 85,
+      "CurrentArmor": 140,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 85,
+      "AssignedArmor": 140,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -154,15 +154,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_275",
+      "ComponentDefID": "Gear_EngineCore_260",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -218,7 +211,14 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_SRM_4_Irian",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_2_Streak",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
       "DamageLevel": "Functional"
@@ -246,7 +246,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Artemis",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Streak_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-3C.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-3C.json
@@ -100,28 +100,28 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 70,
+      "CurrentArmor": 50,
       "CurrentRearArmor": 25,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 70,
+      "AssignedArmor": 50,
       "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 110,
+      "CurrentArmor": 100,
       "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 110,
+      "AssignedArmor": 100,
       "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 70,
+      "CurrentArmor": 50,
       "CurrentRearArmor": 25,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 70,
+      "AssignedArmor": 50,
       "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
@@ -136,19 +136,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 65,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 80,
+      "AssignedArmor": 65,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 65,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 80,
+      "AssignedArmor": 65,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -157,14 +157,6 @@
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_EndoSteel",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -236,6 +228,13 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
@@ -256,6 +255,13 @@
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-6X.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_trebuchet_TBT-6X.json
@@ -160,13 +160,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_CASE2",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_CASE2",
       "ComponentDefType": "Upgrade",
@@ -181,9 +174,23 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
@@ -195,7 +202,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
@@ -238,13 +245,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_HeatSink_Single",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_HeatSink_Single",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/mech/mechdef_toro_TR-A-11.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_toro_TR-A-11.json
@@ -76,10 +76,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 75,
-      "CurrentRearArmor": 30,
+      "CurrentRearArmor": 27,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 75,
-      "AssignedRearArmor": 30,
+      "AssignedRearArmor": 27,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1B.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1B.json
@@ -59,64 +59,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 100,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 100,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 130,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 130,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 130,
-      "CurrentRearArmor": 35,
+      "CurrentArmor": 145,
+      "CurrentRearArmor": 50,
       "CurrentInternalStructure": 115,
-      "AssignedArmor": 130,
-      "AssignedRearArmor": 35,
+      "AssignedArmor": 145,
+      "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 130,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 130,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 100,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 100,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 125,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 110,
+      "AssignedArmor": 125,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 125,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 110,
+      "AssignedArmor": 125,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -140,7 +140,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_ECM_Guardian",
+      "ComponentDefID": "Gear_C3i",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1C.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_toyama_TYM-1C.json
@@ -60,20 +60,20 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 120,
+      "CurrentArmor": 115,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 120,
+      "AssignedArmor": 115,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 160,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 120,
+      "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 160,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 120,
+      "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
@@ -87,37 +87,37 @@
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 160,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 120,
+      "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 160,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 120,
+      "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 120,
+      "CurrentArmor": 115,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 60,
-      "AssignedArmor": 120,
+      "AssignedArmor": 115,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 140,
+      "CurrentArmor": 145,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
+      "AssignedArmor": 145,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 140,
+      "CurrentArmor": 145,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
+      "AssignedArmor": 145,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -236,6 +236,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_Laser_VSPL_Medium",
       "ComponentDefType": "Weapon",
@@ -261,7 +269,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -269,7 +277,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -277,7 +285,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-1.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-1.json
@@ -76,10 +76,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 80,
-      "CurrentRearArmor": 25,
+      "CurrentRearArmor": 31,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 80,
-      "AssignedRearArmor": 25,
+      "AssignedRearArmor": 31,
       "DamageLevel": "Functional"
     },
     {
@@ -102,19 +102,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -157,7 +157,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_245",
+      "ComponentDefID": "Gear_EngineCore_250",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -290,13 +290,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_HeatSink_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_HeatSink_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-2.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_tiburon_TBR-2.json
@@ -76,10 +76,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 80,
-      "CurrentRearArmor": 25,
+      "CurrentRearArmor": 31,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 80,
-      "AssignedRearArmor": 25,
+      "AssignedRearArmor": 31,
       "DamageLevel": "Functional"
     },
     {
@@ -102,19 +102,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -157,7 +157,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_245",
+      "ComponentDefID": "Gear_EngineCore_250",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -290,13 +290,6 @@
     },
     {
       "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Gear_HeatSink_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_HeatSink_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XB.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XB.json
@@ -73,28 +73,28 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 150,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 100,
       "AssignedArmor": 150,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 205,
-      "CurrentRearArmor": 55,
+      "CurrentRearArmor": 50,
       "CurrentInternalStructure": 150,
       "AssignedArmor": 205,
-      "AssignedRearArmor": 55,
+      "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
       "CurrentArmor": 150,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 100,
       "AssignedArmor": 150,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
@@ -239,8 +239,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Double",
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XH.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XH.json
@@ -60,10 +60,10 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
@@ -96,28 +96,28 @@
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 115,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 115,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -133,6 +133,13 @@
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_Composite",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Gyro_Compact",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -196,13 +203,6 @@
     {
       "MountedLocation": "Head",
       "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Heavy",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Heavy_Double",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XJ.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XJ.json
@@ -79,10 +79,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 250,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 51,
       "CurrentInternalStructure": 150,
       "AssignedArmor": 250,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 51,
       "DamageLevel": "Functional"
     },
     {
@@ -201,7 +201,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XL.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_trebaruna_TR-XL.json
@@ -59,10 +59,10 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 180,
+      "AssignedArmor": 185,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
@@ -77,11 +77,11 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 230,
-      "CurrentRearArmor": 50,
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 55,
       "CurrentInternalStructure": 150,
-      "AssignedArmor": 230,
-      "AssignedRearArmor": 50,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
@@ -95,28 +95,28 @@
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 180,
+      "AssignedArmor": 185,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 180,
+      "AssignedArmor": 185,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 180,
+      "CurrentArmor": 185,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 180,
+      "AssignedArmor": 185,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -161,6 +161,13 @@
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double",
       "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Gyro_Compact",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
@@ -250,7 +257,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Slug",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Cluster_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Uniques/mech/mechdef_tiburon_TBR-1-J.json
+++ b/Eras/Republic3081-3130/Uniques/mech/mechdef_tiburon_TBR-1-J.json
@@ -77,10 +77,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 80,
-      "CurrentRearArmor": 25,
+      "CurrentRearArmor": 31,
       "CurrentInternalStructure": 55,
       "AssignedArmor": 80,
-      "AssignedRearArmor": 25,
+      "AssignedRearArmor": 31,
       "DamageLevel": "Functional"
     },
     {
@@ -103,19 +103,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 75,
+      "CurrentArmor": 80,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 40,
-      "AssignedArmor": 75,
+      "AssignedArmor": 80,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -186,7 +186,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_245",
+      "ComponentDefID": "Gear_EngineCore_250",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -333,13 +333,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_HeatSink_Double_Clan",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_HeatSink_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/PirateTech/Base/Looted/chassis/chassisdef_uller_KF-P.json
+++ b/Optionals/PirateTech/Base/Looted/chassis/chassisdef_uller_KF-P.json
@@ -29,7 +29,7 @@
     "Manufacturer": "",
     "Model": "",
     "UIName": "Kit Fox",
-    "Id": "chassisdef_ullr_KF-P",
+    "Id": "chassisdef_uller_KF-P",
     "Name": "Kit Fox",
     "Details": "The Uller aptly named for a god of archery sports long range weapons and agility\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.99</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Right Upper</color>\\n\\n",
     "Icon": "uixTxrIcon_kitfox"

--- a/Optionals/PirateTech/Base/Looted/mech/mechdef_uller_KF-P.json
+++ b/Optionals/PirateTech/Base/Looted/mech/mechdef_uller_KF-P.json
@@ -12,7 +12,6 @@
       "unit_predator",
       "unit_jumpOK",
       "unit_chassis_kitfox",
-      "unit_optional_pirate_tech",
       "wordofblake",
       "comstar",
       "hanse",
@@ -39,15 +38,15 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "chassisdef_ullr_KF-P",
+  "ChassisID": "chassisdef_uller_KF-P",
   "Description": {
     "Cost": 76429,
     "Rarity": 5,
     "Purchasable": true,
     "Manufacturer": null,
     "Model": null,
-    "UIName": "Ullr KF-P",
-    "Id": "mechdef_ullr_KF-P",
+    "UIName": "Uller KF-P",
+    "Id": "mechdef_uller_KF-P",
     "Name": "Kit Fox P",
     "Details": "The Uller aptly named for a god of archery sports long range weapons and agility\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 0.99</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Right Upper</color>\\n\\n",
     "Icon": "uixTxrIcon_kitfox"
@@ -75,10 +74,10 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 45,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 24,
       "CurrentInternalStructure": 35,
       "AssignedArmor": 45,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 24,
       "DamageLevel": "Functional"
     },
     {
@@ -93,10 +92,10 @@
     {
       "Location": "RightTorso",
       "CurrentArmor": 45,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 24,
       "CurrentInternalStructure": 35,
       "AssignedArmor": 45,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 24,
       "DamageLevel": "Functional"
     },
     {

--- a/Optionals/PirateTech/HeavyMetal/KillTeams/mech/mechdef_tommy_ANH-TOM.json
+++ b/Optionals/PirateTech/HeavyMetal/KillTeams/mech/mechdef_tommy_ANH-TOM.json
@@ -78,11 +78,11 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 283,
-      "CurrentRearArmor": 105,
+      "CurrentArmor": 282,
+      "CurrentRearArmor": 100,
       "CurrentInternalStructure": 155,
-      "AssignedArmor": 283,
-      "AssignedRearArmor": 105,
+      "AssignedArmor": 282,
+      "AssignedRearArmor": 100,
       "DamageLevel": "Functional"
     },
     {
@@ -145,13 +145,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Range_Extreme",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Indirect",
       "ComponentDefType": "Upgrade",
@@ -173,7 +166,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_Probe_Active_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/RogueElites/Base/mech/mechdef_toro_TR-S-7.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_toro_TR-S-7.json
@@ -46,10 +46,10 @@
   "Locations": [
     {
       "Location": "Head",
-      "CurrentArmor": 43,
+      "CurrentArmor": 45,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 16,
-      "AssignedArmor": 43,
+      "AssignedArmor": 45,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
@@ -65,28 +65,28 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 60,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
       "AssignedArmor": 60,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 70,
+      "CurrentArmor": 75,
       "CurrentRearArmor": 30,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 70,
+      "AssignedArmor": 75,
       "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
       "CurrentArmor": 60,
-      "CurrentRearArmor": 20,
+      "CurrentRearArmor": 25,
       "CurrentInternalStructure": 40,
       "AssignedArmor": 60,
-      "AssignedRearArmor": 20,
+      "AssignedRearArmor": 25,
       "DamageLevel": "Functional"
     },
     {
@@ -219,7 +219,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_175",
+      "ComponentDefID": "Gear_EngineCore_200",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -295,13 +295,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_HeatSink_Double",
       "ComponentDefType": "HeatSink",
@@ -310,13 +303,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_HeatSink_Double",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_HeatSink_Double",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanlord_UBL-77.json
+++ b/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanlord_UBL-77.json
@@ -136,10 +136,10 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 180,
+      "CurrentArmor": 179,
       "CurrentRearArmor": 65,
       "CurrentInternalStructure": 110,
-      "AssignedArmor": 180,
+      "AssignedArmor": 179,
       "AssignedRearArmor": 65,
       "DamageLevel": "Functional"
     },
@@ -163,19 +163,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 130,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 130,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 130,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 130,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -211,7 +211,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_280",
+      "ComponentDefID": "Gear_EngineCore_275",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"


### PR DESCRIPTION
Completed fixes for Thunderbolts, Trebuchets, Toros, Toyamas, Tiburons, Trebarunas, Urbanlord, Annihilator Tommy, and Kit Fox Uller.

Kit Fox Uller - Renamed chassisdef and mechdef to fix typo in unit name 'Ullr' as the description and external sources provided context that it should be 'Uller'