### PR TITLE
Update Weapon_AMS_Laser_Quicsell.json

### DIFF
--- a/Optionals/Quicsell/Weapons/Weapon_AMS_Laser_Quicsell.json
+++ b/Optionals/Quicsell/Weapons/Weapon_AMS_Laser_Quicsell.json
@@ -66,7 +66,7 @@
   "APCriticalChanceMultiplier": 0.5,
   "AOECapable": false,
   "IndirectFireCapable": false,
-  "AMSActivationsPerTurn": 5,
+  "AMSActivationsPerTurn": 3,
   "RefireModifier": 0,
   "ShotsWhenFired": 0,
   "ProjectilesPerShot": 1,

--- a/Optionals/Quicsell/Weapons/Weapon_AMS_Laser_Quicsell.json
+++ b/Optionals/Quicsell/Weapons/Weapon_AMS_Laser_Quicsell.json
@@ -11,7 +11,7 @@
     "BonusDescriptions": [
       "LAMS",
       "AdvAMS",
-      "AMSActivations: 5",
+      "AMSActivations: 3",
       "AMSDmg: 4",
       "AMSAcc: 75%",
       "AMSShots: 6",


### PR DESCRIPTION
With the new state of AMS, QS LAMS is overperforming slightly (especially in early game).
Lowered activations per turn to 3 so it's easier to strategize around, and avoid losing 4-5 missiles from the important barrages.