### PR TITLE
EWS Ping is not UAV now

### DIFF
--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Scout.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Scout.json
@@ -18,6 +18,7 @@
       "Neith_40",
       "NightshadeVTOL_25",
       "Packrat_20",
+      "PathTrackDrone_3",
       "Pegasus_35",
       "WeaponsCarrier_20",
       "WeaponsCarrier_30",

--- a/Core/RogueModuleTech/AddOn/Specials/Special_AddOn_UAV.json
+++ b/Core/RogueModuleTech/AddOn/Specials/Special_AddOn_UAV.json
@@ -114,7 +114,7 @@
       "Description": {
         "Id": "DeployUnit",
         "Name": "Deploy UAV",
-        "Details": "DEPLOYS A UAV FROM THE UNIT'S STORAGE.\r\n\r\n <b><color=#8080ff>Base Resolve Cost: 10</color></b>\r\n\r\n <b><color=#e11919>Costs 10 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only deploy in one UAV per contract!</color></b>",
+        "Details": "DEPLOYS A UAV FROM THE UNIT'S STORAGE.\r\n\r\n <b><color=#e11919>Costs 10 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only deploy in one UAV per contract!</color></b>",
         "Icon": "uav"
       },
       "activeAbilityEffectData": {

--- a/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole.json
+++ b/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole.json
@@ -37,14 +37,6 @@
       "Sharer",
       "BleedReduction: 40%"
     ],
-    "ActivatableComponent": {
-      "CanNotBeActivatedManualy": true,
-      "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
-      "DeactivationMessage": "",
-      "statusEffects": [],
-      "offlineStatusEffects": []
-    },
     "Flags": [
       "not_broken"
     ],

--- a/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole_Armored.json
+++ b/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole_Armored.json
@@ -38,14 +38,6 @@
       "BleedReduction: 40%",
       "CritRes: 40%"
     ],
-    "ActivatableComponent": {
-      "CanNotBeActivatedManualy": true,
-      "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
-      "DeactivationMessage": "",
-      "statusEffects": [],
-      "offlineStatusEffects": []
-    },
     "Flags": [
       "not_broken"
     ],

--- a/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_AR12.json
+++ b/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_AR12.json
@@ -32,7 +32,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -108,8 +108,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_AR12.json
+++ b/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_AR12.json
@@ -14,7 +14,7 @@
         "CategoryID": "AdvECM"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "WorkOrderCosts": {

--- a/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EWS.json
+++ b/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EWS.json
@@ -33,7 +33,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -328,8 +328,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EWS.json
+++ b/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EWS.json
@@ -14,7 +14,7 @@
         "CategoryID": "AdvECM"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "WorkOrderCosts": {

--- a/Core/RogueModuleTech/Quirks/Upgrades/Quirk_AR20.json
+++ b/Core/RogueModuleTech/Quirks/Upgrades/Quirk_AR20.json
@@ -14,7 +14,7 @@
         "CategoryID": "PositiveQuirk"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "WorkOrderCosts": {

--- a/Core/RogueModuleTech/Quirks/Upgrades/Quirk_AR20.json
+++ b/Core/RogueModuleTech/Quirks/Upgrades/Quirk_AR20.json
@@ -34,7 +34,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -334,8 +334,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_Sensors_AR14-RTO.json
+++ b/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_Sensors_AR14-RTO.json
@@ -35,7 +35,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -138,8 +138,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_Sensors_AR14-RTO.json
+++ b/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_Sensors_AR14-RTO.json
@@ -17,7 +17,7 @@
         "CategoryID": "C3"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "WorkOrderCosts": {

--- a/Core/RogueModuleTech/SuperHeavy/Gear/Unique_AdvancedCommandModule_Mk2.json
+++ b/Core/RogueModuleTech/SuperHeavy/Gear/Unique_AdvancedCommandModule_Mk2.json
@@ -35,7 +35,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -1597,7 +1597,7 @@
         "Icon": "uixSvgIcon_action_sensorlock"
       },
       "activeAbilityEffectData": {
-        "abilityName": "AbilityDef_UAV_D500_H20_CD6"
+        "abilityName": "AbilityDef_Ping_D500_H20_CD6"
       }
     },
     {

--- a/Core/RogueModuleTech/SuperHeavy/Gear/Unique_AdvancedCommandModule_Mk2.json
+++ b/Core/RogueModuleTech/SuperHeavy/Gear/Unique_AdvancedCommandModule_Mk2.json
@@ -11,7 +11,7 @@
         "CategoryID": "AdvUAV"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "BonusDescriptions": [

--- a/Core/RogueModuleTech/Unique/Gear/Unique_AdvancedCommandModule.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_AdvancedCommandModule.json
@@ -35,7 +35,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -1533,7 +1533,7 @@
         "Icon": "uixSvgIcon_action_sensorlock"
       },
       "activeAbilityEffectData": {
-        "abilityName": "AbilityDef_UAV_D500_H20_CD6"
+        "abilityName": "AbilityDef_Ping_D500_H20_CD6"
       }
     },
     {

--- a/Core/RogueModuleTech/Unique/Gear/Unique_AdvancedCommandModule.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_AdvancedCommandModule.json
@@ -11,7 +11,7 @@
         "CategoryID": "AdvUAV"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "BonusDescriptions": [

--- a/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Overcharged.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Overcharged.json
@@ -11,7 +11,7 @@
         "CategoryID": "AdvECM"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "BonusDescriptions": [

--- a/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Overcharged.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Overcharged.json
@@ -24,7 +24,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -322,8 +322,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Prototype.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Prototype.json
@@ -11,7 +11,7 @@
         "CategoryID": "AdvECM"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "BonusDescriptions": [

--- a/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Prototype.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_EWS_Prototype.json
@@ -24,7 +24,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -323,8 +323,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR12.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR12.json
@@ -32,7 +32,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -112,8 +112,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR12.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR12.json
@@ -14,7 +14,7 @@
         "CategoryID": "AdvECM"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "WorkOrderCosts": {

--- a/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR14.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR14.json
@@ -17,7 +17,7 @@
         "CategoryID": "C3"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "WorkOrderCosts": {

--- a/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR14.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Sensors_AR14.json
@@ -35,7 +35,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -141,8 +141,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/Upgrade/Gear_EWS.json
+++ b/Core/RogueModuleTech/Upgrade/Gear_EWS.json
@@ -24,7 +24,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -320,8 +320,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Core/RogueModuleTech/Upgrade/Gear_EWS.json
+++ b/Core/RogueModuleTech/Upgrade/Gear_EWS.json
@@ -11,7 +11,7 @@
         "CategoryID": "AdvECM"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       }
     ],
     "BonusDescriptions": [

--- a/Core/RogueModuleTech/Vehicle/Upgrades/Gear_Vehicle_CommunicationsEquipment.json
+++ b/Core/RogueModuleTech/Vehicle/Upgrades/Gear_Vehicle_CommunicationsEquipment.json
@@ -11,7 +11,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -650,7 +650,7 @@
         "Icon": "uixSvgIcon_action_sensorlock"
       },
       "activeAbilityEffectData": {
-        "abilityName": "AbilityDef_UAV_D500_H20_CD6"
+        "abilityName": "AbilityDef_Ping_D500_H20_CD6"
       }
     },
     {

--- a/Core/RogueModuleTech/Vehicle/Upgrades/Gear_Vehicle_CommunicationsEquipment_Double.json
+++ b/Core/RogueModuleTech/Vehicle/Upgrades/Gear_Vehicle_CommunicationsEquipment_Double.json
@@ -11,7 +11,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -681,7 +681,7 @@
         "Icon": "uixSvgIcon_action_sensorlock"
       },
       "activeAbilityEffectData": {
-        "abilityName": "AbilityDef_UAV_D500_H20_CD2"
+        "abilityName": "AbilityDef_Ping_D500_H20_CD2"
       }
     },
     {

--- a/Core/RogueTechCore/UAVAbilities/AbilityDef_EWS_Ping.json
+++ b/Core/RogueTechCore/UAVAbilities/AbilityDef_EWS_Ping.json
@@ -10,5 +10,5 @@
   "ActivationCooldown": 2,
   "FloatParam1": 310.0,
   "FloatParam2": 15.0,
-  "StringParam1": "UAV is unavailable."
+  "StringParam1": "Ping is unavailable."
 }

--- a/Core/RogueTechCore/UAVAbilities/AbilityDef_Ping_D250_H5_CD3.json
+++ b/Core/RogueTechCore/UAVAbilities/AbilityDef_Ping_D250_H5_CD3.json
@@ -1,14 +1,14 @@
 {
   "Description": {
-    "Id": "AbilityDef_UAV_D500_H20_CD6",
+    "Id": "AbilityDef_Ping_D250_H5_CD3",
     "Name": "SpySat PING",
     "Details": "ACTION: Perform a Sensor Lock on all enemies within [FloatParam1] meters, and generates [FloatParam2] Heat for the user. There is a [ActivationCooldown] round cooldown and Ends your Turn.",
     "Icon": "uixSvgIcon_action_sensorlock"
   },
   "ActivationTime": "ConsumedByFiring",
   "Targeting": "ActiveProbe",
-  "ActivationCooldown": 6,
-  "FloatParam1": 500.0,
-  "FloatParam2": 20.0,
+  "ActivationCooldown": 3,
+  "FloatParam1": 250.0,
+  "FloatParam2": 5.0,
   "StringParam1": "Satellite unavailable."
 }

--- a/Core/RogueTechCore/UAVAbilities/AbilityDef_Ping_D500_H20_CD2.json
+++ b/Core/RogueTechCore/UAVAbilities/AbilityDef_Ping_D500_H20_CD2.json
@@ -1,6 +1,6 @@
 {
   "Description": {
-    "Id": "AbilityDef_UAV_D500_H20_CD2",
+    "Id": "AbilityDef_Ping_D500_H20_CD2",
     "Name": "SpySat PING",
     "Details": "ACTION: Perform a Sensor Lock on all enemies within [FloatParam1] meters, and generates [FloatParam2] Heat for the user. There is a [ActivationCooldown] round cooldown and Ends your Turn.",
     "Icon": "uixSvgIcon_action_sensorlock"
@@ -8,7 +8,7 @@
   "ActivationTime": "ConsumedByFiring",
   "Targeting": "ActiveProbe",
   "ActivationCooldown": 2,
-  "FloatParam1": 600.0,
+  "FloatParam1": 500.0,
   "FloatParam2": 20.0,
   "StringParam1": "Satellite unavailable."
 }

--- a/Core/RogueTechCore/UAVAbilities/AbilityDef_Ping_D500_H20_CD6.json
+++ b/Core/RogueTechCore/UAVAbilities/AbilityDef_Ping_D500_H20_CD6.json
@@ -1,14 +1,14 @@
 {
   "Description": {
-    "Id": "AbilityDef_UAV_D250_H5_CD3",
-    "Name": "UAV PING",
+    "Id": "AbilityDef_Ping_D500_H20_CD6",
+    "Name": "SpySat PING",
     "Details": "ACTION: Perform a Sensor Lock on all enemies within [FloatParam1] meters, and generates [FloatParam2] Heat for the user. There is a [ActivationCooldown] round cooldown and Ends your Turn.",
     "Icon": "uixSvgIcon_action_sensorlock"
   },
   "ActivationTime": "ConsumedByFiring",
   "Targeting": "ActiveProbe",
-  "ActivationCooldown": 3,
-  "FloatParam1": 250.0,
-  "FloatParam2": 5.0,
-  "StringParam1": "UAV is unavailable."
+  "ActivationCooldown": 6,
+  "FloatParam1": 500.0,
+  "FloatParam2": 20.0,
+  "StringParam1": "Satellite unavailable."
 }

--- a/Core/RogueTechCore/UAVAbilities/AbilityDef_UAV_Ping.json
+++ b/Core/RogueTechCore/UAVAbilities/AbilityDef_UAV_Ping.json
@@ -10,5 +10,5 @@
   "ActivationCooldown": 3,
   "FloatParam1": 250.0,
   "FloatParam2": 5.0,
-  "StringParam1": "UAV is unavailable."
+  "StringParam1": "Ping is unavailable."
 }

--- a/Core/RogueTechCore/UAVAbilities/AbilityDef_WDEWS_Ping.json
+++ b/Core/RogueTechCore/UAVAbilities/AbilityDef_WDEWS_Ping.json
@@ -10,5 +10,5 @@
   "ActivationCooldown": 4,
   "FloatParam1": 360.0,
   "FloatParam2": 15.0,
-  "StringParam1": "UAV is unavailable."
+  "StringParam1": "Ping is unavailable."
 }

--- a/Core/RogueTechCore/categories/Categories_EWS.json
+++ b/Core/RogueTechCore/categories/Categories_EWS.json
@@ -29,6 +29,20 @@
       ]
     },
     {
+      "Name": "SensorPing",
+      "DisplayName": "Sensor Ping",
+      "DefaultCustoms": {
+        "TRGBColor": {
+          "Color": "#CC91FF"
+        }
+      },
+      "BaseLimits": [
+        {
+          "Max": 1
+        }
+      ]
+    },
+    {
       "Name": "Searchlight",
       "DisplayName": "Searchlight",
       "DefaultCustoms": {

--- a/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch_DroneController.json
+++ b/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch_DroneController.json
@@ -1,0 +1,22 @@
+{
+  "Description": {
+    "Id": "AbilityDefCMD_UAVLaunch_DroneController",
+    "Name": "UAV Launch",
+    "Details": "DEPLOYS A UAV FROM THE UNIT'S STORAGE.\r\n\r\n <b><color=#e11919>Costs 10 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only deploy in one UAV per contract!</color></b>",
+    "Icon": "uav"
+  },
+  "ActivationTime": "CommandAbility",
+  "Resource": "CommandAbility",
+  "ActivationCooldown": 2,
+  "NumberOfUses": 4,
+  "specialRules": "SpawnTurret",
+  "Targeting": "CommandSpawnPosition",
+  "ActorResource": "vehicledef_UAV_Drone",
+  "StringParam1": "UAV Deployment Unavailable",
+  "StringParam2": "Contract_Drone",
+  "FloatParam1": 50,
+  "FloatParam2": 50,
+  "IntParam2": 120,
+  "CBillCost": 10000,
+  "CMDPilotOverride": "pilot_vehicle_droneoperator"
+}

--- a/Documents/Patch Notes Scratch Pad.txt
+++ b/Documents/Patch Notes Scratch Pad.txt
@@ -1,3 +1,6 @@
+Special UAV - Now compatible with various EWS
+Ingame labeling of AOE sensor pings tweaked to no longer refer to them as UAV.
+
 Vehicles:
 Schrek AC Carrier - Schrek AC
 Schrek Command Tank - Schrek Command

--- a/Documents/Patch Notes Scratch Pad.txt
+++ b/Documents/Patch Notes Scratch Pad.txt
@@ -1,3 +1,6 @@
+1.0.1X
+
+Misc:
 Special UAV - Now compatible with various EWS
 Ingame labeling of AOE sensor pings tweaked to no longer refer to them as UAV.
 
@@ -30,6 +33,10 @@ Weapons:
 VSPL Lasers (ALL) - Removed incorrect blue text from description.
 RISC MML (ALL) - Maximum range in LRM mode 690 to 840
 Rotary AC/10 RISC - Dmg. 56-55. Short 180-150, Med 360-300, Long 510-450, Extreme 570-600
+
+WIP stuff, don't changelog :
+AbilityDefCMD_UAVLaunch_DroneController - new drone launch ability
+vehicledef_UGV_PATHTRACK - New drone not yet in use.
 
 1.0.12
 

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_UGV_PATHTRACK.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_UGV_PATHTRACK.json
@@ -2,77 +2,55 @@
   "VehicleTags": {
     "items": [
       "NOSALVAGE",
-      "mr-resize-0.57",
+      "mr-resize-0.49",
       "unit_drone",
-      "unit_uav",
-      "apply_bomb_drag_tag",
+      "unit_tracks",
       "unit_release"
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "vehiclechassisdef_UAV_Drone",
+  "ChassisID": "vehiclechassisdef_UGV_PATHTRACK",
   "Description": {
-    "Cost": 62911,
+    "Cost": 30000,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "UAV",
-    "Id": "vehicledef_UAV_Drone",
-    "Name": "UAV",
-    "Details": "This is a 0.5 ton spotter UAV.",
-    "Icon": "uav"
+    "UIName": "Pathtrack UGV",
+    "Id": "vehicledef_UGV_PATHTRACK",
+    "Name": "Pathtrack UGV",
+    "Details": "",
+    "Icon": "Swiftwind"
   },
   "Locations": [
     {
       "Location": "Front",
-      "CurrentArmor": 5,
+      "CurrentArmor": 10,
       "CurrentInternalStructure": 5,
-      "AssignedArmor": 5,
+      "AssignedArmor": 10,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Left",
-      "CurrentArmor": 5,
+      "CurrentArmor": 10,
       "CurrentInternalStructure": 5,
-      "AssignedArmor": 5,
+      "AssignedArmor": 10,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Right",
-      "CurrentArmor": 5,
+      "CurrentArmor": 10,
       "CurrentInternalStructure": 5,
-      "AssignedArmor": 5,
+      "AssignedArmor": 10,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Rear",
-      "CurrentArmor": 5,
+      "CurrentArmor": 10,
       "CurrentInternalStructure": 5,
-      "AssignedArmor": 5,
-      "DamageLevel": "Functional"
-    },
-    {
-      "Location": "Turret",
-      "CurrentArmor": 5,
-      "CurrentInternalStructure": 5,
-      "AssignedArmor": 5,
+      "AssignedArmor": 10,
       "DamageLevel": "Functional"
     }
   ],
   "inventory": [
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "BoltOn_Weapon_RemoteSensor",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Weapon_PowerArmor_Rocket_Heavy_2",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
     {
       "MountedLocation": "Front",
       "ComponentDefID": "Weapon_PowerArmor_TAG",
@@ -102,15 +80,29 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Default_Armor_Standard",
+      "MountedLocation": "Left",
+      "ComponentDefID": "Default_Vehicle_Motive_Tracked_Left",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Right",
+      "ComponentDefID": "Default_Vehicle_Motive_Tracked_Right",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "VehicleTrait_Micro",
+      "ComponentDefID": "Gear_Probe_Active",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Default_Armor_Standard",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -124,21 +116,28 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Quirk_Vehicle_ImprovedComms",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Turret",
-      "ComponentDefID": "Default_Vehicle_Motive_VTOL",
+      "ComponentDefID": "Default_Vehicle_Motive_Tracked_Defaultbox",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_PowerArmor_EngineCore_002",
+      "ComponentDefID": "Quirk_Vehicle_ImprovedComms",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_EngineCore_025",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Gear_Engine_FuelCell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -146,13 +145,6 @@
     {
       "MountedLocation": "Rear",
       "ComponentDefID": "Gear_Vehicle_EngineCooling_CoolantSystem",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_Engine_Standard",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_UGV_PATHTRACK.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_UGV_PATHTRACK.json
@@ -1,0 +1,115 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "PathTrackDrone",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "FiringArc": 50,
+    "CustomParts": [],
+    "CrewLocation": "None"
+  },
+  "Description": {
+    "Cost": 30000,
+    "Rarity": 0,
+    "Purchasable": false,
+    "UIName": "Pathtrack UGV",
+    "Id": "vehiclechassisdef_UGV_PATHTRACK",
+    "Name": "Pathtrack UGV",
+    "Details": "",
+    "Icon": "Swiftwind"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_8-12cv",
+  "movementType": "Tracked",
+  "PathingCapDefID": "pathingdef_ultralight_vehicle",
+  "HardpointDataDefID": "hardpointdatadef_swiftwind",
+  "PrefabIdentifier": "chrPrfVhcl_swiftwind",
+  "PrefabBase": "swiftwind",
+  "Tonnage": 3,
+  "weightClass": "LIGHT",
+  "BattleValue": 564,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 2,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "z": 3.5
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3.5,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 2,
+      "z": 3.5
+    },
+    {
+      "x": -1.5,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 1.5,
+      "y": 2.5,
+      "z": 0
+    },
+    {
+      "x": 0,
+      "y": 2.25,
+      "z": -2.75
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 65,
+      "InternalStructure": 5
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 35,
+      "InternalStructure": 5
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 35,
+      "InternalStructure": 5
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 30,
+      "InternalStructure": 5
+    }
+  ]
+}

--- a/Optionals/RISCtech/Base/Items/Upgrade/Gear_EWS_RISC.json
+++ b/Optionals/RISCtech/Base/Items/Upgrade/Gear_EWS_RISC.json
@@ -31,7 +31,7 @@
     "ActivatableComponent": {
       "CanNotBeActivatedManualy": true,
       "NoUniqueCheck": true,
-      "ActivationMessage": "UAV",
+      "ActivationMessage": "Ping",
       "DeactivationMessage": "",
       "statusEffects": [],
       "offlineStatusEffects": []
@@ -532,8 +532,8 @@
       },
       "effectType": "ActiveAbility",
       "Description": {
-        "Id": "UAV_Ping",
-        "Name": "UAV PING",
+        "Id": "EWS_Ping",
+        "Name": "EWS PING",
         "Details": "Activated ability (uses Firing action). Performs a Sensor Lock against all enemies within its radius, as indicated by the spinning gold ring. Will go into cooldown state after use.",
         "Icon": "uixSvgIcon_action_sensorlock"
       },

--- a/Optionals/RISCtech/Base/Items/Upgrade/Gear_EWS_RISC.json
+++ b/Optionals/RISCtech/Base/Items/Upgrade/Gear_EWS_RISC.json
@@ -11,7 +11,7 @@
         "CategoryID": "AdvECM"
       },
       {
-        "CategoryID": "UAV"
+        "CategoryID": "SensorPing"
       },
       {
         "CategoryID": "C3Equipment"


### PR DESCRIPTION
I made a new category called "SensorPing" for AOE sensor lock items and switched them to it. They are no longer incompatible with the physical UAV item. Ingame text has been changed to reduce player confusing now that UAV are a "real" thing.