### PR TITLE
Fix issues with Locust Stick Event

### DIFF
--- a/Core/Locust_Stick/StatDesc/SimGameStatDesc_Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust.json
+++ b/Core/Locust_Stick/StatDesc/SimGameStatDesc_Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust.json
@@ -1,0 +1,20 @@
+{
+  "Description": {
+    "Id": "SimGameStatDesc_Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+    "Name": "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+    "Details": "Locust Stick Mace",
+    "Icon": null
+  },
+  "setResult": "",
+  "positiveResult": "Locust Stick added to inventory",
+  "negativeResult": "",
+  "temporalSetResult": "",
+  "temporalPositiveResult": "",
+  "temporalNegativeResult": "",
+  "infinitiveSetResult": "",
+  "infinitivePositiveResult": "",
+  "infinitiveNegativeResult": "",
+  "CustomParts": {
+    "CustomParts": []
+  }
+}

--- a/Core/Locust_Stick/events/event_mw_Locust_Stick.json
+++ b/Core/Locust_Stick/events/event_mw_Locust_Stick.json
@@ -1,487 +1,2258 @@
 {
-  "Description": {
-    "Id": "event_mw_Locust_Stick",
-    "Name": "Clobberin Time",
-    "Details": "While pacing through the Mech Bay on a sleepless night, you stumble across [[TGT_MW,{TGT_MW.Callsign}]]. {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:are|Default:is} looking over the schematics of a [[DM.BaseDescriptionDefs[BaseDesc_Locust],Locust LCT-1V]]. A jumbled pile of Spanners, bolts, and loose papers covered in scribbles litter the deck plating around {TGT_MW.Obj}.\r\n\r\nAs you approach, {TGT_MW.Callsign} looks up, a sheepish grin on {TGT_MW.Det} face. \"Uh. Hello, Commander. I was just trying to work out a way to make that Locust actually useful on the battlefield. I think we can weld the legs together, cram as much scrap metal into the chassis and actually fashion it into a club one of the bigger mechs can weild!  Can you talk to the Chief, he's already shooed me out of here once this week.\"",
-    "Icon": "uixTxrSpot_LocustStick.png"
-  },
-  "Scope": "MechWarrior",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "MechWarrior",
-    "RequirementTags": {
-      "items": [],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_mw_Locust_Stick",
+        "Name" : "Clobberin Time",
+        "Details" : "While pacing through the Mech Bay on a sleepless night, you stumble across [[TGT_MW,{TGT_MW.Callsign}]]. {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:are|Default:is} looking over the schematics of a [[DM.BaseDescriptionDefs[BaseDesc_Locust],Locust LCT-1V]]. A jumbled pile of Spanners, bolts, and loose papers covered in scribbles litter the deck plating around {TGT_MW.Obj}.\r\n\r\nAs you approach, {TGT_MW.Callsign} looks up, a sheepish grin on {TGT_MW.Det} face. \"Uh. Hello, Commander. I was just trying to work out a way to make that Locust in storage actually useful on the battlefield. I think we can weld the legs together, cram as much scrap metal into the chassis and actually fashion it into a club that one of the bigger mechs can weild!  Can you talk to the Chief, he's already shooed me out of here once this week.\"",
+        "Icon" : "uixTxrSpot_LocustStick.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": ""
-    },
-    "RequirementComparisons": [
-      {
-        "obj": "Injuries",
-        "op": "Equal",
-        "val": 0,
-        "valueConstant": "0"
-      }
-    ]
-  },
-  "AdditionalRequirements": [
-    {
-      "Scope": "Company",
-      "RequirementTags": {
-        "items": [],
-        "tagSetSourceFile": ""
-      },
-      "ExclusionTags": {
-        "items": [
-          "event_mw_locust_1v"
-        ],
-        "tagSetSourceFile": "Tags/CompanyTags"
-      },
-      "RequirementComparisons": [
-        {
-          "obj": "Item.MechDef.chassisdef_locust_LCT-1V",
-          "op": "GreaterThanOrEqual",
-          "val": 1,
-          "valueConstant": "1"
-        }
-      ]
-    }
-  ],
-  "AdditionalObjects": [
-    {
-      "Scope": "SecondaryMech",
-      "Requirements": {
-        "Scope": "SecondaryMech",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
+    "Scope" : "MechWarrior",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "MechWarrior",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
         },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
         },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "Remind {TGT_MW.Obj} that's not a MechWarrior's job.",
-        "Details": "Non-participation option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "Nothing happens",
-            "Details": "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. Let the specialists do their jobs.\"\r\n\r\nAs [[TGT_MW,{TGT_MW.Callsign}]] starts to get up, you gesture at the pile of bits on the ground. \"And clean up this mess. I don't want the Chief stumbling across your experiment in the morning.\"",
-            "Icon": null
-          },
-          "Weight": 100,
-          "Results": [
+        "RequirementComparisons" : [
             {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "event_mw_locust_1v"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
+                "obj" : "Injuries",
+                "op" : "Equal",
+                "val" : 0,
+                "valueConstant" : "0"
             }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
+        ]
     },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "Let {TGT_MW.Obj} keep working at it.",
-        "Details": "Risk vs Reward",
-        "Icon": null
-      },
-      "RequirementList": [
+    "AdditionalRequirements" : [
         {
-          "Scope": "MechWarrior",
-          "RequirementTags": {
-            "items": [
-              "pilot_bookish",
-              "pilot_lucky"
-            ],
-            "tagSetSourceFile": ""
-          },
-          "ExclusionTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RequirementComparisons": []
-        }
-      ],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "Success",
-            "Details": "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, glowing with excitement.\r\n\r\n\"I did it, Commander! That locust is a LOT deadlier now. Well, in the hands of a mech that wants to clobber other 'Mechs. I welded the legs together, removed the weapons and other gear and then filled all the empty spaces with scrap metal to bring it back to 20 tons.  I call it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"",
-            "Icon": null
-          },
-          "Weight": 10,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
+            "Scope" : "Company",
+            "RequirementTags" : {
+                "items" : [],
+                "tagSetSourceFile" : ""
+            },
+            "ExclusionTags" : {
+                "items" : [
+                    "event_mw_locust_1v"
+                ],
+                "tagSetSourceFile" : "Tags/CompanyTags"
+            },
+            "RequirementComparisons" : [
                 {
-                  "typeString": "System.Int32",
-                  "name": "Item.MechDef.chassisdef_locust_LCT-1V",
-                  "value": "-1",
-                  "set": false,
-                  "valueConstant": null
+                    "obj" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                    "op" : "GreaterThanOrEqual",
+                    "val" : 1,
+                    "valueConstant" : "1"
+                }
+            ]
+        }
+    ],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "Remind {TGT_MW.Obj} that's not a MechWarrior's job.",
+                "Details" : "Non-participation option",
+                "Icon" : null
+            },
+            "RequirementList" : [],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. Let the specialists do their jobs.\"\r\n\r\nAs [[TGT_MW,{TGT_MW.Callsign}]] starts to get up, you gesture at the pile of bits on the ground. \"And clean up this mess. I don't want the Chief stumbling across your experiment in the morning.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "Let {TGT_MW.Obj} keep working at it.",
+                "Details" : "Feeling Lucky",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "MechWarrior",
+                    "RequirementTags" : {
+                        "items" : [
+                            "pilot_lucky"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Success",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, glowing with excitement.\r\n\r\n\"I did it, Commander! That locust is a LOT deadlier now. Well, in the hands of a mech that wants to clobber other 'Mechs. I welded the legs together, removed the weapons and other gear and then filled all the empty spaces with scrap metal to bring it back to 20 tons.  I call it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 1,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
                 },
                 {
-                  "typeString": "System.Int32",
-                  "name": "Item.UpgradeDef.HandHeld_Melee_Mace_Locust",
-                  "value": "1",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "event_mw_locust_1v"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Mech Destroyed",
-            "Details": "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And…\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
-            "Icon": null
-          },
-          "Weight": 50,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Item.MechDef.chassisdef_locust_LCT-1V",
-                  "value": "-1",
-                  "set": false,
-                  "valueConstant": null
-                }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [
-                  "pilot_morale_high"
-                ],
-                "tagSetSourceFile": "Tags/PilotTags"
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "MechWarrior",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "pilot_morale_low"
-                ],
-                "tagSetSourceFile": "Tags/PilotTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 14
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "event_mw_locust_1v"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Nothing happens",
-            "Details": "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
-            "Icon": null
-          },
-          "Weight": 40,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "event_mw_locust_1v"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_2",
-        "Name": "Tell {TGT_MW.Obj} to share {TGT_MW.Det} ideas with Yang.",
-        "Details": "Inspiration",
-        "Icon": null
-      },
-      "RequirementList": [
-        {
-          "Scope": "MechWarrior",
-          "RequirementTags": {
-            "items": [
-              "pilot_tech",
-              "pilot_bookish"
-            ],
-            "tagSetSourceFile": "Tags/PilotTags"
-          },
-          "ExclusionTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RequirementComparisons": []
-        }
-      ],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_2_0",
-            "Name": "Success, wpn 1",
-            "Details": "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So… does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
-            "Icon": null
-          },
-          "Weight": 45,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                  "typeString": "System.Int32",
-                  "name": "Item.MechDef.chassisdef_locust_LCT-1V",
-                  "value": "-1",
-                  "set": false,
-                  "valueConstant": null
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 11,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
                 },
                 {
-                  "typeString": "System.Int32",
-                  "name": "Item.UpgradeDef.HandHeld_Melee_Mace_Locust",
-                  "value": "1",
-                  "set": false,
-                  "valueConstant": null
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 11,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_4",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_5",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 11,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_6",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 15,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_7",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 11,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
                 }
-              ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "event_mw_locust_1v"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
             }
-          ]
         },
         {
-          "Description": {
-            "Id": "outcome_2_1",
-            "Name": "Nothing happens",
-            "Details": "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
-            "Icon": null
-          },
-          "Weight": 55,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [
-                  "event_mw_locust_1v"
-                ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 90
+            "Description" : {
+                "Id" : "outcome_2",
+                "Name" : "Let {TGT_MW.Obj} keep working at it.",
+                "Details" : "Do More Research",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "MechWarrior",
+                    "RequirementTags" : {
+                        "items" : [
+                            "pilot_bookish"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_0",
+                        "Name" : "Success",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, glowing with excitement.\r\n\r\n\"I did it, Commander! That locust is a LOT deadlier now. Well, in the hands of a mech that wants to clobber other 'Mechs. I welded the legs together, removed the weapons and other gear and then filled all the empty spaces with scrap metal to bring it back to 20 tons.  I call it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_1",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_2",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_3",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_4",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_5",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_6",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_7",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_8",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall with an update.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. I did not even take anything apart on it.  The project is just way beyond my capabilities.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_9",
+                        "Name" : "Mech Destroyed",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, but doesn't look you in the eyes.\r\n\r\n\"Commander, I'm sorry to report that I wasn't able to weaponize that Locust like I wanted to. And\u2026\" {TGT_MW.Subj_C} {TGT_MW.Gender?NonBinary:struggle|Default:struggles} to continue. \"I wasn't able to put it back together either. I already told the Chief and he raked me over the coals. No more than I deserve, though.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_morale_high"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "MechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "pilot_morale_low"
+                                ],
+                                "tagSetSourceFile" : "Tags/PilotTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 14
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_10",
+                        "Name" : "Success",
+                        "Details" : "\"I suppose that was in storage for a reason, so maybe it won't hurt to see if your idea works. Just be careful. It may only be a 20 ton 'Mech, but it is not worthless.\"\r\n\r\nLater that week, [[TGT_MW,{TGT_MW.Callsign}]] catches you in the hall, glowing with excitement.\r\n\r\n\"I did it, Commander! That locust is a LOT deadlier now. Well, in the hands of a mech that wants to clobber other 'Mechs. I welded the legs together, removed the weapons and other gear and then filled all the empty spaces with scrap metal to bring it back to 20 tons.  I call it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
             }
-          ]
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_3",
+                "Name" : "Tell {TGT_MW.Obj} to share {TGT_MW.Det} ideas with Yang.",
+                "Details" : "Inspiration",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "MechWarrior",
+                    "RequirementTags" : {
+                        "items" : [
+                            "pilot_tech"
+                        ],
+                        "tagSetSourceFile" : "Tags/PilotTags"
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : []
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_0",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_1",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_2",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_3",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_4",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_5",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_6",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_7",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_8",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_9",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_10",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_11",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_12",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_13",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_14",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_15",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_16",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_17",
+                        "Name" : "Success, wpn 1",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the good news. He investigated your suggestions and managed to turn that Locust into a 20 ton mace.  He's called it the [[DM.BaseDescriptionDefs[BaseDesc_Special_Mace_Locust],Locust Stick]].\"\r\n\r\n{TGT_MW.Callsign} basks in the glow of victory. \"I knew it would work! So\u2026 does that mean I'm riding out on the next contract? I feel like I should be the first to get to use it!\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.MechDef.chassisdef_locust_LCT-1V",
+                                    "value" : "-1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                },
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "Item.UpgradeDef.Unique_HandHeld_Melee_Mace_Locust",
+                                    "value" : "1",
+                                    "set" : false,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_18",
+                        "Name" : "Nothing happens",
+                        "Details" : "\"MechWarriors belong in the 'Mechs. Technicians belong in the Mech Bay. But you seem pretty knowledgeable about these things, and you've already pulled the schematics and have the 'Mech in a harness. Explain to Yang what you were going for, and maybe he can finish what you started.\"\r\n\r\nLater that week, you catch [[TGT_MW,{TGT_MW.Callsign}]] in the hall.\r\n\r\n\"Chief Virtanen wanted me to pass along the news. He investigated your suggestions, but they didn't lead anywhere productive.\"\r\n\r\n{TGT_MW.Callsign} stares at the floor, crestfallen. \"Damn, I thought for sure that would work. Thanks for asking the Chief to give it a try, though. I guess I'd better stick to what I do best: using the weapons instead of trying to make them.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 5,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [
+                                    "event_mw_locust_1v"
+                                ],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 90
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "NORMAL",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [],
+        "tagSetSourceFile" : "tags/EventTags"
     }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "NORMAL",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [],
-    "tagSetSourceFile": "tags/EventTags"
-  }
 }


### PR DESCRIPTION
Changed parameters for event to be less stringent on pilot choice; Add StatDesc for Locust Stick Mace; Updated Locust Stick Mace item in event to renamed UNIQUE_HandHeld_Melee_Mace_Locust so that successful event actually puts item in inventory