### PR TITLE
SAR work

### DIFF
--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
@@ -179,12 +179,12 @@
           },
           "Stats": [
             {
-              "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.15",
-              "set": false,
-              "valueConstant": null
-            }
+							"typeString": "System.Single",
+							"name": "ContractBonusRewardFlat",
+							"value": "150000",
+							"set": false,
+							"valueConstant": null
+						}
           ],
           "Actions": [],
           "ForceEvents": [],
@@ -655,7 +655,7 @@
   "disableLanceConfiguration": false,
   "disableCancelButton": false,
   "disableAfterAction": false,
-  "contractRewardOverride": -1,
+  "contractRewardOverride": 0,
   "travelOnly": false,
   "useTravelCostPenalty": false,
   "usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
@@ -13,7 +13,7 @@
   "goodFaithStatementOverride": null,
   "shortDescription": "We've tracked our missing personnel. They're being held in a facility here on {TGT_SYSTEM.name}. Go get them. Make a show of force, commandeer a transport and escort them to a pickup point.",
   "longDescription": "We should expect resistance, but no one is paying us to shoot up the place. We're here for our person. A quick in and out is an option.",
-  "salvagePotential": 1,
+  "salvagePotential": 0,
   "requirementList": [],
   "OnContractSuccessResults": [],
   "OnContractFailureResults": [],
@@ -660,8 +660,8 @@
   "useTravelCostPenalty": false,
   "usesExpiration": true,
   "expirationTimeOverride": 15,
-  "negotiatedSalary": 0.5,
-  "negotiatedSalvage": 0.5,
+  "negotiatedSalary": 1.0,
+  "negotiatedSalvage": 0,
   "excludedFromProceduralGeneration": true,
   "player1Team": {
     "encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -13,7 +13,7 @@
   "goodFaithStatementOverride": null,
   "shortDescription": "We've tracked our missing personnel. They're being held in a facility here on {TGT_SYSTEM.name}. Go get them. Make a show of force, commandeer a transport and escort them to a pickup point.",
   "longDescription": "We should expect resistance, but no one is paying us to shoot up the place. We're here for our person. A quick in and out is an option.",
-  "salvagePotential": 1,
+  "salvagePotential": 0,
   "requirementList": [],
   "OnContractSuccessResults": [],
   "OnContractFailureResults": [],
@@ -660,8 +660,8 @@
   "useTravelCostPenalty": false,
   "usesExpiration": true,
   "expirationTimeOverride": 15,
-  "negotiatedSalary": 0.5,
-  "negotiatedSalvage": 0.5,
+  "negotiatedSalary": 1.0,
+  "negotiatedSalvage": 0,
   "excludedFromProceduralGeneration": true,
   "player1Team": {
     "encounterLayerData": {
@@ -1343,7 +1343,9 @@
         "name": "Lance_Enemy_Hunter",
         "lanceDefId": "Manual",
         "lanceTagSet": {
-          "items": [],
+          "items": [
+            "lance_type_notallvehicles"
+          ],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -178,13 +178,13 @@
             "tagSetSourceFile": ""
           },
           "Stats": [
-            {
-              "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.15",
-              "set": false,
-              "valueConstant": null
-            }
+						{
+							"typeString": "System.Single",
+							"name": "ContractBonusRewardFlat",
+							"value": "150000",
+							"set": false,
+							"valueConstant": null
+						}
           ],
           "Actions": [],
           "ForceEvents": [],
@@ -655,7 +655,7 @@
   "disableLanceConfiguration": false,
   "disableCancelButton": false,
   "disableAfterAction": false,
-  "contractRewardOverride": -1,
+  "contractRewardOverride": 0,
   "travelOnly": false,
   "useTravelCostPenalty": false,
   "usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -167,30 +167,30 @@
       "isPrimary": false,
       "OnSuccessResults": [
         {
-          "Scope": "Company",
-          "Requirements": null,
-          "AddedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RemovedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "Stats": [
-            {
-              "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.15",
-              "set": false,
-              "valueConstant": null
-            }
-          ],
-          "Actions": [],
-          "ForceEvents": [],
-          "TemporaryResult": false,
-          "ResultDuration": 0
-        },
+					"Scope": "Company",
+					"Requirements": null,
+					"AddedTags": {
+						"items": [],
+						"tagSetSourceFile": ""
+					},
+					"RemovedTags": {
+						"items": [],
+						"tagSetSourceFile": ""
+					},
+					"Stats": [
+						{
+							"typeString": "System.Single",
+							"name": "ContractBonusRewardFlat",
+							"value": "150000",
+							"set": false,
+							"valueConstant": null
+						}
+					],
+					"Actions": [],
+					"ForceEvents": [],
+					"TemporaryResult": false,
+					"ResultDuration": 0
+				},
         {
           "Scope": "Company",
           "Requirements": null,
@@ -655,7 +655,7 @@
   "disableLanceConfiguration": false,
   "disableCancelButton": false,
   "disableAfterAction": false,
-  "contractRewardOverride": -1,
+  "contractRewardOverride": 0,
   "travelOnly": false,
   "useTravelCostPenalty": false,
   "usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -13,7 +13,7 @@
   "goodFaithStatementOverride": null,
   "shortDescription": "We've tracked our missing personnel. They're being held in a facility here on {TGT_SYSTEM.name}. Go get them. Make a show of force, commandeer a transport and escort them to a pickup point.",
   "longDescription": "We should expect resistance, but no one is paying us to shoot up the place. We're here for our person. A quick in and out is an option.",
-  "salvagePotential": 1,
+  "salvagePotential": 0,
   "requirementList": [],
   "OnContractSuccessResults": [],
   "OnContractFailureResults": [],
@@ -660,8 +660,8 @@
   "useTravelCostPenalty": false,
   "usesExpiration": true,
   "expirationTimeOverride": 15,
-  "negotiatedSalary": 0.5,
-  "negotiatedSalvage": 0.5,
+  "negotiatedSalary": 1.0,
+  "negotiatedSalvage": 0,
   "excludedFromProceduralGeneration": true,
   "player1Team": {
     "encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_AssetRetrieval_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_AssetRetrieval_Easy.json
@@ -13,7 +13,7 @@
 	"goodFaithStatementOverride": null,
 	"shortDescription": "Nothing fancy, go get our pilot back. Drop light, go fast. No one is paying us to grind dozens of mechs into dust.",
 	"longDescription": "We've marked a data store as an optional objective, may as well see if they have any intel we can sell.",
-	"salvagePotential": 2,
+	"salvagePotential": 0,
 	"requirementList": [],
 	"OnContractSuccessResults": [],
 	"OnContractFailureResults": [],
@@ -534,9 +534,9 @@
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,
-	"expirationTimeOverride": 14,
-	"negotiatedSalary": 0.5,
-	"negotiatedSalvage": 0.5,
+	"expirationTimeOverride": 15,
+	"negotiatedSalary": 1.0,
+	"negotiatedSalvage": 0,
 	"excludedFromProceduralGeneration": true,
 	"player1Team": {
 		"encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_AssetRetrieval_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_AssetRetrieval_Easy.json
@@ -147,32 +147,7 @@
 						{
 							"typeString": "System.Single",
 							"name": "ContractBonusRewardFlat",
-							"value": "250000",
-							"set": false,
-							"valueConstant": null
-						}
-					],
-					"Actions": [],
-					"ForceEvents": [],
-					"TemporaryResult": false,
-					"ResultDuration": 0
-				},
-				{
-					"Scope": "Company",
-					"Requirements": null,
-					"AddedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"RemovedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"Stats": [
-						{
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardPct",
-							"value": "0.10",
+							"value": "300000",
 							"set": false,
 							"valueConstant": null
 						}
@@ -530,7 +505,7 @@
 	"disableLanceConfiguration": false,
 	"disableCancelButton": false,
 	"disableAfterAction": false,
-	"contractRewardOverride": -1,
+	"contractRewardOverride": 0,
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Easy.json
@@ -13,7 +13,7 @@
 	"goodFaithStatementOverride": null,
 	"shortDescription": "Nothing fancy, go get our pilot back. Drop light, go fast. No one is paying us to grind dozens of mechs into dust.",
 	"longDescription": "We've marked a data store as an optional objective, may as well see if they have any intel we can sell.",
-	"salvagePotential": 1,
+	"salvagePotential": 0,
 	"requirementList": [],
 	"OnContractSuccessResults": [],
 	"OnContractFailureResults": [],
@@ -535,8 +535,8 @@
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,
 	"expirationTimeOverride": 15,
-	"negotiatedSalary": 0.5,
-	"negotiatedSalvage": 0.5,
+	"negotiatedSalary": 1.0,
+	"negotiatedSalvage": 0,
 	"excludedFromProceduralGeneration": true,
 	"player1Team": {
 		"encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Easy.json
@@ -147,32 +147,7 @@
 						{
 							"typeString": "System.Single",
 							"name": "ContractBonusRewardFlat",
-							"value": "250000",
-							"set": false,
-							"valueConstant": null
-						}
-					],
-					"Actions": [],
-					"ForceEvents": [],
-					"TemporaryResult": false,
-					"ResultDuration": 0
-				},
-				{
-					"Scope": "Company",
-					"Requirements": null,
-					"AddedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"RemovedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"Stats": [
-						{
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardPct",
-							"value": "0.10",
+							"value": "300000",
 							"set": false,
 							"valueConstant": null
 						}
@@ -530,7 +505,7 @@
 	"disableLanceConfiguration": false,
 	"disableCancelButton": false,
 	"disableAfterAction": false,
-	"contractRewardOverride": -1,
+	"contractRewardOverride": 0,
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Hard.json
@@ -13,7 +13,7 @@
 	"goodFaithStatementOverride": null,
 	"shortDescription": "Nothing fancy, go get our pilot back. Drop light, go fast. No one is paying us to grind dozens of mechs into dust.",
 	"longDescription": "We've marked a data store as an optional objective, may as well see if they have any intel we can sell.",
-	"salvagePotential": 1,
+	"salvagePotential": 0,
 	"requirementList": [],
 	"OnContractSuccessResults": [],
 	"OnContractFailureResults": [],
@@ -535,8 +535,8 @@
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,
 	"expirationTimeOverride": 15,
-	"negotiatedSalary": 0.5,
-	"negotiatedSalvage": 0.5,
+	"negotiatedSalary": 1.0,
+	"negotiatedSalvage": 0,
 	"excludedFromProceduralGeneration": true,
 	"player1Team": {
 		"encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Hard.json
@@ -147,32 +147,7 @@
 						{
 							"typeString": "System.Single",
 							"name": "ContractBonusRewardFlat",
-							"value": "250000",
-							"set": false,
-							"valueConstant": null
-						}
-					],
-					"Actions": [],
-					"ForceEvents": [],
-					"TemporaryResult": false,
-					"ResultDuration": 0
-				},
-				{
-					"Scope": "Company",
-					"Requirements": null,
-					"AddedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"RemovedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"Stats": [
-						{
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardPct",
-							"value": "0.10",
+							"value": "300000",
 							"set": false,
 							"valueConstant": null
 						}
@@ -530,7 +505,7 @@
 	"disableLanceConfiguration": false,
 	"disableCancelButton": false,
 	"disableAfterAction": false,
-	"contractRewardOverride": -1,
+	"contractRewardOverride": 0,
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Hard.json
@@ -13,7 +13,7 @@
 	"goodFaithStatementOverride": null,
 	"shortDescription": "Nothing fancy, go get our pilot back. Drop light, go fast. No one is paying us to grind dozens of mechs into dust.",
 	"longDescription": "We've marked a data store as an optional objective, may as well see if they have any intel we can sell.",
-	"salvagePotential": 2,
+	"salvagePotential": 0,
 	"requirementList": [],
 	"OnContractSuccessResults": [],
 	"OnContractFailureResults": [],
@@ -535,8 +535,8 @@
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,
 	"expirationTimeOverride": 15,
-	"negotiatedSalary": 0.5,
-	"negotiatedSalvage": 0.5,
+	"negotiatedSalary": 1.0,
+	"negotiatedSalvage": 0,
 	"excludedFromProceduralGeneration": true,
 	"player1Team": {
 		"encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Hard.json
@@ -147,32 +147,7 @@
 						{
 							"typeString": "System.Single",
 							"name": "ContractBonusRewardFlat",
-							"value": "250000",
-							"set": false,
-							"valueConstant": null
-						}
-					],
-					"Actions": [],
-					"ForceEvents": [],
-					"TemporaryResult": false,
-					"ResultDuration": 0
-				},
-				{
-					"Scope": "Company",
-					"Requirements": null,
-					"AddedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"RemovedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"Stats": [
-						{
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardPct",
-							"value": "0.10",
+							"value": "300000",
 							"set": false,
 							"valueConstant": null
 						}
@@ -530,7 +505,7 @@
 	"disableLanceConfiguration": false,
 	"disableCancelButton": false,
 	"disableAfterAction": false,
-	"contractRewardOverride": -1,
+	"contractRewardOverride": 0,
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Med.json
@@ -13,7 +13,7 @@
 	"goodFaithStatementOverride": null,
 	"shortDescription": "Nothing fancy, go get our pilot back. Drop light, go fast. No one is paying us to grind dozens of mechs into dust.",
 	"longDescription": "We've marked a data store as an optional objective, may as well see if they have any intel we can sell.",
-	"salvagePotential": 2,
+	"salvagePotential": 0,
 	"requirementList": [],
 	"OnContractSuccessResults": [],
 	"OnContractFailureResults": [],
@@ -534,9 +534,9 @@
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,
-	"expirationTimeOverride": 14,
-	"negotiatedSalary": 0.5,
-	"negotiatedSalvage": 0.5,
+	"expirationTimeOverride": 15,
+	"negotiatedSalary": 1.0,
+	"negotiatedSalvage": 0,
 	"excludedFromProceduralGeneration": true,
 	"player1Team": {
 		"encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_IntelligenceAgent_Med.json
@@ -147,32 +147,7 @@
 						{
 							"typeString": "System.Single",
 							"name": "ContractBonusRewardFlat",
-							"value": "250000",
-							"set": false,
-							"valueConstant": null
-						}
-					],
-					"Actions": [],
-					"ForceEvents": [],
-					"TemporaryResult": false,
-					"ResultDuration": 0
-				},
-				{
-					"Scope": "Company",
-					"Requirements": null,
-					"AddedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"RemovedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"Stats": [
-						{
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardPct",
-							"value": "0.10",
+							"value": "300000",
 							"set": false,
 							"valueConstant": null
 						}
@@ -530,7 +505,7 @@
 	"disableLanceConfiguration": false,
 	"disableCancelButton": false,
 	"disableAfterAction": false,
-	"contractRewardOverride": -1,
+	"contractRewardOverride": 0,
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Med.json
@@ -13,7 +13,7 @@
 	"goodFaithStatementOverride": null,
 	"shortDescription": "Nothing fancy, go get our pilot back. Drop light, go fast. No one is paying us to grind dozens of mechs into dust.",
 	"longDescription": "We've marked a data store as an optional objective, may as well see if they have any intel we can sell.",
-	"salvagePotential": 1,
+	"salvagePotential": 0,
 	"requirementList": [],
 	"OnContractSuccessResults": [],
 	"OnContractFailureResults": [],
@@ -535,8 +535,8 @@
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,
 	"expirationTimeOverride": 15,
-	"negotiatedSalary": 0.5,
-	"negotiatedSalvage": 0.5,
+	"negotiatedSalary": 1.0,
+	"negotiatedSalvage": 0,
 	"excludedFromProceduralGeneration": true,
 	"player1Team": {
 		"encounterLayerData": {

--- a/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/Rescue_SAR_Med.json
@@ -147,32 +147,7 @@
 						{
 							"typeString": "System.Single",
 							"name": "ContractBonusRewardFlat",
-							"value": "250000",
-							"set": false,
-							"valueConstant": null
-						}
-					],
-					"Actions": [],
-					"ForceEvents": [],
-					"TemporaryResult": false,
-					"ResultDuration": 0
-				},
-				{
-					"Scope": "Company",
-					"Requirements": null,
-					"AddedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"RemovedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"Stats": [
-						{
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardPct",
-							"value": "0.10",
+							"value": "300000",
 							"set": false,
 							"valueConstant": null
 						}
@@ -530,7 +505,7 @@
 	"disableLanceConfiguration": false,
 	"disableCancelButton": false,
 	"disableAfterAction": false,
-	"contractRewardOverride": -1,
+	"contractRewardOverride": 0,
 	"travelOnly": false,
 	"useTravelCostPenalty": false,
 	"usesExpiration": true,

--- a/Core/SearchAndRescue/itemcollection/itemcollection_SAR_ExtractionLoot.csv
+++ b/Core/SearchAndRescue/itemcollection/itemcollection_SAR_ExtractionLoot.csv
@@ -1,3 +1,3 @@
 itemcollection_SAR_ExtractionLoot,,,
-itemCollection_table_OneItem_common,Reference,1,10
+itemCollection_table_OneItem_common,Reference,2,10
 RT_Ammo_Loot,Reference,2,10

--- a/Documents/Patch Notes Scratch Pad.txt
+++ b/Documents/Patch Notes Scratch Pad.txt
@@ -11,6 +11,12 @@ Later on weapons we added had limited shots. Leading to some weirdness.
 This update brings consistency and makes all their non-laser and PPC weapons have limited ammo.
 
 SAR:
+
+It's miserable.
+No salvage. None. You gotta scoot. No one is giving any support while you scavenge the field.
+No pay. You have no employer. It's your company financing a run to get your pilot back. Secondary objectives for cash may offset costs.
+How can you do this mission more cheaply and efficiently?
+
 Tweaks to enemy force composition on Rescue type SAR, setting one to always be a Mixed lance of mechs and vehicles.
 
 Escort type: 

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Coupe.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Coupe.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "Some pilots from {TEAM_TAR.FactionDef.Name} want a piece of us. They've issued a direct to our challenge and are sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Expect heavy resistance, Commander.",
   "longDescription": "We came to {TGT_SYSTEM.Name} to chew gum and kick ass, and the crew tells me we just ran out of gum.",
-  "salvagePotential": "7",
+  "salvagePotential": 8,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Coupe_hard.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Coupe_hard.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "Some pilots from {TEAM_TAR.FactionDef.Name} want a piece of us. They've issued a direct to our challenge and are sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Don't expect this lot to fight fair, Commander.",
   "longDescription": "We came to {TGT_SYSTEM.Name} to chew gum and kick ass, and the crew tells me we just ran out of gum.",
-  "salvagePotential": "7",
+  "salvagePotential": 8,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Coupe_solo.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Coupe_solo.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "Some pilots from {TEAM_TAR.FactionDef.Name} want a piece of us. They've issued a direct to our challenge and are sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. There's also word on the wind that they brought specialists with them.",
   "longDescription": "We came to {TGT_SYSTEM.Name} to chew gum and kick ass, and the crew tells me we just ran out of gum.",
-  "salvagePotential": "7",
+  "salvagePotential": 8,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_EnGarde.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_EnGarde.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "A group of pilots from {TEAM_TAR.FactionDef.Name} have issued a direct challenge against your company. They're sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Expect heavy resistance, Commander.",
   "longDescription": "If they want a demonstration of our skills in {TGT_SYSTEM.Name}, we can do that for them.",
-  "salvagePotential": "5",
+  "salvagePotential": 4,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_EnGarde_hard.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_EnGarde_hard.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "A group of pilots from {TEAM_TAR.FactionDef.Name} have issued a direct challenge against your company. They're sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Don't expect a fair fight, though.",
   "longDescription": "If they want a demonstration of our skills in {TGT_SYSTEM.Name}, we can do that for them.",
-  "salvagePotential": "6",
+  "salvagePotential": 4,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_EnGarde_solo.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_EnGarde_solo.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "A group of pilots from {TEAM_TAR.FactionDef.Name} have issued a direct challenge against your company. They're sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Rumour has it that they've got specialists in their team, too.",
   "longDescription": "If they want a demonstration of our skills in {TGT_SYSTEM.Name}, we can do that for them.",
-  "salvagePotential": "6",
+  "salvagePotential": 4,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Frontlines.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Frontlines.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "There's a DropShip flying {TEAM_TAR.FactionDef.Name} colours trying to make landfall. {TEAM_EMP.FactionDef.Government} is hiring us to address this violation of their aerospace by force. They're promising an elite strike force stowed on the enemy ship, and a fat paycheque for resolving the cargo.",
   "longDescription": "I don't know why there's such a decorated unit coming to {TGT_SYSTEM.Name}, but be ready to have your work cut out for you.",
-  "salvagePotential": "8",
+  "salvagePotential": 8,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Meatgrinder.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Meatgrinder.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "2 elite lances belonging to {TEAM_TAR.FactionDef.Name} are holding an important location on {TGT_SYSTEM.Name}. {TEAM_EMP.FactionDef.Government} wants to enlist us to remedy this situation on their behalf. If these pilots are as good as intel suggests, we're going to have a real fight on our hands.",
   "longDescription": "I don't know why high end pilots are fighting over this patch of dirt, Commander. We're being paid to evict them, not ask questions.",
-  "salvagePotential": "10",
+  "salvagePotential": 12,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Riposte.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Riposte.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "Some pilots from {TEAM_TAR.FactionDef.Name} are challenging our company in battle. They're sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Expect heavy resistance, Commander.",
   "longDescription": "Those are fighting words, Commander. Want to give the locals in {TGT_SYSTEM.Name} a show?",
-  "salvagePotential": "6",
+  "salvagePotential": 4,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Riposte_hard.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Riposte_hard.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "Some pilots from {TEAM_TAR.FactionDef.Name} are challenging our company in battle. They're sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Expect heavy resistance, Commander. I wouldn't expect a fair fight, though.",
   "longDescription": "Those are fighting words, Commander. Want to give the locals in {TGT_SYSTEM.Name} a show?",
-  "salvagePotential": "7",
+  "salvagePotential": 8,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_Riposte_solo.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_Riposte_solo.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "Some pilots from {TEAM_TAR.FactionDef.Name} are challenging our company in battle. They're sporting high end mechs kitted to the gills with gear. Our {TEAM_EMP.FactionDef.Government} leadership would pay a handsome fee for the broadcast rights to the ensuing carnage. Expect heavy resistance, Commander - rumour has it they've got specialists in their ranks.",
   "longDescription": "Those are fighting words, Commander. Want to give the locals in {TGT_SYSTEM.Name} a show?",
-  "salvagePotential": "7",
+  "salvagePotential": 8,
   "requirementList": [
     {
       "Scope": "Company",

--- a/Optionals/RogueElites/Base/DuelContracts/Duel_TrialByFire.json
+++ b/Optionals/RogueElites/Base/DuelContracts/Duel_TrialByFire.json
@@ -8,7 +8,7 @@
   "finalDifficulty": 0,
   "shortDescription": "{TEAM_EMP.FactionDef.Government} wants two elite lances belonging to {TEAM_TAR.FactionDef.Name} taken out. The contract is claiming that they're raiders terrorising {TGT_SYSTEM.Name}. Intel suggests they have an excellent supply line, so expect stiff resistance.",
   "longDescription": "Our employer is saying that the bad guys are 'terrorists', but this contract reads like the legal equivalent of, 'Talk shit, get hit.'",
-  "salvagePotential": "9",
+  "salvagePotential": 8,
   "requirementList": [
     {
       "Scope": "Company",


### PR DESCRIPTION
Tip of the hat to Werecat for this general bleak idea. Literally no one is paying you. This contract should not pay.

It's miserable.
No salvage. None. You gotta scoot. No one is giving any support while you scavenge the field.
No pay. You have no employer. It's your company financing a run to get your pilot back. Secondary objectives for cash may offset costs.
How can you do this mission more cheaply and efficiently? 

300k for secondary objective in Rescue.
150k and crap lootbox for both APC in Escort.

This will suck, but most of the suck is because players won't have considered for it in their company design at all. Just like before we started revising SAR the high-level impossible Rescues didn't suck for D20 RTO players because they had a crazy LAM to do it in 1.5 turns. Conceptually if you start a career understanding how SAR works you *will* maintain units capable of either running or killing through one cheaply. Or get used to tanking the cost. 