### PR TITLE
Custom Eurus config and a rep-me fix

### DIFF
--- a/Eras/ClanInvasion3061/Uniques/mech/mechdef_pirates_bane_LCT-PB.json
+++ b/Eras/ClanInvasion3061/Uniques/mech/mechdef_pirates_bane_LCT-PB.json
@@ -15,6 +15,8 @@
       "unit_core",
       "unit_mwo",
       "unit_tonnage_20",
+      "RimWorldsRepublic",
+      "AmarisEmpire",
       "republic",
       "wordofblake",
       "comstar",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_EURUS_E.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_EURUS_E.json
@@ -1,0 +1,259 @@
+{
+    "VehicleTags": {
+        "items": [
+            "mr-resize-0.9",
+            "unit_vehicle",
+            "unit_vehicle_clan",
+            "unit_heavy",
+            "unit_tracks",
+            "unit_release",
+            "unit_lance_tank",
+            "unit_lance_assassin",
+            "unit_advanced",
+            "unit_bracket_med",
+            "unit_proxy_icon",
+            "unit_proxy",
+            "clanhellshorses"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_EURUS_E",
+    "Description": {
+        "Cost": 14276960,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Eurus MBT (Eta)",
+        "Id": "vehicledef_EURUS_E",
+        "Name": "Eurus MBT (Eta)",
+        "Details": "Designed to complement the unique Hell's Horses TankWarrior phenotype, the Eurus is a 60 ton OmniTank designed to engage and destroy a wide array of threats. Powered by a 300 rated XL Engine that pushes the tank to speeds of 88 kph, the Eurus is armoured in 11.5 tons of Ferro-Lamellor armour; making for a fast and very tough tank. 23 tons of pod space allow for a variety of nasty configurations; making for a very versatile and deadly tank\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Ferro-Lamellor (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       210     30\n<b>Left</b>         155     30\n<b>Right</b>       155     30\n<b>Rear</b>        100     30\n<b>Turret</b>      155     30\n\n<b>Total</b>      775    150</color>\n\n<color=#ff0000>Quirk: Main Battle Tank</color>",
+        "Icon": "Challenger"
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 210,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 210,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 155,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 155,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 155,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 155,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 155,
+            "CurrentInternalStructure": 30,
+            "AssignedArmor": 155,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_Pulse_Medium_Clan",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_Pulse_Medium_Clan",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_LRM_15_Streak",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_LRM_15_Streak",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LRM_Streak",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LRM_Streak",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LRM_Streak",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LRM_Streak",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_LRM_Streak",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Crew_Compartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_FCS_Generic_2",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Sensors_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Structure_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Defaultbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Armor_FerroLamellor_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_CASE_Clan",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Quirk_MBTBulwark",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "VehicleTrait_Ubiquitous",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Default_Vehicle_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Linked_Engine_Size_2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Linked_Engine_Size_2",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_EngineCore_215",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_EngineCore_300",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_XL_Clan",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_EngineCooling_CoolantSystem",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Eras/DarkAge3131-/Base/vehiclechassis/vehiclechassisdef_EURUS_E.json
+++ b/Eras/DarkAge3131-/Base/vehiclechassis/vehiclechassisdef_EURUS_E.json
@@ -1,0 +1,138 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Eurus",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": [],
+    "CrewLocation": "None"
+  },
+  "Description": {
+    "Cost": 14276960,
+    "Rarity": 0,
+    "Purchasable": false,
+    "UIName": "Eurus MBT (Eta)",
+    "Id": "vehiclechassisdef_EURUS_E",
+    "Name": "Eurus MBT",
+    "Details": "Designed to complement the unique Hell's Horses TankWarrior phenotype, the Eurus is a 60 ton OmniTank designed to engage and destroy a wide array of threats. Powered by a 300 rated XL Engine that pushes the tank to speeds of 88 kph, the Eurus is armoured in 11.5 tons of Ferro-Lamellor armour; making for a fast and very tough tank. 23 tons of pod space allow for a variety of nasty configurations; making for a very versatile and deadly tank\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 5/8 Hex: 150/240 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Ferro-Lamellor (C)\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       210     30\n<b>Left</b>         155     30\n<b>Right</b>       155     30\n<b>Rear</b>        100     30\n<b>Turret</b>      155     30\n\n<b>Total</b>      775    150</color>\n\n<color=#ff0000>Quirk: Main Battle Tank</color>",
+    "Icon": "Challenger"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_5-8cv",
+  "movementType": "Tracked",
+  "PathingCapDefID": "pathingdef_heavy_tracked",
+  "HardpointDataDefID": "hardpointdatadef_challenger",
+  "PrefabIdentifier": "chrprfvhcl_challengerbase",
+  "PrefabBase": "challenger",
+  "Tonnage": 60,
+  "weightClass": "HEAVY",
+  "BattleValue": 993,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 4,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3,
+      "z": -0.5
+    },
+    {
+      "x": 0.0,
+      "y": 1.5,
+      "z": 3.5
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3,
+      "z": -0.5
+    },
+    {
+      "x": 0.0,
+      "y": 1.5,
+      "z": 3.5
+    },
+    {
+      "x": -2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 2,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 0.0,
+      "y": 1.6,
+      "z": -4.0
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 210,
+      "InternalStructure": 30
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 155,
+      "InternalStructure": 30
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 155,
+      "InternalStructure": 30
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 100,
+      "InternalStructure": 30
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 155,
+      "InternalStructure": 30
+    }
+  ]
+}


### PR DESCRIPTION
Custom 2 * MPL + 2* SLRM-15 Eurus and a temp rep me for 2 factions (Pirates Bane has an ERML which is out of time line, rest of the Mech is fine. Will be replaced with a new fix at some point)