### PR TITLE
Rep-Me fixes and Browning MHQ

### DIFF
--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_hunchback_HBK-5E.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_hunchback_HBK-5E.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_hunchback_HBK-5H.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_hunchback_HBK-5H.json
@@ -8,7 +8,7 @@
       "unit_lance_tank",
       "unit_role_sniper",
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_chassis_hunchback",
       "unit_era_civil_war",
       "unit_optional_era",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_hunchback_HBK-6S.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_hunchback_HBK-6S.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/CivilWar3062-3067/Uniques/mech/mechdef_hunchback_HBK-7X-4.json
+++ b/Eras/CivilWar3062-3067/Uniques/mech/mechdef_hunchback_HBK-7X-4.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/CivilWar3062-3067/Uniques/mech/mechdef_hunchback_HBK-C.json
+++ b/Eras/CivilWar3062-3067/Uniques/mech/mechdef_hunchback_HBK-C.json
@@ -3,7 +3,7 @@
     "items": [
       "unit_generic",
       "unit_legendary",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-1G.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-1G.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4A.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4A.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4G.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4G.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4GK.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4GK.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4GR.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4GR.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4GW.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4GW.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4G_gauss_prototype.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4G_gauss_prototype.json
@@ -8,7 +8,7 @@
       "unit_lance_tank",
       "unit_role_sniper",
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_legendary",
       "unit_chassis_hunchback",
       "unit_era_clan_invasion",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4Gb.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4Gb.json
@@ -7,7 +7,7 @@
       "unit_mech",
       "unit_medium",
       "unit_ready",
-      "unit_lance_assassin",
+      "unit_lance_vanguard",
       "unit_lance_tank",
       "unit_role_brawler",
       "unit_sldf",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4H.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4H.json
@@ -6,7 +6,7 @@
       "unit_medium",
       "unit_lance_tank",
       "unit_role_brawler",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_generic",
       "unit_solaris",
       "unit_chassis_hunchback",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4J.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4J.json
@@ -7,7 +7,7 @@
       "unit_medium",
       "unit_lance_support",
       "unit_role_sniper",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_generic",
       "unit_solaris",
       "unit_chassis_hunchback",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4Jb.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4Jb.json
@@ -8,7 +8,7 @@
       "unit_lance_tank",
       "unit_role_brawler",
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_chassis_hunchback",
       "unit_era_clan_invasion",
       "unit_core",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4K.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4K.json
@@ -8,7 +8,7 @@
       "unit_lance_tank",
       "unit_role_brawler",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_high",
       "unit_jumpOK",
       "unit_chassis_hunchback",
       "unit_era_clan_invasion",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4MA.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4MA.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4MJ.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4MJ.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4MW.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4MW.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4N.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4N.json
@@ -7,7 +7,7 @@
       "unit_medium",
       "unit_lance_support",
       "unit_role_sniper",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_generic",
       "unit_solaris",
       "unit_chassis_hunchback",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4P.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4P.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4SP.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4SP.json
@@ -6,7 +6,7 @@
       "unit_medium",
       "unit_lance_tank",
       "unit_role_flanker",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_generic",
       "unit_solaris",
       "unit_chassis_hunchback",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4T.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4T.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4TD.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4TD.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4U.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-4U.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5A.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5A.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5L.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5L.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5M.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5M.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5N.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5N.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5S.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5S.json
@@ -6,7 +6,7 @@
       "unit_medium",
       "unit_lance_tank",
       "unit_role_brawler",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_jumpOK",
       "unit_advanced",
       "unit_chassis_hunchback",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5SU.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-5SU.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-6A.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-6A.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-6N.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_hunchback_HBK-6N.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_thorn_THE-Nb.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_thorn_THE-Nb.json
@@ -14,6 +14,7 @@
       "unit_era_clan_invasion",
       "unit_core",
       "unit_tonnage_20",
+      "TerranHegemony",
       "GreenGhosts",
       "RimWorldsRepublic",
       "AmarisEmpire",

--- a/Eras/ClanInvasion3061/Uniques/mech/mechdef_hunchback_HBK-4G_hohiro.json
+++ b/Eras/ClanInvasion3061/Uniques/mech/mechdef_hunchback_HBK-4G_hohiro.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/ClanInvasion3061/Uniques/mech/mechdef_hunchback_HBK-4G_shakir.json
+++ b/Eras/ClanInvasion3061/Uniques/mech/mechdef_hunchback_HBK-4G_shakir.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_generic",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",

--- a/Eras/DarkAge3131-/Base/mech/mechdef_hunchback_HBK-7S.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_hunchback_HBK-7S.json
@@ -7,7 +7,7 @@
       "unit_ready",
       "unit_lance_vanguard",
       "unit_role_brawler",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_advanced",
       "unit_predator",
       "unit_totem",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_BROWNING_MOBILEHQ.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_BROWNING_MOBILEHQ.json
@@ -1,0 +1,223 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-1.0",
+            "unit_vehicle",
+            "unit_light",
+            "unit_wheels",
+            "unit_lance_support",
+            "unit_vehicle_mobileHQ",
+            "unit_vehicle_apc",
+            "unit_generic",
+            "unit_bracket_med",
+            "unit_command",
+            "republic",
+            "davion"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_BROWNING_MOBILEHQ",
+    "Description": {
+        "Cost": 909333,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Browning Mobile HQ",
+        "Id": "vehicledef_BROWNING_MOBILEHQ",
+        "Name": "Browning Mobile HQ",
+        "Details": "A mobile Command and Control unit, the Browning Mobile HQ is an armoured truck containing 4 tons of communications gear designed to allow senior officers to coordinate the actions of an entire mech regiment across an entire planet. The Browning Mobile HQ carries an AMS and a Guardian ECM Suite for self defence.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        85     15\n<b>Left</b>         100     15\n<b>Right</b>       100     15\n<b>Rear</b>         80     15\n<b>Turret</b>       60     15\n\n<b>Total</b>      425     75</color>\n\n<color=#ff0000>Quirk: Battle Computer B2000</color>\n\n<color=#ffcc00>Can Resupply/Repair</color>",
+        "Icon": "MobileHQ"
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 75,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 75,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 75,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 75,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 75,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 75,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 75,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 75,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 60,
+            "CurrentInternalStructure": 15,
+            "AssignedArmor": 60,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_AMS",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_AMS",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Crew_Compartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_FCS_Generic_2",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Sensors",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Default_Vehicle_Motive_Wheeled_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Default_Vehicle_Motive_Wheeled_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_CASE",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_ECM_Guardian",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Armor_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Structure_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Vehicle_Motive_Wheeled_Defaultbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_CommunicationsEquipment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Quirk_BattleComputer_B2000",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Default_Vehicle_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Single",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Single",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_EngineCore_155",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Single",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_HeatSink_Single",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_EngineCooling_CoolantSystem",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Eras/DarkAge3131-/Base/vehiclechassis/vehiclechassisdef_BROWNING_MOBILEHQ.json
+++ b/Eras/DarkAge3131-/Base/vehiclechassis/vehiclechassisdef_BROWNING_MOBILEHQ.json
@@ -1,0 +1,126 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "MobileHQ",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "CustomParts": {
+        "CustomParts": [],
+        "CrewLocation": "None"
+    },
+    "Description": {
+        "Cost": 909333,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Browning Mobile HQ",
+        "Id": "vehiclechassisdef_BROWNING_MOBILEHQ",
+        "Name": "Mobile HQ",
+        "Details": "A mobile Command and Control unit, the Browning Mobile HQ is an armoured truck containing 4 tons of communications gear designed to allow senior officers to coordinate the actions of an entire mech regiment across an entire planet. The Browning Mobile HQ carries an AMS and a Guardian ECM Suite for self defence.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        85     15\n<b>Left</b>         100     15\n<b>Right</b>       100     15\n<b>Rear</b>         80     15\n<b>Turret</b>       60     15\n\n<b>Total</b>      425     75</color>\n\n<color=#ff0000>Quirk: Battle Computer B2000</color>\n\n<color=#ffcc00>Can Resupply/Repair</color>",
+        "Icon": "MobileHQ"
+    },
+    "YangsThoughts": "A command and control center on wheels, this thing has all the info a commander in the field would need to coordinate their troops. Why that commander would not want to be in a proper 'Mech I don't know though boss.",
+    "MovementCapDefID": "movedef_7-11cv",
+    "movementType": "Wheeled",
+    "PathingCapDefID": "pathingdef_light_wheeled",
+    "HardpointDataDefID": "hardpointdatadef_mobilehq",
+    "PrefabIdentifier": "chrPrfVhcl_mobilehq",
+    "PrefabBase": "mobilehq",
+    "Tonnage": 25,
+    "weightClass": "LIGHT",
+    "BattleValue": 564,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 6,
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 6,
+            "z": 2.5
+        },
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": 7
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 6,
+            "z": 2.5
+        },
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": 7
+        },
+        {
+            "x": -2,
+            "y": 6,
+            "z": 0
+        },
+        {
+            "x": 2,
+            "y": 6,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 5,
+            "z": -9
+        }
+    ],
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 85,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 85,
+            "InternalStructure": 15
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "AntiPersonnel",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 70,
+            "InternalStructure": 15
+        }
+    ]
+}

--- a/Eras/Republic3081-3130/Base/mech/mechdef_hunchback_HBK-7R.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_hunchback_HBK-7R.json
@@ -2,7 +2,7 @@
   "MechTags": {
     "items": [
       "unit_advanced",
-      "unit_bracket_med",
+      "unit_bracket_high",
       "unit_release",
       "unit_mech",
       "unit_medium",


### PR DESCRIPTION
Added the new Browning MHQ from Rec Guide #29. Added TH tag to the Royal Thorn to fill a gap. Upped Hunchbacks to high bracket (excluding the primitive 1g) threats to fill a few more rep-me's