### PR TITLE
Removed mg modes

### DIFF
--- a/Core/RogueModuleTech/AMS/Weapon_AMS.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS.json
@@ -15,9 +15,7 @@
       "AMSAcc: 55%",
       "AMSShots: 30",
       "AMSHeat: 0",
-      "LanceMode: -15%, +1, 20%, +50m",
-      "AMSDirectMG: 5",
-      "JamChanceMode1: 15%, MG"
+      "LanceMode: -15%, +1, 20%, +50m"
     ],
     "Flags": [
       "not_broken"
@@ -136,19 +134,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "MG",
-      "UIName": "MG",
-      "Name": "Machinegun",
-      "Description": "AMS Fires 5 shots as a MG",
-      "isBaseMode": false,
-      "DamagePerShot": 1.0,
-      "HeatGenerated": 6,
-      "ShotsWhenFired": 5,
-      "FlatJammingChance": 0.15,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1
     }
   ],
   "statusEffects": [],

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Advanced_Pirate.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Advanced_Pirate.json
@@ -215,7 +215,7 @@
       "Id": "LMG",
       "UIName": "LMG",
       "Name": "Machinegun",
-      "Description": "AMS Fires 12 Salvos. Consumes 8 Bullets Per Salvo.",
+      "Description": "AMS Fires 12 Salvos as an LMG array. Consumes 8 Bullets Per Salvo.",
       "isBaseMode": false,
       "ShotsWhenFired": 12,
       "RefireModifier": 4,

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Advanced_Pirate.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Advanced_Pirate.json
@@ -213,7 +213,7 @@
     },
     {
       "Id": "LMG",
-      "UIName": "MG",
+      "UIName": "LMG",
       "Name": "Machinegun",
       "Description": "AMS Fires 12 Salvos. Consumes 8 Bullets Per Salvo.",
       "isBaseMode": false,

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Advanced_Pirate.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Advanced_Pirate.json
@@ -20,7 +20,11 @@
       "AMSShots: 8 to 48",
       "AMSHeat: 2 to 12",
       "AmmoPerShot: 1 to 1.5",
-      "WeaponJAMFlatShotBase: 7%"
+      "WeaponJAMFlatShotBase: 7%",
+      "AMSDirectMG: 12x4",
+      "JamChanceMode1: 40%, LMG",
+      "AccuracyUnitBoth: +10, Battle Armor & Protomech",
+      "DamageUnitBoth: +200%, Battle Armor & Protomech"
     ],
     "Flags": [
       "not_broken"
@@ -56,17 +60,24 @@
   ],
   "AmmoCategory": "LMG",
   "StartingAmmoCapacity": 0,
-  "HeatGenerated": 12,
-  "Damage": 0,
+  "HeatGenerated": 6,
+  "Damage": 4,
   "OverheatedDamageMultiplier": 0,
   "EvasiveDamageMultiplier": 0,
-  "EvasivePipsIgnored": 0,
-  "DamageVariance": 0,
+  "EvasivePipsIgnored": 1,
+  "DamageVariance": 1,
+  "TrooperSquadDamageModifier": 3,
   "HeatDamage": 0,
-  "AccuracyModifier": 0,
-  "CriticalChanceMultiplier": 1,
-  "APArmorShardsMod": 0,
-  "APMaxArmorThickness": 1,
+  "HeatMultiplier": 4,
+  "APDamageMultiplier": 4,
+  "AccuracyModifier": -1,
+  "ChassisTagsAccuracyModifiers": {
+    "unit_powerarmor": -10,
+    "unit_protomech": -10
+  },
+  "CriticalChanceMultiplier": 4,
+  "APArmorShardsMod": 0.1,
+  "APMaxArmorThickness": 6,
   "APCriticalChanceMultiplier": 0.5,
   "AOECapable": false,
   "IndirectFireCapable": false,
@@ -199,6 +210,20 @@
       "GunneryJammingBase": 1,
       "HeatGenerated": 0,
       "ShotsPerAmmo": 0.67
+    },
+    {
+      "Id": "LMG",
+      "UIName": "MG",
+      "Name": "Machinegun",
+      "Description": "AMS Fires 12 Salvos. Consumes 8 Bullets Per Salvo.",
+      "isBaseMode": false,
+      "ShotsWhenFired": 12,
+      "RefireModifier": 4,
+      "HeatGenerated": 12,
+      "FlatJammingChance": 0.4,
+      "GunneryJammingMult": 0.01,
+      "GunneryJammingBase": 1,
+      "ShotsPerAmmo": 0.125
     },
     {
       "Id": "Off",

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Clan.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Clan.json
@@ -15,9 +15,7 @@
       "AMSAcc: 60%",
       "AMSShots: 30",
       "AMSHeat: 1",
-      "BurstMode: +30, -10%, +1, 50%, 2",
-      "AMSDirectMG: 10",
-      "JamChanceMode1: 15%, MG"
+      "BurstMode: +30, -10%, +1, 50%, 2"
     ],
     "Flags": [
       "not_broken"
@@ -134,19 +132,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "MG",
-      "UIName": "MG",
-      "Name": "Machinegun",
-      "Description": "AMS Fires 10 shots as a MG",
-      "isBaseMode": false,
-      "DamagePerShot": 1.0,
-      "HeatGenerated": 12,
-      "ShotsWhenFired": 10,
-      "FlatJammingChance": 0.15,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1
     }
   ],
   "statusEffects": [],

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Laser.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Laser.json
@@ -19,7 +19,6 @@
       "AMSShots: 12",
       "AMSHeat: 4",
       "LanceMode: -15%, +4, 20, +50m",
-      "AMSDirectMLAS",
       "JamChanceMode1: 15%, Laser"
     ],
     "Flags": [
@@ -138,19 +137,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "Laser",
-      "UIName": "Laser",
-      "Name": "Laser",
-      "Description": "LAMS Fires as a Medium Laser",
-      "isBaseMode": false,
-      "ShotsWhenFired": 1,
-      "DamagePerShot": 25.0,
-      "HeatGenerated": 10,
-      "FlatJammingChance": 0.15,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1
     }
   ],
   "statusEffects": [],

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Laser_Clan.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Laser_Clan.json
@@ -15,8 +15,7 @@
       "AMSAcc: 40%",
       "AMSShots: 18",
       "AMSHeat: 5",
-      "DamageMode: +2, -10%, +5, 50%",
-      "AMSDirectSLAS"
+      "DamageMode: +2, -10%, +5, 50%"
     ],
     "Flags": [
       "not_broken"
@@ -131,22 +130,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "Laser",
-      "UIName": "Laser",
-      "Name": "Laser",
-      "Description": "LAMS Fires as a Small Pulse Laser",
-      "isBaseMode": false,
-      "ShotsWhenFired": 3,
-      "DamagePerShot": 5.0,
-      "EvasivePipsIgnored": 1,
-      "AccuracyModifier": -1,
-      "HeatGenerated": 0,
-      "FlatJammingChance": 0.15,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1,
-      "FireDelayMultiplier": 0.12
     }
   ],
   "statusEffects": [],

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Mk2.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Mk2.json
@@ -16,9 +16,7 @@
       "AMSAcc: 65%",
       "AMSShots: 35",
       "AMSHeat: 1",
-      "AmmoPerShot: 1.5",
-      "AMSDirectMG: 15",
-      "JamChanceMode1: 15%, MG"
+      "AmmoPerShot: 1.5"
     ],
     "Flags": [
       "not_broken"
@@ -121,19 +119,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "MG",
-      "UIName": "MG",
-      "Name": "Machinegun",
-      "Description": "AMS Fires 15 shots as a MG",
-      "isBaseMode": false,
-      "DamagePerShot": 1.0,
-      "HeatGenerated": 18,
-      "ShotsWhenFired": 15,
-      "FlatJammingChance": 0.15,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1
     }
   ],
   "statusEffects": [],

--- a/Core/RogueModuleTech/RISC/Weapons/Weapon_AMS_Advanced.json
+++ b/Core/RogueModuleTech/RISC/Weapons/Weapon_AMS_Advanced.json
@@ -17,8 +17,7 @@
       "AMSDmg: 1",
       "AMSAcc: 65%",
       "AMSShots: 40",
-      "AMSHeat: 3",
-      "AMSDirectMG: 25"
+      "AMSHeat: 3"
     ],
     "Flags": [
       "not_broken",
@@ -121,19 +120,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "MG",
-      "UIName": "MG",
-      "isBaseMode": false,
-      "Name": "Machinegun",
-      "Description": "AMS Fires 25 shots as a MG",
-      "DamagePerShot": 1.0,
-      "HeatGenerated": 20,
-      "ShotsWhenFired": 25,
-      "FlatJammingChance": 0.3,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1
     }
   ],
   "statusEffects": [],

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_AMS_Laser_Avatar.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_AMS_Laser_Avatar.json
@@ -13,8 +13,7 @@
       "AMSDmg: 2",
       "AMSAcc: 55%",
       "AMSShots: 25",
-      "AMSHeat: 15",
-      "AMSDirectSLAS"
+      "AMSHeat: 15"
     ],
     "Flags": [
       "not_broken",
@@ -116,19 +115,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "Laser",
-      "UIName": "Laser",
-      "Name": "Off",
-      "Description": "LAMS Fires as a Small Laser",
-      "isBaseMode": false,
-      "ShotsWhenFired": 1,
-      "DamagePerShot": 15.0,
-      "HeatGenerated": 10,
-      "FlatJammingChance": 0.1,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1
     }
   ],
   "statusEffects": [],

--- a/Documents/Patch Notes Savebreak.txt
+++ b/Documents/Patch Notes Savebreak.txt
@@ -54,6 +54,7 @@ Holly: Removed
 Irian: -25% AMS hit chance to +1 missile HP
 
 AMS overhaul (the short version):
+MG/Laser modes removed from nearly all AMS
 Adv. AMS: good generalist, but no special modes, slight nerf
 Adv. AMS (P): good ammo economy, but higher fire modes lose some ammo efficiency, slight accuracy nerf
 Adv. LAMS (C): no more lance coverage, single activation mode or sustain mode, best selfish protection in the game

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_AMS_Head.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_AMS_Head.json
@@ -23,7 +23,6 @@
       "AMSShots: 35",
       "AMSHeat: 1",
       "RangeMode: -5%, 25%, +100m",
-      "AMSDirectMG: 15",
       "InternalAmmoBoom: 1",
       "InternalAmmoShot: 200"
     ],
@@ -151,19 +150,6 @@
       "isBaseMode": false,
       "ShotsWhenFired": 0,
       "AMSHitChance": 0.0
-    },
-    {
-      "Id": "MG",
-      "UIName": "MG",
-      "Name": "Machinegun",
-      "Description": "AMS Fires 15 shots as a MG",
-      "isBaseMode": false,
-      "DamagePerShot": 1.0,
-      "HeatGenerated": 18,
-      "ShotsWhenFired": 15,
-      "FlatJammingChance": 0.15,
-      "GunneryJammingMult": 0.01,
-      "GunneryJammingBase": 1
     }
   ],
   "statusEffects": [],


### PR DESCRIPTION
After discussion in #contributers, removed MG/Laser modes from most AMS, since AI doesn't know how to use AMS properly, and they prefer doing any damage from the weapon mode. Only two exceptions are the Disco laser and Adv. AMS (P), at LA's request.

Tested the new LMG mode for Adv. AMS (P) in skirmish mode.