### PR TITLE
Add "ID": "DestroyBase_CleverGirl" contract to exclude list

### DIFF
--- a/Core/CodeWords/mod.json
+++ b/Core/CodeWords/mod.json
@@ -150,7 +150,8 @@
       "Rescue_SAR_Easy",
       "CaptureEscort_SAR_Med",
       "CaptureEscort_SAR_Easy",
-      "CaptureEscort_SAR_Hard"
+      "CaptureEscort_SAR_Hard",
+      "DestroyBase_CleverGirl"
     ]
   }
 }


### PR DESCRIPTION
Raptor Attack event adds new contract "ID": "DestroyBase_CleverGirl" which is supposed to retain the contract name of but it is currently overwritten with codeword when generated.  Added the ID to exclusion list