### PR TITLE
Fixes for era heavies - C through CAT

### DIFF
--- a/Eras/CivilWar3062-3067/Base Heavy Metal/mech/mechdef_archer_ARC-6S.json
+++ b/Eras/CivilWar3062-3067/Base Heavy Metal/mech/mechdef_archer_ARC-6S.json
@@ -139,13 +139,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_280",
       "ComponentDefType": "HeatSink",
@@ -213,7 +206,16 @@
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "CenterTorso",
@@ -234,20 +236,22 @@
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_SRM_2_Streak",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/CivilWar3062-3067/Base Heavy Metal/mech/mechdef_archer_ARC-8M.json
+++ b/Eras/CivilWar3062-3067/Base Heavy Metal/mech/mechdef_archer_ARC-8M.json
@@ -142,22 +142,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_280",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -202,7 +188,16 @@
       "ComponentDefID": "Weapon_LRM_15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "CenterTorso",
@@ -216,7 +211,16 @@
       "ComponentDefID": "Weapon_LRM_15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",

--- a/Eras/CivilWar3062-3067/Base Heavy Metal/mech/mechdef_archer_ARC-C2.json
+++ b/Eras/CivilWar3062-3067/Base Heavy Metal/mech/mechdef_archer_ARC-C2.json
@@ -129,13 +129,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_ECM_Guardian_Clan",
       "ComponentDefType": "Upgrade",
@@ -175,7 +168,16 @@
       "ComponentDefID": "Weapon_LRM_20_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "LeftTorso",
@@ -189,7 +191,16 @@
       "ComponentDefID": "Weapon_LRM_20_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightTorso",
@@ -215,20 +226,6 @@
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis_Clan",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis_Clan",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis_Clan_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_caesar_CES-4R.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_caesar_CES-4R.json
@@ -118,6 +118,10 @@
       "Location": "LeftTorso",
       "Hardpoints": [
         {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
           "WeaponMountID": "Special",
           "Omni": false
         }
@@ -147,10 +151,6 @@
       "Hardpoints": [
         {
           "WeaponMountID": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMountID": "Energy",
           "Omni": false
         },
         {

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_argus_AGS-2D.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_argus_AGS-2D.json
@@ -129,14 +129,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_300",
       "ComponentDefType": "HeatSink",
@@ -198,7 +190,16 @@
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "IsFixed": false,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "LeftTorso",
@@ -206,21 +207,22 @@
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "IsFixed": false,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Weapon_PPC_ER",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
       "IsFixed": false,
       "DamageLevel": "Functional"
     },

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_bandersnatch_BNDR-01D.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_bandersnatch_BNDR-01D.json
@@ -131,20 +131,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Missile",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_300",
       "ComponentDefType": "HeatSink",
@@ -207,14 +193,32 @@
       "ComponentDefID": "Weapon_LRM_10",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_LRM_10",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_bombardier_BMB-14C.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_bombardier_BMB-14C.json
@@ -135,13 +135,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_C3i",
       "ComponentDefType": "Upgrade",
@@ -172,13 +165,6 @@
     {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Linked_Engine_Size_3",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -216,14 +202,32 @@
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "LeftTorso",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_caesar_CES-4R.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_caesar_CES-4R.json
@@ -175,6 +175,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_CASE",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_Pulse_Medium",
       "ComponentDefType": "Weapon",
@@ -203,7 +211,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Laser_ER_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
@@ -238,14 +246,14 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_Gauss",
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
+      "MountedLocation": "LeftArm",
       "ComponentDefID": "Gear_HeatSink_Double",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_catapult_CPLT-C2.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_catapult_CPLT-C2.json
@@ -59,64 +59,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 75,
+      "CurrentArmor": 85,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 75,
+      "AssignedArmor": 85,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 95,
-      "CurrentRearArmor": 40,
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 30,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 95,
-      "AssignedRearArmor": 40,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 100,
-      "CurrentRearArmor": 55,
+      "CurrentArmor": 140,
+      "CurrentRearArmor": 45,
       "CurrentInternalStructure": 105,
-      "AssignedArmor": 100,
-      "AssignedRearArmor": 55,
+      "AssignedArmor": 140,
+      "AssignedRearArmor": 45,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 95,
-      "CurrentRearArmor": 40,
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 30,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 95,
-      "AssignedRearArmor": 40,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 30,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 75,
+      "CurrentArmor": 85,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 75,
+      "AssignedArmor": 85,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 90,
+      "CurrentArmor": 130,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 90,
+      "AssignedArmor": 130,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 90,
+      "CurrentArmor": 130,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 90,
+      "AssignedArmor": 130,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -130,21 +130,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_ECM",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Probe_BeagleActiveProbe",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
@@ -200,38 +186,26 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_CASE2",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_CASE2",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_LRM_15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Autocannon_LBX_2",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Weapon_AMS",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
@@ -246,7 +220,16 @@
       "ComponentDefID": "Weapon_LRM_15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "LeftTorso",
@@ -263,8 +246,8 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_AMS",
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -272,6 +255,13 @@
     {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LBX_2_Slug",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/DarkAge3131-/Base/mech/mechdef_cataphract_CTF-5L.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_cataphract_CTF-5L.json
@@ -67,28 +67,28 @@
     {
       "Location": "LeftTorso",
       "CurrentArmor": 110,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
       "AssignedArmor": 110,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 180,
-      "CurrentRearArmor": 63,
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 55,
       "CurrentInternalStructure": 110,
-      "AssignedArmor": 180,
-      "AssignedRearArmor": 63,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
       "CurrentArmor": 110,
-      "CurrentRearArmor": 50,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
       "AssignedArmor": 110,
-      "AssignedRearArmor": 50,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/DarkAge3131-/Base/mech/mechdef_catapult_ii_CPLT-C7.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_catapult_ii_CPLT-C7.json
@@ -88,10 +88,10 @@
     {
       "Location": "CenterTorso",
       "CurrentArmor": 170,
-      "CurrentRearArmor": 68,
+      "CurrentRearArmor": 65,
       "CurrentInternalStructure": 110,
       "AssignedArmor": 170,
-      "AssignedRearArmor": 68,
+      "AssignedRearArmor": 65,
       "DamageLevel": "Functional"
     },
     {
@@ -192,6 +192,20 @@
       "MountedLocation": "RightTorso",
       "ComponentDefID": "BoltOn_Weapon_AMS",
       "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_AdvancedMaterials1",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_AdvancedMaterials1",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },

--- a/Eras/DarkAge3131-/Base/mech/mechdef_catapult_ii_CPLT-L7.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_catapult_ii_CPLT-L7.json
@@ -70,29 +70,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 156,
+      "CurrentArmor": 150,
       "CurrentRearArmor": 55,
       "CurrentInternalStructure": 110,
-      "AssignedArmor": 156,
+      "AssignedArmor": 150,
       "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/DarkAge3131-/Base/mech/mechdef_catapult_ii_CPLT-L7L.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_catapult_ii_CPLT-L7L.json
@@ -77,10 +77,10 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 145,
+      "CurrentArmor": 150,
       "CurrentRearArmor": 56,
       "CurrentInternalStructure": 110,
-      "AssignedArmor": 145,
+      "AssignedArmor": 150,
       "AssignedRearArmor": 56,
       "DamageLevel": "Functional"
     },
@@ -104,19 +104,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 115,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 110,
+      "AssignedArmor": 115,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 115,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 110,
+      "AssignedArmor": 115,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -138,13 +138,6 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Tracker",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -159,7 +152,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_250",
+      "ComponentDefID": "Gear_EngineCore_280",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -211,14 +204,16 @@
       "ComponentDefID": "Weapon_MML_9",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_Medium_DiverseOptics",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "LeftTorso",
@@ -230,13 +225,6 @@
     {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Plasma_Cannon",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Laser_Medium_DiverseOptics",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
@@ -260,31 +248,40 @@
       "ComponentDefID": "Weapon_MML_9",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightArm",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_SRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightArm",
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_SRM_Deadfire",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
@@ -292,20 +289,6 @@
     },
     {
       "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Ammo_AmmunitionBox_Plasma",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Ammo_AmmunitionBox_Plasma",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightLeg",
       "ComponentDefID": "Ammo_AmmunitionBox_Plasma",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
@@ -326,7 +309,14 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Heavy",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_JumpJet_Heavy",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base HeavyMetal/mech/mechdef_archer_ARC-7S.json
+++ b/Eras/Jihad3068-3080/Base HeavyMetal/mech/mechdef_archer_ARC-7S.json
@@ -135,13 +135,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_280",
       "ComponentDefType": "HeatSink",
@@ -165,13 +158,6 @@
     {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Linked_Engine_Size_2",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -216,7 +202,16 @@
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "CenterTorso",
@@ -230,7 +225,16 @@
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",

--- a/Eras/Jihad3068-3080/Base HeavyMetal/mech/mechdef_archer_ARC-9M.json
+++ b/Eras/Jihad3068-3080/Base HeavyMetal/mech/mechdef_archer_ARC-9M.json
@@ -85,10 +85,10 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 150,
+      "CurrentArmor": 140,
       "CurrentRearArmor": 49,
       "CurrentInternalStructure": 110,
-      "AssignedArmor": 150,
+      "AssignedArmor": 140,
       "AssignedRearArmor": 49,
       "DamageLevel": "Functional"
     },
@@ -133,13 +133,6 @@
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Armor_LightFerroFibrous",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -205,7 +198,16 @@
       "ComponentDefID": "Weapon_LRM_15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "LeftTorso",
@@ -219,7 +221,16 @@
       "ComponentDefID": "Weapon_LRM_15",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 1,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightTorso",
@@ -272,15 +283,15 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_PartialWing_IS",
-      "ComponentDefType": "Upgrade",
+      "ComponentDefID": "Gear_JumpJet_Heavy_Improved",
+      "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_PartialWing_LTslot",
-      "ComponentDefType": "Upgrade",
+      "ComponentDefID": "Gear_JumpJet_Heavy_Improved",
+      "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
@@ -295,6 +306,13 @@
       "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_JumpJet_Heavy_Improved",
       "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },

--- a/Eras/Jihad3068-3080/Base HeavyMetal/mech/mechdef_archer_ARC-9W.json
+++ b/Eras/Jihad3068-3080/Base HeavyMetal/mech/mechdef_archer_ARC-9W.json
@@ -178,13 +178,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_ECM_Angel",
       "ComponentDefType": "Upgrade",
@@ -221,7 +214,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCooling_Heatsinks_4",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_3",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -245,14 +238,32 @@
       "ComponentDefID": "Weapon_LRM_15_LongFire",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_LRM_15_LongFire",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_barghest_BGS-7S.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_barghest_BGS-7S.json
@@ -127,13 +127,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_350",
       "ComponentDefType": "HeatSink",
@@ -201,7 +194,16 @@
       "ComponentDefID": "Weapon_MML_7",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "LeftTorso",

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_black_knight_BL-10-KNT.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_black_knight_BL-10-KNT.json
@@ -82,29 +82,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 50,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 50,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 150,
-      "CurrentRearArmor": 60,
+      "CurrentRearArmor": 50,
       "CurrentInternalStructure": 115,
       "AssignedArmor": 150,
-      "AssignedRearArmor": 60,
+      "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 140,
-      "CurrentRearArmor": 50,
+      "CurrentArmor": 130,
+      "CurrentRearArmor": 35,
       "CurrentInternalStructure": 80,
-      "AssignedArmor": 140,
-      "AssignedRearArmor": 50,
+      "AssignedArmor": 130,
+      "AssignedRearArmor": 35,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_cataphract_CTF-1E.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_cataphract_CTF-1E.json
@@ -283,7 +283,7 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftArm",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_UAC_10",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-C1M.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-C1M.json
@@ -56,64 +56,64 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 65,
+      "CurrentArmor": 70,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 65,
+      "AssignedArmor": 70,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 95,
+      "CurrentArmor": 100,
       "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 95,
+      "AssignedArmor": 100,
       "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 120,
-      "CurrentRearArmor": 51,
+      "CurrentRearArmor": 55,
       "CurrentInternalStructure": 105,
       "AssignedArmor": 120,
-      "AssignedRearArmor": 51,
+      "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 95,
+      "CurrentArmor": 100,
       "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 95,
+      "AssignedArmor": 100,
       "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 65,
+      "CurrentArmor": 70,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 50,
-      "AssignedArmor": 65,
+      "AssignedArmor": 70,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 90,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 80,
+      "AssignedArmor": 90,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 90,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 80,
+      "AssignedArmor": 90,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
@@ -170,7 +170,7 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
+      "ComponentDefID": "Gear_FCS_ArtemisIII",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
@@ -268,14 +268,14 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Artemis",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM_ListenKill",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-K9.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-K9.json
@@ -65,28 +65,28 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 150,
+      "CurrentArmor": 130,
       "CurrentRearArmor": 50,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 150,
+      "AssignedArmor": 130,
       "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 198,
-      "CurrentRearArmor": 90,
+      "CurrentArmor": 170,
+      "CurrentRearArmor": 70,
       "CurrentInternalStructure": 105,
-      "AssignedArmor": 198,
-      "AssignedRearArmor": 90,
+      "AssignedArmor": 170,
+      "AssignedRearArmor": 70,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 150,
+      "CurrentArmor": 130,
       "CurrentRearArmor": 50,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 150,
+      "AssignedArmor": 130,
       "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
@@ -124,13 +124,6 @@
       "ComponentDefID": "Gear_AdvancedMaterials1",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Armor_LightFerroFibrous",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-KC.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-KC.json
@@ -81,28 +81,28 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 115,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 115,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 135,
+      "CurrentArmor": 125,
       "CurrentRearArmor": 55,
       "CurrentInternalStructure": 105,
-      "AssignedArmor": 135,
+      "AssignedArmor": 125,
       "AssignedRearArmor": 55,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 115,
+      "CurrentArmor": 110,
       "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 115,
+      "AssignedArmor": 110,
       "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
@@ -140,6 +140,13 @@
       "ComponentDefID": "Gear_Structure_EndoSteel",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_AdvancedMaterials1",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_barghest_BGS-4X.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_barghest_BGS-4X.json
@@ -173,17 +173,35 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_PPC_Light_Capacitor",
+      "ComponentDefID": "Weapon_PPC_Light",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_PPC_Light_Capacitor",
+      "ComponentDefID": "Weapon_PPC_Light",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_PPCCapacitor",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_PPCCapacitor",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightTorso",

--- a/Eras/Republic3081-3130/Base Heavy Metal/mech/mechdef_archer_ARC-4M2.json
+++ b/Eras/Republic3081-3130/Base Heavy Metal/mech/mechdef_archer_ARC-4M2.json
@@ -147,13 +147,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_280",
       "ComponentDefType": "HeatSink",
@@ -193,7 +186,16 @@
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "CenterTorso",
@@ -214,7 +216,16 @@
       "ComponentDefID": "Weapon_LRM_20",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisIV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",
@@ -232,13 +243,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base Heavy Metal/mech/mechdef_archer_ARC-7C.json
+++ b/Eras/Republic3081-3130/Base Heavy Metal/mech/mechdef_archer_ARC-7C.json
@@ -134,27 +134,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Range_Extreme",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_ArtemisV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_350",
       "ComponentDefType": "HeatSink",
@@ -222,7 +201,16 @@
       "ComponentDefID": "Weapon_LRM_20_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "CenterTorso",
@@ -243,7 +231,16 @@
       "ComponentDefID": "Weapon_LRM_20_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional"
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment1"
+    },,
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_ArtemisV",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment1"
     },
     {
       "MountedLocation": "RightArm",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_carronade_CRN-7M.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_carronade_CRN-7M.json
@@ -79,7 +79,12 @@
   "Locations": [
     {
       "Location": "Head",
-      "Hardpoints": [],
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 6,
       "MaxArmor": 45,
@@ -107,10 +112,6 @@
     {
       "Location": "LeftTorso",
       "Hardpoints": [
-        {
-          "WeaponMountID": "Energy",
-          "Omni": false
-        },
         {
           "WeaponMountID": "Energy",
           "Omni": false

--- a/Eras/Republic3081-3130/Base/mech/mechdef_anzu_ZU-G60.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_anzu_ZU-G60.json
@@ -182,7 +182,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_PPCCapacitator",
+      "ComponentDefID": "Gear_Attachment_PPCCapacitor",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": 1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_carronade_CRN-7M.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_carronade_CRN-7M.json
@@ -56,76 +56,69 @@
     },
     {
       "Location": "LeftArm",
-      "CurrentArmor": 100,
+      "CurrentArmor": 110,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 100,
+      "AssignedArmor": 110,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftTorso",
       "CurrentArmor": 130,
-      "CurrentRearArmor": 60,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
       "AssignedArmor": 130,
-      "AssignedRearArmor": 60,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
       "CurrentArmor": 185,
-      "CurrentRearArmor": 90,
+      "CurrentRearArmor": 50,
       "CurrentInternalStructure": 110,
       "AssignedArmor": 185,
-      "AssignedRearArmor": 90,
+      "AssignedRearArmor": 50,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
       "CurrentArmor": 130,
-      "CurrentRearArmor": 60,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 75,
       "AssignedArmor": 130,
-      "AssignedRearArmor": 60,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightArm",
-      "CurrentArmor": 100,
+      "CurrentArmor": 110,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 100,
+      "AssignedArmor": 110,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 80,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 80,
+      "CurrentArmor": 120,
       "CurrentRearArmor": -1,
       "CurrentInternalStructure": 75,
-      "AssignedArmor": 80,
+      "AssignedArmor": 120,
       "AssignedRearArmor": -1,
       "DamageLevel": "Functional"
     }
   ],
   "inventory": [
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Armor_LightFerroFibrous",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_EndoSteel",
@@ -143,13 +136,6 @@
     {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Ballistic",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -211,22 +197,22 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_Medium_Magna",
+      "MountedLocation": "Head",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_MagnaVI",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_Medium_Magna",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_MagnaVI",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Weapon_Laser_Medium_Magna",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_MagnaVI",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"


### PR DESCRIPTION
```
- [x] anzu_ZU-G60
- [x] archer_ARC-4M2
- [x] archer_ARC-6S
- [x] archer_ARC-7C
- [x] archer_ARC-7S
- [x] archer_ARC-8M
- [x] archer_ARC-9M
- [x] archer_ARC-9W
- [x] archer_ARC-C2
- [x] argus_AGS-2D
- [x] bandersnatch_BNDR-01D
- [x] barghest_BGS-4X
- [x] barghest_BGS-7S
- [x] black_knight_BL-10-KNT
- [x] bombardier_BMB-14C
- [x] caesar_CES-4R
- [x] carronade_CRN-7M 
- [x] cataphract_CTF-1E
- [x] cataphract_CTF-5L
- [x] catapult_CPLT-C1M
- [x] catapult_CPLT-C2 
- [x] catapult_CPLT-K9
- [x] catapult_CPLT-KC
- [x] catapult_ii_CPLT-C7
- [x] catapult_ii_CPLT-L7
- [x] catapult_ii_CPLT-L7L
```