### PR TITLE
Update carry weight actuators to location only.    AoE description up…

### DIFF
--- a/Core/RogueModuleTech/Actuators/Gear_Actuator_Arm_Lower_Melee_Weapon.json
+++ b/Core/RogueModuleTech/Actuators/Gear_Actuator_Arm_Lower_Melee_Weapon.json
@@ -8,10 +8,10 @@
     "BonusDescriptions": [
       "CBTBEPhysicalAttackAccuracyUpgrade: +1",
       "CBTBEPhysicalBaseModifier: +0.2, +0.1",
-      "CarryWeight: +10%",
+      "CarryWeightArm: +20%",
       "ChassisBasedWeight: 1.5%"
     ],
-    "CarryCapacityFactor": 1.1,
+    "CarryHandCapacityChassisFactor": 0.01,
     "Flags": [
       "not_broken"
     ],

--- a/Core/RogueModuleTech/Actuators/Gear_Actuator_Gripy.json
+++ b/Core/RogueModuleTech/Actuators/Gear_Actuator_Gripy.json
@@ -8,11 +8,11 @@
     "BonusDescriptions": [
       "HandHeldQuirk: +1",
       "CBTBEPhysicalAttackAccuracyUpgrade: +1",
-      "CarryWeight: +5%",
+      "CarryWeightArm: +10%",
       "ChassisBasedWeight: 0.5%",
       "HandActuator"
     ],
-    "CarryCapacityFactor": 1.05,
+    "CarryHandCapacityChassisFactor": 0.055,
     "Flags": [
       "not_broken"
     ],

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -412,7 +412,7 @@
       "Bonus": "AreaOfEffectDmg",
       "Short": "AOEDmg",
       "Long": "AOE {0} Dmg",
-      "Full": "{0} area-of-effect damage to units in radius."
+      "Full": "Up to {0} area-of-effect damage to units in radius.  Units further from the point of impact take less damage"
     },
     {
       "Bonus": "AreaOfEffectHeatDmg",

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Special.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Special.json
@@ -115,6 +115,12 @@
       "Full": "Increases Maximum Carry Weight by {0}."
     },
     {
+      "Bonus": "CarryWeightArm",
+      "Short": "{0} Arm Carry",
+      "Long": "{0} Arm Carry",
+      "Full": "Increases maximum carry weight of this arm by {0}."
+    },
+    {
       "Bonus": "CarryCapacityExplain",
       "Short": "CarryCapacity",
       "Long": "CarryCapacity",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_black_knight_BL-9-KNT.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_black_knight_BL-9-KNT.json
@@ -215,7 +215,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Lootable_HandHeld_Melee_Hatchet_10tons",
+      "ComponentDefID": "Lootable_HandHeld_Melee_Hatchet_9tons",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"


### PR DESCRIPTION
Values of CarryHandCapacityChassisFactor can look a bit weird.   base value defined in the default hand actuator is 0.05
% increases need to be calculated from this.   This stacks additively from multiple sources

The actuator carry bonus is now only applying to 1 arm, so the +% needed to double 

BL-9-KT no longer can carry a 10t hatchet due to difference between multiplicative vs additive stacking.   swapping to 9t hatchet

AoE description now mentions falloff