### PR TITLE
Typo and start tweak

### DIFF
--- a/Core/InnerSphereMap/StarSystems/starsystemdef_RimWorldsRepublicOutpost27.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_RimWorldsRepublicOutpost27.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "starsystemdef_RimWorldsRepublicOutpost27",
     "Name": "Rim Worlds Republic Outpost #27",
-    "Details": "Rim Worlds Republic Outpost #27 was a station settled in this system by the Rim Worlds Republic but subsequently abandoned, before being found my pirates who settled here.",
+    "Details": "Rim Worlds Republic Outpost #27 was a station settled in this system by the Rim Worlds Republic but subsequently abandoned, before being found by pirates who settled here.",
     "Icon": ""
   },
   "Position": {

--- a/InstallOptions/ISM2765/patchdef.json
+++ b/InstallOptions/ISM2765/patchdef.json
@@ -12968,16 +12968,7 @@
                         "ConstantName": "StartingSystems"
                     },
                     "patch": {
-                        "ConstantValue": "Terra"
-                    }
-                },
-                {
-                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Royals\"}::DifficultyConstants",
-                    "indexIdentifier": {
-                        "ConstantName": "StartingSystems"
-                    },
-                    "patch": {
-                        "ConstantValue": "Terra"
+                        "ConstantValue": "Epsilon Eridani"
                     }
                 },
                 {
@@ -13253,7 +13244,7 @@
                             {
                                 "ConstantType": "CareerMode",
                                 "ConstantName": "StartingSystems",
-                                "ConstantValue": "Apollo"
+                                "ConstantValue": "Talitha"
                             },
                             {
                                 "ConstantType": "CareerMode",
@@ -13296,6 +13287,15 @@
                                 "ConstantValue": "TerranHegemony:50"
                             }
                         ]
+                    }
+                },
+                {
+                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Royals\"}::DifficultyConstants",
+                    "indexIdentifier": {
+                        "ConstantName": "FactionReputation"
+                    },
+                    "patch": {
+                        "ConstantValue": "SLDF:50"
                     }
                 }
             ]

--- a/InstallOptions/PersistentMapClient/patchdef.json
+++ b/InstallOptions/PersistentMapClient/patchdef.json
@@ -771,7 +771,7 @@
                         "ConstantName": "StartingSystems"
                     },
                     "patch": {
-                        "ConstantValue": "Terra"
+                        "ConstantValue": "Epsilon Eridani"
                     }
                 },
                 {
@@ -1047,7 +1047,7 @@
                             {
                                 "ConstantType": "CareerMode",
                                 "ConstantName": "StartingSystems",
-                                "ConstantValue": "Apollo"
+                                "ConstantValue": "Talitha"
                             },
                             {
                                 "ConstantType": "CareerMode",
@@ -1246,6 +1246,15 @@
                         "ID": "diff_Wobbles"
                     },
                     "patch": {}
+                },
+                {
+                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Royals\"}::DifficultyConstants",
+                    "indexIdentifier": {
+                        "ConstantName": "FactionReputation"
+                    },
+                    "patch": {
+                        "ConstantValue": "SLDF:50"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Fixed a typo in Rim Worlds Outpost #27 (my instead of by) and patched Royal start to use SLDF rep instead of fire mandrils. Moved royal start to epsilon eridani and sldf to talitha