### PR TITLE
Convoy tagging and Sherpa

### DIFF
--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_APC_DAIMYO_HQ_67_K2.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_APC_DAIMYO_HQ_67_K2.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_lance_support",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_release",
       "unit_advanced",
       "unit_bracket_med",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BADGER_C_E.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BADGER_C_E.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BADGER_C_H.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BADGER_C_H.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "RavenAlliance",
       "EscorpionImperio",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BAILEY.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BAILEY.json
@@ -9,6 +9,7 @@
       "unit_release",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_advanced",
       "unit_bracket_low",
       "wordofblake",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BANDIT-E_CLAN.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BANDIT-E_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "EscorpionImperio",
       "RavenAlliance",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BANDIT-H_CLAN.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BANDIT-H_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_vanguard",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "RavenAlliance",
       "EscorpionImperio",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BLIZZARD_SRM.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_BLIZZARD_SRM.json
@@ -8,6 +8,7 @@
       "unit_hover",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_A.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_A.json
@@ -5,6 +5,7 @@
       "unit_vehicle",
       "unit_vehicle_clan",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_proxy_model",
       "unit_proxy_icon",
       "omni_tank",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_B.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_B.json
@@ -6,6 +6,7 @@
       "unit_vehicle",
       "unit_vehicle_clan",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_proxy_model",
       "unit_proxy_icon",
       "omni_tank",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_C.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_C.json
@@ -6,6 +6,7 @@
       "unit_vehicle",
       "unit_vehicle_clan",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_proxy_model",
       "unit_proxy_icon",
       "omni_tank",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_D.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_D.json
@@ -6,6 +6,7 @@
       "unit_vehicle",
       "unit_vehicle_clan",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_proxy_model",
       "unit_proxy_icon",
       "omni_tank",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_PRIME.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_HEPHAESTUS_ST_PRIME.json
@@ -5,6 +5,7 @@
       "unit_vehicle",
       "unit_vehicle_clan",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_proxy_model",
       "unit_proxy_icon",
       "omni_tank",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_MOBILEHQ_C3M.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_MOBILEHQ_C3M.json
@@ -9,6 +9,7 @@
       "unit_lance_support",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_advanced",
       "unit_bracket_med",
       "unit_command",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_MORNINGSTAR.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_MORNINGSTAR.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_tank",
       "unit_lance_support",
       "unit_advanced",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_MORNINGSTAR_LASER.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_MORNINGSTAR_LASER.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_tank",
       "unit_lance_assassin",
       "unit_advanced",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_SVANTOVIT_ATM_CLAN.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_SVANTOVIT_ATM_CLAN.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_noconvoy",
       "unit_generic",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_TYR.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_TYR.json
@@ -11,6 +11,7 @@
       "unit_lance_vanguard",
       "unit_lance_assassin",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_advanced",
       "unit_bracket_med",
       "clandiamondshark",

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT.json
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT.json
@@ -10,6 +10,7 @@
       "unit_bracket_low",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_noconvoy",
       "republic",
       "comstar",

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_1.json
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_1.json
@@ -11,6 +11,7 @@
       "unit_bracket_low",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "FroncReaches",
       "RimCommonality",
       "OrienteProtectorate",

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_ICE.json
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_ICE.json
@@ -12,6 +12,7 @@
       "NoBiome_martianVacuum",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "FroncReaches",
       "RimCommonality",
       "OrienteProtectorate",

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_ML.json
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_ML.json
@@ -10,6 +10,7 @@
       "unit_bracket_low",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "DuchyOfAndurien",
       "RimCommonality",
       "RegulanFiefs",

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_SRM2.json
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/vehicle/vehicledef_PACKRAT_SRM2.json
@@ -9,6 +9,7 @@
       "unit_bracket_low",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_noconvoy",
       "FroncReaches",
       "ives",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_APC_INDRA_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_APC_INDRA_CLAN.json
@@ -7,6 +7,7 @@
       "unit_light",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_lance_tank",
       "unit_release",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_APC_MAXIM_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_APC_MAXIM_CLAN.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_A.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_A.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_B.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_B.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_C.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_C.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_D.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_D.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "ClanWolfInExile",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_PRIME.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BADGER_C_PRIME.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-A_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-A_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-B_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-B_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-C_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-C_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_vanguard",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-D_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-D_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-I_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT-I_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_BANDIT_CLAN.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "EscorpionImperio",
       "clansgeneric",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_GOBLIN_EC.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_GOBLIN_EC.json
@@ -9,6 +9,7 @@
       "unit_lance_tank",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_low",
       "unit_rt_custom",
       "unit_early_clan",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_GOBLIN_LRM_EC.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_GOBLIN_LRM_EC.json
@@ -10,6 +10,7 @@
       "unit_lance_tank",
       "unit_indirectFire",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "unit_rt_custom",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_GOBLIN_SRM_EC.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_GOBLIN_SRM_EC.json
@@ -9,6 +9,7 @@
       "unit_lance_assassin",
       "unit_lance_tank",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "unit_rt_custom",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_SVANTOVIT_IFV_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_SVANTOVIT_IFV_CLAN.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_noconvoy",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_SVANTOVIT_MORTAR_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_SVANTOVIT_MORTAR_CLAN.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_noconvoy",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_SVANTOVIT_ORIGINAL_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_SVANTOVIT_ORIGINAL_CLAN.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_noconvoy",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_2_PRIMITIVE.json
+++ b/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_2_PRIMITIVE.json
@@ -12,6 +12,7 @@
       "unit_indirectFire",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_primitive",
       "comstar",
       "liao",

--- a/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_JUMBO2_PRIMITIVE.json
+++ b/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_JUMBO2_PRIMITIVE.json
@@ -12,6 +12,7 @@
       "unit_indirectFire",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_primitive",
       "comstar",
       "liao",

--- a/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_JUMBO_PRIMITIVE.json
+++ b/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_JUMBO_PRIMITIVE.json
@@ -13,6 +13,7 @@
       "unit_indirectFire",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_primitive",
       "comstar",
       "liao",

--- a/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_PRIMITIVE.json
+++ b/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_NOTABRADLEY_PRIMITIVE.json
@@ -11,6 +11,7 @@
       "unit_indirectFire",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_primitive",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_TURHAN_MICROWAVE.json
+++ b/Eras/ClanInvasion3061/Base/PrimitiveTanks/vehicle/vehicledef_APC_TURHAN_MICROWAVE.json
@@ -5,6 +5,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Alsvin.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Alsvin.json
@@ -8,6 +8,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_advanced",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Arvakr.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Arvakr.json
@@ -9,6 +9,7 @@
       "unit_heavy",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_advanced",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_DAIMYO_HQ_67_K.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_DAIMYO_HQ_67_K.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_lance_support",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_release",
       "unit_generic",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover.json
@@ -8,6 +8,7 @@
       "unit_resupply",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_Chem.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_Chem.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_LRM.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_MG.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyHover_SRM.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked.json
@@ -8,6 +8,7 @@
       "unit_resupply",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_Chem.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_Chem.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_tracks",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_LRM.json
@@ -7,6 +7,7 @@
       "unit_tracks",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_MG.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_tracks",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyTracked_SRM.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_tracks",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_Chem.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_Chem.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_LRM.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_MG.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_HeavyWheeled_SRM.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover.json
@@ -7,6 +7,7 @@
       "unit_hover",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_LRM.json
@@ -8,6 +8,7 @@
       "unit_hover",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_MG.json
@@ -7,6 +7,7 @@
       "unit_hover",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_SRM.json
@@ -7,6 +7,7 @@
       "unit_hover",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_Sensors.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Hover_Sensors.json
@@ -8,6 +8,7 @@
       "unit_hover",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir.json
@@ -6,6 +6,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_COMMAND.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_COMMAND.json
@@ -7,6 +7,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_command",
       "unit_release",
       "unit_advanced",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_FUSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_FUSION.json
@@ -6,6 +6,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_advanced",
       "unit_bracket_high",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_LRM.json
@@ -6,6 +6,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Sleipnir_SRM.json
@@ -6,6 +6,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_TRIDENT.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_TRIDENT.json
@@ -10,6 +10,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "unit_rt_custom",
       "GreenGhosts",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_TRIDENT_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_TRIDENT_SRM.json
@@ -10,6 +10,7 @@
       "unit_rt_custom",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "GreenGhosts",
       "RimCommonality",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_TURHAN.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_TURHAN.json
@@ -5,6 +5,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked.json
@@ -7,6 +7,7 @@
       "unit_tracks",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked_LRM.json
@@ -8,6 +8,7 @@
       "unit_tracks",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked_MG.json
@@ -7,6 +7,7 @@
       "unit_tracks",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Tracked_SRM.json
@@ -7,6 +7,7 @@
       "unit_tracks",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr.json
@@ -7,6 +7,7 @@
       "unit_heavy",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_FUSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_FUSION.json
@@ -6,6 +6,7 @@
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",
+      "Unit_Convoy_Troops",
       "unit_vehicle_apc",
       "unit_resupply",
       "unit_release",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_LRM.json
@@ -7,6 +7,7 @@
       "unit_heavy",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_SLDF.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_SLDF.json
@@ -7,6 +7,7 @@
       "unit_heavy",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "unit_release",
       "unit_advanced",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Vargr_SRM.json
@@ -7,6 +7,7 @@
       "unit_heavy",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_Chem.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_Chem.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_LRM.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_MG.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_vanguard",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Wheeled_SRM.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_rare",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Winterhawk.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_APC_Winterhawk.json
@@ -7,6 +7,7 @@
       "unit_light",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_A.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_A.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "omni_tank",
       "locals",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_B.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_B.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "omni_tank",
       "locals",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_C.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_C.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_indirectFire",
       "omni_tank",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_D.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_D.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "omni_tank",
       "locals",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_E.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_E.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "omni_tank",
       "locals",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_F.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_F.json
@@ -8,6 +8,7 @@
       "unit_advanced",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "omni_tank",
       "locals",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_PRIME.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BADGER_PRIME.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "omni_tank",
       "locals",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BEARCAT.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BEARCAT.json
@@ -9,6 +9,7 @@
       "unit_release",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BLIZZARD.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BLIZZARD.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "unit_lance_vanguard",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BROWNING_MOBILEHQ.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_BROWNING_MOBILEHQ.json
@@ -9,6 +9,7 @@
       "unit_lance_support",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_generic",
       "unit_bracket_med",
       "unit_command",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COMMAND_VAN_FUSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COMMAND_VAN_FUSION.json
@@ -11,6 +11,7 @@
       "unit_vehicle_mobileHQ",
       "unit_command",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_generic",
       "unit_bracket_low",
       "RimCommonality",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COMMAND_VAN_ICE.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COMMAND_VAN_ICE.json
@@ -11,6 +11,7 @@
       "unit_vehicle_mobileHQ",
       "unit_command",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_generic",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK_HOVER.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK_HOVER.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_generic",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK_TRACKED.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_COOLANT_TRUCK_TRACKED.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_generic",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27.json
@@ -9,6 +9,7 @@
       "unit_generic",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_j27",
       "unit_resupply",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27_ARMOR.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27_ARMOR.json
@@ -9,6 +9,7 @@
       "unit_generic",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_j27",
       "unit_resupply",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27_FUSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27_FUSION.json
@@ -9,6 +9,7 @@
       "unit_generic",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_j27",
       "unit_resupply",
       "RimCommonality",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27_KILLJOY.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_J-27_KILLJOY.json
@@ -9,6 +9,7 @@
       "unit_generic",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_j27",
       "unit_resupply",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_KNOX.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_KNOX.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_release",
       "unit_generic",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck-ICE.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck-ICE.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_vehicle_mashTruck",
       "unit_vehicle_apc",
+      "Unit_Convoy_Medical",
       "unit_generic",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck-L.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck-L.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_vehicle_mashTruck",
       "unit_vehicle_apc",
+      "Unit_Convoy_Medical",
       "unit_noncombatant",
       "unit_generic",
       "wordofblake",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck-UA.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck-UA.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_vehicle_mashTruck",
       "unit_vehicle_apc",
+      "Unit_Convoy_Medical",
       "unit_weaponless",
       "unit_noncombatant",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MASHTruck.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_vehicle_mashTruck",
       "unit_vehicle_apc",
+      "Unit_Convoy_Medical",
       "unit_noncombatant",
       "unit_generic",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ.json
@@ -9,6 +9,7 @@
       "unit_lance_support",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_generic",
       "unit_bracket_med",
       "unit_command",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_ACM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_ACM.json
@@ -9,6 +9,7 @@
       "unit_wheels",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_lance_support",
       "unit_noncombatant",
       "unit_advanced",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_ARMORED.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_ARMORED.json
@@ -11,6 +11,7 @@
       "unit_command",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_generic",
       "unit_bracket_med",
       "EscorpionImperio",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_ICE_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_ICE_LRM.json
@@ -10,6 +10,7 @@
       "unit_indirectFire",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_LL.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_LL.json
@@ -9,6 +9,7 @@
       "unit_lance_support",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_command",
       "unit_generic",
       "unit_bracket_med",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_MOBILEHQ_LRM.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_generic",
       "unit_bracket_med",
       "unit_command",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_PRIME_MOVER.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_PRIME_MOVER.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_bracket_med",
       "unit_resupply",
       "republic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_PRIME_MOVER_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_PRIME_MOVER_LRM.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_bracket_med",
       "unit_resupply",
       "republic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_PRIME_MOVER_SW.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_PRIME_MOVER_SW.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_bracket_med",
       "unit_resupply",
       "republic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SAVIOR.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SAVIOR.json
@@ -8,6 +8,7 @@
       "unit_tracks",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Technical",
       "unit_lance_support",
       "unit_generic",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA.json
@@ -1,0 +1,188 @@
+{
+    "VehicleTags": {
+        "items": [
+            "unit_singleton",
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_vehicle_apc",
+            "unit_generic",
+            "unit_bracket_low",
+            "NoBiome_lunarVacuum",
+            "NoBiome_martianVacuum",
+            "RimWorldsRepublic",
+            "TerranHegemony",
+            "SLDF",
+            "AmarisEmpire",
+            "liao",
+            "taurianconcordat",
+            "FroncReaches",
+            "ives"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_SHERPA",
+    "Description": {
+        "Cost": 326021,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Sherpa Armored Truck",
+        "Id": "vehicledef_SHERPA",
+        "Name": "Sherpa Armored Truck",
+        "Details": "Designed during the Age of War, the Sherpa is an armored logistics vehicle adapted from a civilian chassis. Powered by a 140 rated ICE, the 35 ton Truck can reach a top speed of 60 k/ph. A single Machine Gun and 2 tons of BAR 10 armor are all that protect the vehicles 7 tons of cargo.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       115     20\n<b>Left</b>          60     20\n<b>Right</b>        60     20\n<b>Rear</b>         40     20\n<b>Turret</b>       90     20\n\n<b>Total</b>      365    100</color>\n\n<color=#ff0000>Quirk: Improved Lifesupport</color>\n\n<color=#ffcc00>Can Resupply/Repair</color>",
+        "Icon": "APC"
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 35,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 35,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 30,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 30,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_MachineGun",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Ammo_AmmunitionBox_MachineGun",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Crew_Compartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_FCS_Generic_2",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Sensors",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Armor_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Structure_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Defaultbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Quirk_EasyToMaintain",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Default_Vehicle_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_Compartment_Cargo",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_EngineCore_140",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_ICE",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_EngineCooling_CoolantSystem",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA.json
@@ -8,6 +8,7 @@
             "unit_tracks",
             "unit_release",
             "unit_vehicle_apc",
+            "Unit_Convoy_Cargo",
             "unit_generic",
             "unit_bracket_low",
             "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA_FUSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA_FUSION.json
@@ -1,0 +1,207 @@
+{
+    "VehicleTags": {
+        "items": [
+            "unit_singleton",
+            "mr-resize-1.50",
+            "unit_vehicle",
+            "unit_light",
+            "unit_tracks",
+            "unit_release",
+            "unit_vehicle_apc",
+            "unit_generic",
+            "unit_bracket_low",
+            "RimWorldsRepublic",
+            "TerranHegemony",
+            "SLDF",
+            "AmarisEmpire",
+            "liao",
+            "taurianconcordat",
+            "FroncReaches",
+            "ives"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_SHERPA_FUSION",
+    "Description": {
+        "Cost": 326021,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Sherpa Armored Truck",
+        "Id": "vehicledef_SHERPA_FUSION",
+        "Name": "Sherpa Armored Truck",
+        "Details": "An expensive and rarely seen redesign of the Sherpa, the Sherpa (Fusion) utilises a Mech grade 210 rated Fusion Engine to eliminate the Trucks notorious fuel consumption issues. The swap to a Fusion Engine allowed the engineers to increase the vehicles speed to 97 k/ph and add an additional 2.5 tons of armour. Cargo capacity has been increased to 9 tons and the Machine Gun replaced with an AMS with a CASE protected magazine.11\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       115     20\n<b>Left</b>          60     20\n<b>Right</b>        60     20\n<b>Rear</b>         40     20\n<b>Turret</b>       90     20\n\n<b>Total</b>      365    100</color>\n\n<color=#ff0000>Quirk: Improved Lifesupport</color>\n\n<color=#ffcc00>Can Resupply/Repair</color>",
+        "Icon": "APC"
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 75,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 75,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 70,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 70,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 75,
+            "CurrentInternalStructure": 20,
+            "AssignedArmor": 75,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_AMS",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Ammo_AmmunitionBox_AMS",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_CASE",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Crew_Compartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_FCS_Generic_2",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Sensors",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Armor_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Structure_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Defaultbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_Compartment_Cargo",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Quirk_EasyToMaintain",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Default_Vehicle_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Gear_HeatSink_Single",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Gear_HeatSink_Single",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_EngineCore_210",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_Standard",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_EngineCooling_CoolantSystem",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA_FUSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_SHERPA_FUSION.json
@@ -8,6 +8,7 @@
             "unit_tracks",
             "unit_release",
             "unit_vehicle_apc",
+            "Unit_Convoy_Cargo",
             "unit_generic",
             "unit_bracket_low",
             "RimWorldsRepublic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_TRUCK_BURRO_2.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_TRUCK_BURRO_2.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_resupply",
       "unit_release",
       "unit_generic",

--- a/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_WHEELED_SCOUT.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/apc/vehicledef_WHEELED_SCOUT.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_noconvoy",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_generic",
       "unit_bracket_low",
       "unit_lance_vanguard",

--- a/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_CENTAURUS.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_CENTAURUS.json
@@ -10,6 +10,7 @@
       "unit_lance_vanguard",
       "unit_lance_assassin",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "magistracyofcanopus",

--- a/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_IGNIS.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_IGNIS.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_lance_tank",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_IGNISSRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_IGNISSRM.json
@@ -10,6 +10,7 @@
       "unit_generic",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",
       "wordofblake",

--- a/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_IGNIS_SSRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_IGNIS_SSRM.json
@@ -12,6 +12,7 @@
       "unit_predator",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "RimWorldsRepublic",
       "AmarisEmpire"
     ],

--- a/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_SKULKER_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/light/vehicledef_SKULKER_MG.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_lance_support",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_low",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_3052.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_3052.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "unit_predator",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_AI.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_AI.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "unit_predator",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_BA.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_BA.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_BA_FIELD.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_BA_FIELD.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "unit_predator",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_FS.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_FS.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "unit_indirectFire",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_INFANTRY.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_INFANTRY.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "unit_predator",
       "RimCommonality",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_APC_MAXIM_SRM.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-A.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-A.json
@@ -10,6 +10,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "auriganmercenaries",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-B.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-B.json
@@ -10,6 +10,7 @@
       "unit_bracket_high",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "auriganmercenaries",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-C.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-C.json
@@ -10,6 +10,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "auriganmercenaries",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-D.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-D.json
@@ -11,6 +11,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "auriganmercenaries",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-E.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-E.json
@@ -11,6 +11,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "auriganmercenaries",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-F.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-F.json
@@ -10,6 +10,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "auriganmercenaries",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-G.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-G.json
@@ -10,6 +10,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "auriganmercenaries",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-H.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT-H.json
@@ -10,6 +10,7 @@
       "unit_bracket_med",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "auriganpirates",
       "locals",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_BANDIT.json
@@ -10,6 +10,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "locals",
       "auriganmercenaries",
       "nofaction",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_DECURION_APC.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_DECURION_APC.json
@@ -6,6 +6,7 @@
       "unit_medium",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_generic",
       "unit_proxy_icon",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_DECURION_APC_UPGRADE.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_DECURION_APC_UPGRADE.json
@@ -6,6 +6,7 @@
       "unit_medium",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_rt_custom",
       "unit_advanced",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN.json
@@ -9,6 +9,7 @@
       "unit_lance_tank",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_CHEM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_CHEM.json
@@ -9,6 +9,7 @@
       "unit_lance_tank",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_ISV.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_ISV.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_solaris",
       "GreenGhosts",
       "republic",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_LRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_LRM.json
@@ -10,6 +10,7 @@
       "unit_lance_tank",
       "unit_indirectFire",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_MG.json
@@ -9,6 +9,7 @@
       "unit_lance_assassin",
       "unit_lance_tank",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_GOBLIN_SRM.json
@@ -9,6 +9,7 @@
       "unit_lance_assassin",
       "unit_lance_tank",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "NoBiome_lunarVacuum",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_indirectFire",
       "unit_predator",
       "unit_solaris",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER_ECM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER_ECM.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_indirectFire",
       "unit_solaris",
       "unit_predator",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER_SUCCESSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER_SUCCESSION.json
@@ -11,6 +11,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_resupply",
       "unit_indirectFire",
       "unit_solaris",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER_SUPPORT.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_PROWLER_SUPPORT.json
@@ -11,6 +11,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_indirectFire",
       "unit_solaris",
       "RimCommonality",

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_WHIRLWIND_SCOUT.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_WHIRLWIND_SCOUT.json
@@ -7,6 +7,7 @@
       "unit_medium",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_lance_support",
       "unit_generic",
       "unit_bracket_high",

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_SHERPA.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_SHERPA.json
@@ -1,0 +1,132 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Sherpa",
+      "Exclude": false,
+      "Include": true
+    },
+    "CustomWeights": [
+        {
+          "ComponentDefID": "Gear_Vehicle_Compartment_Cargo",
+          "Tonnage": 7
+        }
+      ]
+    },
+  "CustomParts": {
+    "CustomParts": [],
+    "CrewLocation": "None"
+  },
+  "Description": {
+    "Cost": 326021,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Sherpa Armored Truck",
+    "Id": "vehiclechassisdef_SHERPA",
+    "Name": "Sherpa Armored Truck",
+    "Details": "Designed during the Age of War, the Sherpa is an armored logistics vehicle adapted from a civilian chassis. Powered by a 140 rated ICE, the 35 ton Truck can reach a top speed of 60 k/ph. A single Machine Gun and 2 tons of BAR 10 armor are all that protect the vehicles 7 tons of cargo.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       115     20\n<b>Left</b>          60     20\n<b>Right</b>        60     20\n<b>Rear</b>         40     20\n<b>Turret</b>       90     20\n\n<b>Total</b>      365    100</color>\n\n<color=#ff0000>Quirk: Improved Lifesupport</color>\n\n<color=#ffcc00>Can Resupply/Repair</color>",
+    "Icon": "APC"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_4-6cv",
+  "movementType": "Tracked",
+  "PathingCapDefID": "pathingdef_light_tracked",
+  "HardpointDataDefID": "hardpointdatadef_giapc",
+  "PrefabIdentifier": "chrprfvhcl_giapc",
+  "PrefabBase": "giapc",
+  "Tonnage": 35,
+  "weightClass": "LIGHT",
+  "BattleValue": 564,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 3,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3.25,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3.25,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    },
+    {
+      "x": -1.5,
+      "y": 4,
+      "z": 0
+    },
+    {
+      "x": 1.5,
+      "y": 4,
+      "z": 0
+    },
+    {
+      "x": 0,
+      "y": 2.5,
+      "z": -4
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 115,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 60,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 60,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 40,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 90,
+      "InternalStructure": 20
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_SHERPA_FUSION.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_SHERPA_FUSION.json
@@ -1,0 +1,132 @@
+{
+  "Custom": {
+    "VAssemblyVariant": {
+      "PrefabID": "Sherpa",
+      "Exclude": false,
+      "Include": true
+    },
+    "CustomWeights": [
+        {
+          "ComponentDefID": "Gear_Vehicle_Compartment_Cargo",
+          "Tonnage": 9
+        }
+      ]
+    },
+  "CustomParts": {
+    "CustomParts": [],
+    "CrewLocation": "None"
+  },
+  "Description": {
+    "Cost": 326021,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Sherpa Armored Truck",
+    "Id": "vehiclechassisdef_SHERPA_FUSION",
+    "Name": "Sherpa Armored Truck",
+    "Details": "An expensive and rarely seen redesign of the Sherpa, the Sherpa (Fusion) utilises a Mech grade 210 rated Fusion Engine to eliminate the Trucks notorious fuel consumption issues. The swap to a Fusion Engine allowed the engineers to increase the vehicles speed to 97 k/ph and add an additional 2.5 tons of armour. Cargo capacity has been increased to 9 tons and the Machine Gun replaced with an AMS with a CASE protected magazine.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 6/9 Hex: 180/270 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       115     20\n<b>Left</b>          60     20\n<b>Right</b>        60     20\n<b>Rear</b>         40     20\n<b>Turret</b>       90     20\n\n<b>Total</b>      365    100</color>\n\n<color=#ff0000>Quirk: Improved Lifesupport</color>\n\n<color=#ffcc00>Can Resupply/Repair</color>",
+    "Icon": "APC"
+  },
+  "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+  "MovementCapDefID": "movedef_5-8cv",
+  "movementType": "Tracked",
+  "PathingCapDefID": "pathingdef_light_tracked",
+  "HardpointDataDefID": "hardpointdatadef_giapc",
+  "PrefabIdentifier": "chrprfvhcl_giapc",
+  "PrefabBase": "giapc",
+  "Tonnage": 35,
+  "weightClass": "LIGHT",
+  "BattleValue": 564,
+  "TopSpeed": 85,
+  "TurnRadius": 90,
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 3,
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 3.25,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 3.25,
+      "z": -0.5
+    },
+    {
+      "x": 0,
+      "y": 1.5,
+      "z": 3
+    },
+    {
+      "x": -1.5,
+      "y": 4,
+      "z": 0
+    },
+    {
+      "x": 1.5,
+      "y": 4,
+      "z": 0
+    },
+    {
+      "x": 0,
+      "y": 2.5,
+      "z": -4
+    }
+  ],
+  "Locations": [
+    {
+      "Location": "Front",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 115,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Left",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 80,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Right",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 80,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Rear",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 80,
+      "InternalStructure": 20
+    },
+    {
+      "Location": "Turret",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 0,
+      "MaxArmor": 90,
+      "InternalStructure": 20
+    }
+  ]
+}

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_D.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_D.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_G.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_G.json
@@ -5,6 +5,7 @@
       "omni_tank",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "mr-resize-1.50",
       "unit_vehicle",
       "unit_heavy",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_I.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_I.json
@@ -5,6 +5,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_Primary_arty.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_BOLLA_Primary_arty.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_GALLEON_GAL-106M.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_GALLEON_GAL-106M.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_lance_vanguard",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_noconvoy",
       "unit_bracket_low",
       "locals",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_MASHTruck_AMS.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_MASHTruck_AMS.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_vehicle_mashTruck",
       "unit_vehicle_apc",
+      "Unit_Convoy_Medical",
       "unit_noncombatant",
       "steiner",
       "RimCommonality",

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_PROWLER_3140.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_PROWLER_3140.json
@@ -13,6 +13,7 @@
       "unit_predator",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_indirectFire",
       "republic"
     ],

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_WHIRLWIND_IFV.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_WHIRLWIND_IFV.json
@@ -8,6 +8,7 @@
       "unit_hover",
       "unit_lance_support",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_advanced",
       "unit_predator",
       "unit_bracket_high",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_AJAX_D.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_AJAX_D.json
@@ -13,6 +13,7 @@
       "unit_indirectFire",
       "unit_lance_support",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_resupply",
       "unit_arrow",
       "unit_advanced",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_DAIMYO_HQ_67_R.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_DAIMYO_HQ_67_R.json
@@ -8,6 +8,7 @@
       "unit_wheels",
       "unit_lance_support",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_release",
       "unit_advanced",
       "unit_bracket_med",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_HeavyWheeled_WOB.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_HeavyWheeled_WOB.json
@@ -9,6 +9,7 @@
       "unit_resupply",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_advanced",
       "unit_bracket_low",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_INDRA_BA_CLAN.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_INDRA_BA_CLAN.json
@@ -6,6 +6,7 @@
       "unit_light",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_release",
       "unit_generic",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_KU_TURHAN2_CLAN.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_KU_TURHAN2_CLAN.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_release",
       "unit_bracket_med",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_MAXIM_C3M.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_MAXIM_C3M.json
@@ -10,6 +10,7 @@
       "unit_advanced",
       "unit_predator",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "NoBiome_lunarVacuum",
       "NoBiome_martianVacuum",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_MAXIM_C3S.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_MAXIM_C3S.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "unit_predator",
       "NoBiome_lunarVacuum",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_MAXIM_INFANTRY_COMMAND.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_MAXIM_INFANTRY_COMMAND.json
@@ -10,6 +10,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_high",
       "unit_predator",
       "DuchyOfAndurien",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_TURHAN_AMS.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_APC_TURHAN_AMS.json
@@ -6,6 +6,7 @@
       "unit_wheels",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_tank",
       "unit_release",
       "unit_advanced",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BADGER_C_F.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BADGER_C_F.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BADGER_G.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BADGER_G.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals"
     ],

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BANDIT-F_CLAN.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BANDIT-F_CLAN.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BANDIT-G_CLAN.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BANDIT-G_CLAN.json
@@ -10,6 +10,7 @@
       "unit_predator",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "EscorpionImperio",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BANDIT-I.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BANDIT-I.json
@@ -10,6 +10,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals"
     ],

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_COMMINUS.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_COMMINUS.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_DOMINUS.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_DOMINUS.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_INFERNUS.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_INFERNUS.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_INVICTUS.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_BOLLA_INVICTUS.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_ELDINGAR.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_ELDINGAR.json
@@ -5,6 +5,7 @@
       "unit_vehicle",
       "unit_vehicle_clan",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_medium",
       "unit_release",
       "unit_lance_vanguard",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_GIGGINS.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_GIGGINS.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_advanced",
       "unit_bracket_med",
       "republic",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_GIGGINS_FS.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_GIGGINS_FS.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_advanced",
       "unit_bracket_med",
       "republic",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_GOBLIN_II_ISV.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_GOBLIN_II_ISV.json
@@ -10,6 +10,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "davion"
     ],
     "tagSetSourceFile": ""

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_J-37.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_J-37.json
@@ -9,6 +9,7 @@
       "unit_release",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_j27",
       "unit_resupply",
       "republic",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_J-37_CISTERN.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_J-37_CISTERN.json
@@ -9,6 +9,7 @@
       "unit_release",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_j27",
       "unit_resupply",
       "republic",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MAGI_UCSV.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MAGI_UCSV.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_lance_tank",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "unit_advanced",
       "unit_bracket_med",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MANTEUFFEL_D.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MANTEUFFEL_D.json
@@ -10,6 +10,7 @@
       "unit_lance_tank",
       "unit_lance_assassin",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_advanced",
       "unit_bracket_med",
       "republic",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MORNINGSTAR_CC.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MORNINGSTAR_CC.json
@@ -7,6 +7,7 @@
       "unit_wheels",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_tank",
       "unit_lance_support",
       "unit_advanced",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MUSKETEER_3080.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_MUSKETEER_3080.json
@@ -6,6 +6,7 @@
       "unit_medium",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_lance_tank",
       "unit_predator",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_PROWLER_RAF.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_PROWLER_RAF.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_indirectFire",
       "unit_predator",
       "republic",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_PROWLER_WOB.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_PROWLER_WOB.json
@@ -15,6 +15,7 @@
       "unit_bracket_med",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_indirectFire",
       "wordofblake"
     ],

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_THANG-TA.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_THANG-TA.json
@@ -7,6 +7,7 @@
       "unit_light",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_release",
       "unit_advanced",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_TYR_KURITA.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_TYR_KURITA.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "republic",
       "kurita"
     ],

--- a/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_APC_MAXIM_FLANKER.json
+++ b/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_APC_MAXIM_FLANKER.json
@@ -10,6 +10,7 @@
       "unit_generic",
       "unit_prototype",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "unit_indirectFire",
       "unit_legendary",

--- a/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_GALLEON_MAXWELL.json
+++ b/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_GALLEON_MAXWELL.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_light",
       "unit_tracks",

--- a/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_GOBLIN_X.json
+++ b/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_GOBLIN_X.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_legendary",
       "locals"
     ],

--- a/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_PHALANX.json
+++ b/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_PHALANX.json
@@ -16,6 +16,7 @@
       "unit_proxy",
       "unit_indirectFire",
       "unit_sniper",
+      "Unit_Convoy_Troops",
       "OrienteProtectorate",
       "marik",
       "steiner"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_AITHLON_CLAN.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_AITHLON_CLAN.json
@@ -13,6 +13,7 @@
       "unit_indirectFire",
       "unit_resupply",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_longtom",
       "clanhellshorses"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_ANAT.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_ANAT.json
@@ -8,6 +8,7 @@
       "unit_resupply",
       "unit_noncombatant",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_generic",
       "unit_bracket_low",
       "unit_vehicle_clan",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_APC_MAXIM_MKII-ECM.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_APC_MAXIM_MKII-ECM.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_advanced",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "republic",
       "steiner",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_APC_MAXIM_MKII-S.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_APC_MAXIM_MKII-S.json
@@ -10,6 +10,7 @@
       "unit_advanced",
       "unit_indirectFire",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "republic",
       "steiner"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_APC_MAXIM_MKII.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_APC_MAXIM_MKII.json
@@ -10,6 +10,7 @@
       "unit_advanced",
       "unit_indirectFire",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "republic",
       "steiner"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_A.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_A.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_B.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_B.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_C.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_C.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_Primary.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_BOLLA_Primary.json
@@ -4,6 +4,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_ELDINGAR_HMMHV.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_ELDINGAR_HMMHV.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_high",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "republic",
       "clanghostbear",
       "rasalhague",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_MAMONO.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_MAMONO.json
@@ -8,6 +8,7 @@
       "unit_tracks",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_lance_tank",
       "unit_advanced",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_MHI_APC.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_MHI_APC.json
@@ -8,6 +8,7 @@
       "unit_release",
       "comment_proxy_model",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_advanced",
       "unit_bracket_low",
       "GhostBearDominion",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_Main_Gauche_IFV.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_Main_Gauche_IFV.json
@@ -6,6 +6,7 @@
       "unit_tracks",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_advanced",
       "unit_bracket_low",
       "comment_proxy_model",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_PROWLER_SECURITY.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_PROWLER_SECURITY.json
@@ -11,6 +11,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_indirectFire",
       "unit_predator",
       "republic"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_QUAESTOR.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_QUAESTOR.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_vehicle_mobileHQ",
       "unit_vehicle_apc",
+      "Unit_Convoy_Command",
       "unit_command",
       "unit_generic",
       "unit_bracket_low",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-A.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-A.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "unit_bracket_med",
       "RavenAlliance",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-B.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-B.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "unit_bracket_med",
       "unit_predator",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-CT.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-CT.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Cargo",
       "unit_bracket_med",
       "DuchyOfAndurien",
       "republic",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-Prime.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_R10-Prime.json
@@ -10,6 +10,7 @@
       "unit_lance_vanguard",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_bracket_med",
       "RavenAlliance",
       "OrienteProtectorate",

--- a/Optionals/Flashpoints/LV426/vehicle/vehicledef_BOLLA_Black.json
+++ b/Optionals/Flashpoints/LV426/vehicle/vehicledef_BOLLA_Black.json
@@ -15,6 +15,7 @@
       "mr-resize-1.50",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle",
       "unit_heavy",
       "unit_wheels",

--- a/Optionals/OperationRevival/vehicle/vehicledef_ERIS_HOVER_APC.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_ERIS_HOVER_APC.json
@@ -12,6 +12,7 @@
       "unit_proxy_model",
       "unit_hover",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_predator",
       "unit_noconvoy",

--- a/Optionals/OperationRevival/vehicle/vehicledef_GANESHA.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_GANESHA.json
@@ -10,6 +10,7 @@
       "unit_resupply",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_lance_tank",
       "unit_lance_vanguard",

--- a/Optionals/OperationRevival/vehicle/vehicledef_NIKE.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_NIKE.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_lance_assassin",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_advanced",
       "unit_bracket_med",

--- a/Optionals/OperationRevival/vehicle/vehicledef_NIKE_TANK.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_NIKE_TANK.json
@@ -8,6 +8,7 @@
       "unit_tracks",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "unit_lance_assassin",
       "unit_vehicle_clan",

--- a/Optionals/OperationRevival/vehicle/vehicledef_POLEMOS.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_POLEMOS.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_lance_vanguard",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_bracket_low",
       "unit_proxy_model",

--- a/Optionals/OperationRevival/vehicle/vehicledef_POLEMOS_LRM.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_POLEMOS_LRM.json
@@ -9,6 +9,7 @@
       "unit_lance_vanguard",
       "unit_indirectFire",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_bracket_low",
       "unit_proxy_model",

--- a/Optionals/OperationRevival/vehicle/vehicledef_POLEMOS_SRM.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_POLEMOS_SRM.json
@@ -8,6 +8,7 @@
       "unit_release",
       "unit_lance_vanguard",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "unit_bracket_low",
       "unit_proxy_model",

--- a/Optionals/PirateTech/Base/vehicle/vehicledef_APC_Sleipnir_PIRATE.json
+++ b/Optionals/PirateTech/Base/vehicle/vehicledef_APC_Sleipnir_PIRATE.json
@@ -7,6 +7,7 @@
       "unit_medium",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_release",
       "unit_generic",
       "unit_bracket_low",

--- a/Optionals/PirateTech/Base/vehicle/vehicledef_APC_Vargr_PIRATE.json
+++ b/Optionals/PirateTech/Base/vehicle/vehicledef_APC_Vargr_PIRATE.json
@@ -8,6 +8,7 @@
       "unit_heavy",
       "unit_wheels",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_resupply",
       "unit_release",
       "unit_generic",

--- a/Optionals/PirateTech/Base/vehicle/vehicledef_BADGER_PRIME_PIRATE.json
+++ b/Optionals/PirateTech/Base/vehicle/vehicledef_BADGER_PRIME_PIRATE.json
@@ -9,6 +9,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_lance_vanguard",
       "omni_tank",
       "locals",

--- a/Optionals/PirateTech/Base/vehicle/vehicledef_BANDIT-F_PIRATE.json
+++ b/Optionals/PirateTech/Base/vehicle/vehicledef_BANDIT-F_PIRATE.json
@@ -11,6 +11,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "jarnfolk",

--- a/Optionals/PirateTech/Base/vehicle/vehicledef_BANDIT-G_PIRATE.json
+++ b/Optionals/PirateTech/Base/vehicle/vehicledef_BANDIT-G_PIRATE.json
@@ -11,6 +11,7 @@
       "unit_bracket_med",
       "unit_generic",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "omni_tank",
       "locals",
       "jarnfolk",

--- a/Optionals/RISCtech/Base/WraithDef/vehicledef_Wraith_IFV.json
+++ b/Optionals/RISCtech/Base/WraithDef/vehicledef_Wraith_IFV.json
@@ -8,6 +8,7 @@
       "unit_assault",
       "unit_release",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_risc",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/RISCtech/Base/vehicle/vehicledef_BOLLA_E.json
+++ b/Optionals/RISCtech/Base/vehicle/vehicledef_BOLLA_E.json
@@ -10,6 +10,7 @@
       "unit_wheels",
       "unit_lance_support",
       "unit_lance_assassin",
+      "Unit_Convoy_Troops",
       "unit_risc",
       "unit_elite",
       "unit_advanced",

--- a/Optionals/RISCtech/Base/vehicle/vehicledef_BOLLA_F.json
+++ b/Optionals/RISCtech/Base/vehicle/vehicledef_BOLLA_F.json
@@ -10,6 +10,7 @@
       "unit_wheels",
       "unit_lance_support",
       "unit_lance_assassin",
+      "Unit_Convoy_Troops",
       "unit_risc",
       "unit_elite",
       "unit_advanced",

--- a/Optionals/RISCtech/Base/vehicle/vehicledef_BOLLA_H.json
+++ b/Optionals/RISCtech/Base/vehicle/vehicledef_BOLLA_H.json
@@ -10,6 +10,7 @@
       "unit_wheels",
       "unit_lance_support",
       "unit_lance_assassin",
+      "Unit_Convoy_Troops",
       "unit_risc",
       "unit_elite",
       "unit_advanced",

--- a/Optionals/RogueSociety/Base/vehicle/vehicledef_BADGER_C_Z.json
+++ b/Optionals/RogueSociety/Base/vehicle/vehicledef_BADGER_C_Z.json
@@ -8,6 +8,7 @@
       "unit_generic",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "omni_tank",
       "clanburrock",

--- a/Optionals/RogueSociety/Base/vehicle/vehicledef_BANDIT-Z_CLAN.json
+++ b/Optionals/RogueSociety/Base/vehicle/vehicledef_BANDIT-Z_CLAN.json
@@ -10,6 +10,7 @@
       "unit_lance_support",
       "unit_bracket_low",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_vehicle_clan",
       "clanburrock",
       "clancoyote",

--- a/Optionals/RogueSociety/Base/vehicle/vehicledef_PROWLER_SOCIETY.json
+++ b/Optionals/RogueSociety/Base/vehicle/vehicledef_PROWLER_SOCIETY.json
@@ -12,6 +12,7 @@
       "unit_advanced",
       "unit_bracket_med",
       "unit_vehicle_apc",
+      "Unit_Convoy_Troops",
       "unit_indirectFire",
       "unit_predator",
       "clanburrock",


### PR DESCRIPTION
Added the Sherpa from TRO: Vehicle Annex and a custom variant. Tagged unit_vehicle_apc units with sub tags for ease of reference
      "Unit_Convoy_Troops",
      "Unit_Convoy_Cargo",
      "Unit_Convoy_Command",
      "Unit_Convoy_Medical",
      "Unit_Convoy_Technical",