### PR TITLE
LAM weapon tab categories - ticket 8847

### DIFF
--- a/Core/CustomComponents/mod.json
+++ b/Core/CustomComponents/mod.json
@@ -134,8 +134,8 @@
                         { "Tag" : "w/s/m/energy", "Color" : "#917a51f0" },
                         { "Tag" : "w/s/m/pa", "Color" : "#917a51f0" },
                         { "Tag" : "w/s/m/explode", "Color" : "#c01836f0" },
-                        { "Tag" : "w/s/m/bomb", "Color" : "#c01836f0" },
-						{ "Tag" : "w/s/m/InternalBombBay", "Color" : "#c01836f0" },
+                        { "Tag" : "w/w/w/bomb", "Color" : "#c01836f0" },
+						{ "Tag" : "w/b/b/InternalBombBay", "Color" : "#c01836f0" },
                         { "Tag" : "w/s/h/HandHeld", "Color" : "#cc9900" },
                         { "Tag" : "w/s/h/BoltOn", "Color" : "#cc9900" },
 

--- a/Core/CustomFilters/RogueTechTabs.json
+++ b/Core/CustomFilters/RogueTechTabs.json
@@ -176,7 +176,6 @@
             "w/s/m/energy",
             "w/s/m/pa",
             "w/s/m/explode",
-            "w/s/m/bomb",
             "w/s/m/support",
             "ProtoAC",
             "Fusiliade",
@@ -191,11 +190,13 @@
       {
         "Icon": "HandHeldRifle",
         "Tag": "",
-        "Tooltip": "Show Specialist Weapons",
+        "Tooltip": "Show Specialist & LAM Weapons",
         "Filter": {
           "Categories": [
             "w/s/h/HandHeld",
-            "w/s/h/BoltOn"
+            "w/s/h/BoltOn",
+            "w/b/b/InternalBombBay",
+            "w/w/w/bomb"
           ]
         }
       },
@@ -280,6 +281,8 @@
             "w/s/m/explode",
             "w/s/h/HandHeld",
             "w/s/h/BoltOn",
+            "w/b/b/InternalBombBay",
+            "w/w/w/bomb",
             "ProtoAC",
             "Fusiliade",
             "iFusiliade",
@@ -450,8 +453,7 @@
             "a/m/t/thunderbolt",
             "a/m/t/arrowiv",
             "a/m/t/cruisemissile",
-            "w/s/m/InternalBombBay",
-            "w/s/m/bomb"
+            "a/w/w/bomb"
           ]
         }
       },
@@ -532,9 +534,7 @@
             "a/a/a/rac",
             "a/a/a/shrac",
             "a/a/a/uac",
-            "w/s/m/InternalBombBay",
-            "w/s/m/bomb",
-            "WingMountedAmmo"
+            "a/w/w/bomb"
           ]
         }
       },

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_DaisyCutter.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_DaisyCutter.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_MOAB.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_MOAB.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAA_Arrow.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAA_Arrow.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAiATM_12_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAiATM_12_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_ArrowIV.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_ArrowIV.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x1.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Phoenix_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Phoenix_x3.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15_x4.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_AA_25.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_AA_25.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Large.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Large.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Medium.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Medium.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemPulse.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemPulse.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_NARC.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_NARC.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_TAG.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_TAG.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_Vulcan.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_Vulcan.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Flare.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Flare.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Hellfire.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Hellfire.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile_x2.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_TBM5.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_TBM5.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "a/w/w/bomb"
       },
       {
         "CategoryID": "LAMBombBayAmmo"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/Weapons/Weapon_Universal_BombChute.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/Weapons/Weapon_Universal_BombChute.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/InternalBombBay"
+        "CategoryID": "w/b/b/InternalBombBay"
       },
       {
         "CategoryID": "LAMInternalBombBay"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/Weapons/Weapon_Universal_InternalBombBay.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/Weapons/Weapon_Universal_InternalBombBay.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/InternalBombBay"
+        "CategoryID": "w/b/b/InternalBombBay"
       },
       {
         "CategoryID": "LAMInternalBombBay"

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/Weapons/Weapon_Universal_MissileTube.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/Weapons/Weapon_Universal_MissileTube.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/InternalBombBay"
+        "CategoryID": "w/b/b/InternalBombBay"
       },
       {
         "CategoryID": "LAMInternalBombBay"

--- a/Core/RogueTechCore/categories/Categories_Ammo.json
+++ b/Core/RogueTechCore/categories/Categories_Ammo.json
@@ -127,7 +127,7 @@
       }
     },
     {
-      "Name": "/a/g/magshot",
+      "Name": "a/a/g/magshot",
       "DisplayName": "Magshot",
       "DefaultCustoms": {
         "ColorTag": "w/a/g/magshot",
@@ -347,6 +347,15 @@
       "DisplayName": "Support Weapon Ammo",
       "DefaultCustoms": {
         "ColorTag": "w/s/m/support"
+      }
+    },
+    {
+      "Name": "a/w/w/bomb",
+      "DisplayName": "Bay Weapon Ammo",
+      "DefaultCustoms": {
+        "ColorTag": "w/w/w/bomb",
+        "Sorter": 700,
+        "InventorySorter": "700"
       }
     },
     {

--- a/Core/RogueTechCore/categories/Categories_LAM.json
+++ b/Core/RogueTechCore/categories/Categories_LAM.json
@@ -61,10 +61,6 @@
       ]
     },
     {
-      "Name": "WingMountedAmmo",
-      "DisplayName": "LAM Munitions"
-    },
-    {
       "Name": "LAMBAWingmountBay",
       "DisplayName": "BattleArmor Wingmount"
     },

--- a/Core/RogueTechCore/categories/Categories_Weapons.json
+++ b/Core/RogueTechCore/categories/Categories_Weapons.json
@@ -631,31 +631,35 @@
       }
     },
     {
-      "Name": "w/s/m/bomb",
-      "DisplayName": "Aircraft Weapon",
-      "DefaultCustoms": {
-        "ColorTag": "w/s/m/bomb"
-      }
-    },
-    {
-      "Name": "w/s/m/InternalBombBay",
-      "DisplayName": "Internal Weapons Bay",
-      "DefaultCustoms": {
-        "ColorTag": "w/s/m/bomb"
-      }
-    },
-    {
       "Name": "w/s/h/HandHeld",
       "DisplayName": "Hand Held Weapon",
       "DefaultCustoms": {
-        "ColorTag": "w/s/h/HandHeld"
+        "ColorTag": "w/s/h/HandHeld",
+        "Sorter": 420
       }
     },
     {
       "Name": "w/s/h/BoltOn",
       "DisplayName": "Bolt On Weapon",
       "DefaultCustoms": {
-        "ColorTag": "w/s/h/BoltOn"
+        "ColorTag": "w/s/h/BoltOn",
+        "Sorter": 425
+      }
+    },
+    {
+      "Name": "w/w/w/bomb",
+      "DisplayName": "Aircraft Weapon",
+      "DefaultCustoms": {
+        "ColorTag": "w/w/w/bomb",
+        "Sorter": 430
+      }
+    },
+    {
+      "Name": "w/b/b/InternalBombBay",
+      "DisplayName": "Internal Weapons Bay",
+      "DefaultCustoms": {
+        "ColorTag": "w/w/w/bomb",
+        "Sorter": 435
       }
     }
   ]

--- a/Core/RogueTechCore/tagRestrictions/TagRestrictions_LAM.json
+++ b/Core/RogueTechCore/tagRestrictions/TagRestrictions_LAM.json
@@ -81,17 +81,6 @@
       ]
     },
     {
-      "Tag": "WingMountedAmmo",
-      "RequiredTags": [
-        "LandAirMech",
-        "LAM-Structure",
-        "LAM-Armor",
-        "LAM-Engine",
-        "LAMFlightSystems",
-        "LAMWingMount"
-      ]
-    },
-    {
       "Tag": "LAMWeaponsBay",
       "RequiredTags": [
         "LandAirMech",

--- a/Optionals/QuicksellCustoms/Weapons/Weapon_WingMount_Firecracker.json
+++ b/Optionals/QuicksellCustoms/Weapons/Weapon_WingMount_Firecracker.json
@@ -2,7 +2,7 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "w/s/m/bomb"
+        "CategoryID": "w/w/w/bomb"
       },
       {
         "CategoryID": "LAMWingMount"


### PR DESCRIPTION
I think I figured out the meaning of the naming convention of the category id and adjusted mine. I seperated the categories of the Bomb ammo from the Bomb oneshot weapons. Put weapon category in weapon tabs, put ammo category in ammo tabs. Deleted an old relic of previous LAM system.