### PR TITLE
Actuator Bonus Description Update 

### DIFF
--- a/Core/Flashpoints/NecromoNightmare/Internals/Gear_Actuator_MinotaurShoulders.json
+++ b/Core/Flashpoints/NecromoNightmare/Internals/Gear_Actuator_MinotaurShoulders.json
@@ -9,7 +9,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +2",
+      "Turret: +2",
       "RecoilLocation: -2",
       "ChassisBasedWeight: 4%",
       "SuperheavyOnly"

--- a/Core/RogueModuleTech/Actuators/Gear_Actuator_Arm_Upper_Recoil_Plus.json
+++ b/Core/RogueModuleTech/Actuators/Gear_Actuator_Arm_Upper_Recoil_Plus.json
@@ -9,7 +9,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +1",
+      "Turret: +1",
       "RecoilLocation: -1",
       "ChassisBasedWeight: 1%"
     ],

--- a/Core/RogueModuleTech/Actuators/Gear_Actuator_WeaponMount_Accuracy.json
+++ b/Core/RogueModuleTech/Actuators/Gear_Actuator_WeaponMount_Accuracy.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +2",
+      "Turret: +2",
       "CBTBEPhysicalAttackAccuracyUpgrade: -3",
       "CBTBEPunchAttackAccuracyUpgrade: -2",
       "ChassisBasedWeight: 1%"

--- a/Core/RogueModuleTech/Actuators/Gear_Actuator_WeaponMount_Heat.json
+++ b/Core/RogueModuleTech/Actuators/Gear_Actuator_WeaponMount_Heat.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +1",
+      "Turret: +1",
       "HeatGenerated: -3%",
       "CBTBEPhysicalAttackAccuracyUpgrade: -3",
       "CBTBEPunchAttackAccuracyUpgrade: -2",

--- a/Core/RogueModuleTech/Actuators/Gear_Actuator_WeaponMount_Recoil.json
+++ b/Core/RogueModuleTech/Actuators/Gear_Actuator_WeaponMount_Recoil.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +1",
+      "Turret: +1",
       "RecoilLocation: -1",
       "JamChanceMultiplierLocation: -30%",
       "CBTBEPhysicalAttackAccuracyUpgrade: -3",

--- a/Core/RogueModuleTech/Basic/ChassisDefaults/Default_Actuator_Arm_Lower.json
+++ b/Core/RogueModuleTech/Basic/ChassisDefaults/Default_Actuator_Arm_Lower.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +1",
+      "Turret: +1",
       "StandUP: 5%"
     ],
     "Flags": [

--- a/Core/RogueModuleTech/OmniTech/Gear_Actuator_Omni_Lower.json
+++ b/Core/RogueModuleTech/OmniTech/Gear_Actuator_Omni_Lower.json
@@ -7,7 +7,7 @@
     ],
     "BonusDescriptions": [
       "StandUP: 5%",
-      "ArmAccuracy: +1"
+      "Turret: +1"
     ],
     "CriticalEffects": {
       "OnDestroyedEffectIDs": [

--- a/Core/RogueModuleTech/Unique/Gear/Unique_Actuator_CoventryX100.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Actuator_CoventryX100.json
@@ -12,7 +12,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +2",
+      "Turret: +2",
       "RecoilLocation: -2",
       "CBTBEPhysicalAttackAccuracyUpgrade: -3",
       "CBTBEPunchAttackAccuracyUpgrade: -2"

--- a/Core/RogueModuleTech/Upgrade/Gear_ActuatorEnhancementSystem_Arms.json
+++ b/Core/RogueModuleTech/Upgrade/Gear_ActuatorEnhancementSystem_Arms.json
@@ -7,7 +7,7 @@
     ],
     "BonusDescriptions": [
       "ChassisBasedWeight: 2.9%",
-      "ArmAccuracy: +1",
+      "Turret: +1",
       "RecoilLocation: -1",
       "CBTBEPunchAttackAccuracyUpgrade: +1",
       "CBTBEPhysicalAttackAccuracyUpgrade: +1",

--- a/Optionals/Flashpoints/LV426/items/upgrade/Unique_Actuator_Xenorauder_Claws.json
+++ b/Optionals/Flashpoints/LV426/items/upgrade/Unique_Actuator_Xenorauder_Claws.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +2",
+      "Turret: +2",
       "CBTBEPhysicalSupportWeapon",
       "CBTBEPhysicalWeaponHits: +1",
       "CBTBEPhysicalDamageMulti: +20%",

--- a/Optionals/Flashpoints/LV426/items/upgrade/Unique_Actuator_Xenorauder_Claws_Queen.json
+++ b/Optionals/Flashpoints/LV426/items/upgrade/Unique_Actuator_Xenorauder_Claws_Queen.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: +2",
+      "Turret: +2",
       "CBTBEPunchHits: +1",
       "CBTBEPunchAttackAccuracyUpgrade: +2",
       "CBTBEPunchDamageMulti: +40%",

--- a/Optionals/QuicksellCustoms/OmniTech/Gear_Actuator_Omni_Lower_QS.json
+++ b/Optionals/QuicksellCustoms/OmniTech/Gear_Actuator_Omni_Lower_QS.json
@@ -7,7 +7,7 @@
     ],
     "BonusDescriptions": [
       "StandUP: 1%",
-      "ArmAccuracy: +1"
+      "Turret: +1"
     ],
     "CriticalEffects": {
       "OnDestroyedEffectIDs": [

--- a/Optionals/Quicsell/Actuators/Gear_Actuator_Arm_Compact_x3_Quicsell.json
+++ b/Optionals/Quicsell/Actuators/Gear_Actuator_Arm_Compact_x3_Quicsell.json
@@ -12,7 +12,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: -1",
+      "Turret: -1",
       "CBTBEPhysicalAttackAccuracyUpgrade: -1",
       "CBTBEPunchAttackAccuracyUpgrade: -1",
       "CBTBEPhysicalDamageMulti: -10%",

--- a/Optionals/Quicsell/Actuators/Gear_Actuator_Arm_Compact_x4_Quicsell.json
+++ b/Optionals/Quicsell/Actuators/Gear_Actuator_Arm_Compact_x4_Quicsell.json
@@ -15,7 +15,7 @@
       }
     ],
     "BonusDescriptions": [
-      "ArmAccuracy: -1",
+      "Turret: -1",
       "CBTBEPhysicalAttackAccuracyUpgrade: -1",
       "CBTBEPunchAttackAccuracyUpgrade: -1",
       "CBTBEPhysicalDamageMulti: -20%",

--- a/Optionals/Quicsell/Actuators/Gear_Actuator_Arm_Recoil_Quicsell.json
+++ b/Optionals/Quicsell/Actuators/Gear_Actuator_Arm_Recoil_Quicsell.json
@@ -11,7 +11,7 @@
     "BonusDescriptions": [
       "ChassisBasedWeight: 1%",
       "RecoilLocation: -3",
-      "ArmAccuracy: -1",
+      "Turret: -1",
       "JamChanceModifier: +2%"
     ],
     "Flags": [


### PR DESCRIPTION
 "Full": "{0} accuracy with arm-mounted weapons."  can be misinterpreted as actuators adding accuracy to both arms

"Full": "{0} accuracy to weapons mounted in the same location." is unambiguous