### PR TITLE
SAR Improvements.

### DIFF
--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
@@ -227,33 +227,7 @@
       "title": "Hidden Objective: Destroy hunter lance for mission complete.",
       "description": "Hidden Objective: Destroy hunter lance for mission complete.",
       "isPrimary": false,
-      "OnSuccessResults": [
-        {
-          "Scope": "Company",
-          "Requirements": null,
-          "AddedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RemovedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "Stats": [
-            {
-              "typeString": "System.Single",
-              "name": "ContractBonusTargetReputation",
-              "value": 2,
-              "set": false,
-              "valueConstant": null
-            }
-          ],
-          "Actions": [],
-          "ForceEvents": [],
-          "TemporaryResult": false,
-          "ResultDuration": 0
-        }
-      ],
+      "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
       "OnFailureDialogueGUID": ""
@@ -1386,7 +1360,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": -1,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
@@ -1347,9 +1347,7 @@
         "name": "Lance_Enemy_Hunter",
         "lanceDefId": "Manual",
         "lanceTagSet": {
-          "items": [
-            "lance_type_battle"
-          ],
+          "items": [],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
@@ -264,7 +264,7 @@
       },
       "title": "Get to the Evac Zone",
       "description": "The objective to escape with all the player units.",
-      "isPrimary": true,
+      "isPrimary": false,
       "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
@@ -312,7 +312,7 @@
       "encounterChunk": {
         "EncounterObjectGuid": "66728491-3cff-4ba8-b173-a6a386ce2c73"
       },
-      "enableChunkFromContract": false,
+      "enableChunkFromContract": true,
       "controlledByContractChunkGroupList": [],
       "requirementList": []
     }
@@ -1216,8 +1216,7 @@
         "lanceDefId": "Tagged",
         "lanceTagSet": {
           "items": [
-            "lance_type_battle",
-            "lance_type_notallvehicles"
+            "lance_type_battle"
           ],
           "tagSetSourceFile": "tags/LanceTags"
         },
@@ -1372,7 +1371,7 @@
           "EncounterObjectGuid": "8a365fc5-d25b-4d64-afbb-4ebf423721a9"
         },
         "name": "Lance_Enemy_Hunter",
-        "lanceDefId": "Tagged",
+        "lanceDefId": "Manual",
         "lanceTagSet": {
           "items": [
             "lance_type_battle"
@@ -1398,7 +1397,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1431,7 +1430,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1464,7 +1463,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1497,7 +1496,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -264,7 +264,7 @@
       },
       "title": "Get to the Evac Zone",
       "description": "The objective to escape with all the player units.",
-      "isPrimary": true,
+      "isPrimary": false,
       "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
@@ -312,7 +312,7 @@
       "encounterChunk": {
         "EncounterObjectGuid": "66728491-3cff-4ba8-b173-a6a386ce2c73"
       },
-      "enableChunkFromContract": false,
+      "enableChunkFromContract": true,
       "controlledByContractChunkGroupList": [],
       "requirementList": []
     }
@@ -899,7 +899,7 @@
           ],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 1,
+        "lanceDifficultyAdjustment": -1,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1056,7 +1056,7 @@
         "lanceDefId": "Tagged",
         "lanceTagSet": {
           "items": [
-            "lance_type_notallvehicles"
+            "lance_type_fire"
           ],
           "tagSetSourceFile": "tags/LanceTags"
         },
@@ -1068,7 +1068,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 2,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1214,8 +1214,8 @@
         "lanceDefId": "Tagged",
         "lanceTagSet": {
           "items": [
-            "lance_type_battle",
-            "lance_type_notallvehicles"
+            "lance_type_support",
+            "lance_type_mech"
           ],
           "tagSetSourceFile": "tags/LanceTags"
         },
@@ -1227,7 +1227,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 0,
+        "lanceDifficultyAdjustment": 2,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1370,7 +1370,7 @@
           "EncounterObjectGuid": "8a365fc5-d25b-4d64-afbb-4ebf423721a9"
         },
         "name": "Lance_Enemy_Hunter",
-        "lanceDefId": "Tagged",
+        "lanceDefId": "Manual",
         "lanceTagSet": {
           "items": [
             "lance_type_notallvehicles"
@@ -1396,7 +1396,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1429,7 +1429,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1462,7 +1462,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1495,7 +1495,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -227,33 +227,7 @@
       "title": "Hidden Objective: Destroy hunter lance for mission complete.",
       "description": "Hidden Objective: Destroy hunter lance for mission complete.",
       "isPrimary": false,
-      "OnSuccessResults": [
-        {
-          "Scope": "Company",
-          "Requirements": null,
-          "AddedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RemovedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "Stats": [
-            {
-              "typeString": "System.Single",
-              "name": "ContractBonusTargetReputation",
-              "value": 2,
-              "set": false,
-              "valueConstant": null
-            }
-          ],
-          "Actions": [],
-          "ForceEvents": [],
-          "TemporaryResult": false,
-          "ResultDuration": 0
-        }
-      ],
+      "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
       "OnFailureDialogueGUID": ""
@@ -1385,7 +1359,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 1,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -1030,7 +1030,7 @@
         "lanceDefId": "Tagged",
         "lanceTagSet": {
           "items": [
-            "lance_type_fire"
+            "lance_type_cavalry"
           ],
           "tagSetSourceFile": "tags/LanceTags"
         },
@@ -1187,10 +1187,7 @@
         "name": "Lance_Enemy_Reinforcement",
         "lanceDefId": "Tagged",
         "lanceTagSet": {
-          "items": [
-            "lance_type_support",
-            "lance_type_mech"
-          ],
+          "items": [],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -264,7 +264,7 @@
       },
       "title": "Get to the Evac Zone",
       "description": "The objective to escape with all the player units.",
-      "isPrimary": true,
+      "isPrimary": false,
       "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
@@ -312,7 +312,7 @@
       "encounterChunk": {
         "EncounterObjectGuid": "66728491-3cff-4ba8-b173-a6a386ce2c73"
       },
-      "enableChunkFromContract": false,
+      "enableChunkFromContract": true,
       "controlledByContractChunkGroupList": [],
       "requirementList": []
     }
@@ -899,7 +899,7 @@
           ],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 1,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1227,7 +1227,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 0,
+        "lanceDifficultyAdjustment": 1,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1370,7 +1370,7 @@
           "EncounterObjectGuid": "8a365fc5-d25b-4d64-afbb-4ebf423721a9"
         },
         "name": "Lance_Enemy_Hunter",
-        "lanceDefId": "Tagged",
+        "lanceDefId": "Manual",
         "lanceTagSet": {
           "items": [
             "lance_type_support",
@@ -1397,7 +1397,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1430,7 +1430,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1463,7 +1463,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1496,7 +1496,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "UseLance",
+            "unitDefId": "mechDef_None",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -227,33 +227,7 @@
       "title": "Hidden Objective: Destroy hunter lance for mission complete.",
       "description": "Hidden Objective: Destroy hunter lance for mission complete.",
       "isPrimary": false,
-      "OnSuccessResults": [
-        {
-          "Scope": "Company",
-          "Requirements": null,
-          "AddedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RemovedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "Stats": [
-            {
-              "typeString": "System.Single",
-              "name": "ContractBonusTargetReputation",
-              "value": 2,
-              "set": false,
-              "valueConstant": null
-            }
-          ],
-          "Actions": [],
-          "ForceEvents": [],
-          "TemporaryResult": false,
-          "ResultDuration": 0
-        }
-      ],
+      "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
       "OnFailureDialogueGUID": ""

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -1030,7 +1030,7 @@
         "lanceDefId": "Tagged",
         "lanceTagSet": {
           "items": [
-            "lance_type_battle"
+            "lance_type_cavalry"
           ],
           "tagSetSourceFile": "tags/LanceTags"
         },
@@ -1042,7 +1042,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 0,
+        "lanceDifficultyAdjustment": -1,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1346,10 +1346,7 @@
         "name": "Lance_Enemy_Hunter",
         "lanceDefId": "Manual",
         "lanceTagSet": {
-          "items": [
-            "lance_type_support",
-            "lance_type_notallvehicles"
-          ],
+          "items": [],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Easy.json
@@ -742,8 +742,7 @@
 				"lanceDefId": "Tagged",
 				"lanceTagSet": {
 					"items": [
-						"lance_type_battle",
-						"lance_type_notallvehicles"
+						"lance_type_mixed"
 					],
 					"tagSetSourceFile": "tags/LanceTags"
 				},

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Hard.json
@@ -742,8 +742,7 @@
 				"lanceDefId": "Tagged",
 				"lanceTagSet": {
 					"items": [
-						"lance_type_battle",
-						"lance_type_notallvehicles"
+						"lance_type_mixed"
 					],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
@@ -757,7 +756,7 @@
 					"items": [],
 					"tagSetSourceFile": "tags/SpawnEffectTags"
 				},
-				"lanceDifficultyAdjustment": 1,
+				"lanceDifficultyAdjustment": 2,
 				"selectedLanceDefId": null,
 				"selectedLanceDifficulty": 0,
 				"unitSpawnPointOverrideList": [
@@ -918,7 +917,7 @@
 					"items": [],
 					"tagSetSourceFile": "tags/SpawnEffectTags"
 				},
-				"lanceDifficultyAdjustment": 2,
+				"lanceDifficultyAdjustment": 1,
 				"selectedLanceDefId": null,
 				"selectedLanceDifficulty": 0,
 				"unitSpawnPointOverrideList": [

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Med.json
@@ -742,8 +742,7 @@
 				"lanceDefId": "Tagged",
 				"lanceTagSet": {
 					"items": [
-						"lance_type_battle",
-						"lance_type_notallvehicles"
+						"lance_type_mixed"
 					],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
@@ -757,7 +756,7 @@
 					"items": [],
 					"tagSetSourceFile": "tags/SpawnEffectTags"
 				},
-				"lanceDifficultyAdjustment": 0,
+				"lanceDifficultyAdjustment": 1,
 				"selectedLanceDefId": null,
 				"selectedLanceDifficulty": 0,
 				"unitSpawnPointOverrideList": [


### PR DESCRIPTION
Currently SAR Escorts have combat up front with the blocking force then no ambush, then hunter lance at the end. I'm not sure why I did this. I generally decided this was boring design for escorts and want to fix it. But don't want to raise difficulty.

This PR removes the hunter lance and adds the Ambush lance that attacks the convoy. Total enemy count is unchanged.

However. This PR also changes reaching the _Player_ extraction point from a primary to a secondary objective effectively eliminating it. None of the enemies are primary objectives in Escort.

As soon as the last primary objective, the convoy extracting is complete the contract will end with Success. No tedious walking. Or being forced to destroy enemies you can't salvage. We just handwave you rode out on the same dropship yes?