### PR TITLE
S4 Faction Colour Shifts

### DIFF
--- a/Core/RogueTechCore/Factions/faction_AmarisEmpire.json
+++ b/Core/RogueTechCore/Factions/faction_AmarisEmpire.json
@@ -106,7 +106,7 @@
     "heraldryDefId": "heraldrydef_AmarisEmpire",
     "storePanelImage": "uixTxrSpot_Store-Marik",
     "factionStoreColor": "rgba(35,24,37,1.0)",
-    "factionMapColor": "rgba(153,0,51,1.0)",
+    "factionMapColor": "rgba(153,102,102,1.0)",
     "StartingReputationValues": [
         0,
         0,

--- a/Core/RogueTechCore/Factions/faction_Illyrian.json
+++ b/Core/RogueTechCore/Factions/faction_Illyrian.json
@@ -104,5 +104,5 @@
     "factionID": "Illyrian",
     "icon": "uixTxrLogo_Illyrian",
     "factionMapBorderOverrideColor": "rgba(0,0,0,1.0)",
-    "factionMapColor": "rgba(0,204,0,0.2)"
+    "factionMapColor": "rgba(102,51,255,0.2)"
 }

--- a/Core/RogueTechCore/Factions/faction_SLDF.json
+++ b/Core/RogueTechCore/Factions/faction_SLDF.json
@@ -106,7 +106,7 @@
     "heraldryDefId": "heraldrydef_SLDF",
     "storePanelImage": "uixTxrSpot_Store-Marik",
     "factionStoreColor": "rgba(35,24,37,1.0)",
-    "factionMapColor": "rgba(204,255,255,1.0)",
+    "factionMapColor": "rgba(153,255,255,1.0)",
     "StartingReputationValues": [
         0,
         0,

--- a/Core/RogueTechCore/Factions/faction_TerranHegemony.json
+++ b/Core/RogueTechCore/Factions/faction_TerranHegemony.json
@@ -106,7 +106,7 @@
     "heraldryDefId": "heraldrydef_TerranHegemony",
     "storePanelImage": "uixTxrSpot_Store-Marik",
     "factionStoreColor": "rgba(35,24,37,1.0)",
-    "factionMapColor": "rgba(102,102,153,1.0)",
+    "factionMapColor": "rgba(204,102,0,1.0)",
     "StartingReputationValues": [
         0,
         0,


### PR DESCRIPTION
Shift to TH, AE, SLDF and Illyrian Faction colours

TerranHegemony -> use Burrock colours (204,102,0)
AmarisEmpire -> use Coyote colours (153,102,102)
SLDF -> shift to 153,255,255 to remove the GB/ComStar visual issues we had last season
Illyrian -> shift to 102,51,255 (it is currently nearly same as Liao, and this shift should give it difference to WoB/DarkCaste