### PR TITLE
Wing Mount and Bay Price Settings

### DIFF
--- a/Core/RogueModuleTech/AddOn/Pods/BoltOn_Weapon_Pod_M.json
+++ b/Core/RogueModuleTech/AddOn/Pods/BoltOn_Weapon_Pod_M.json
@@ -82,7 +82,7 @@
   "DamageNotDivided": true,
   "WeaponEffectID": "WeaponEffect-Weapon_LB20X",
   "Description": {
-    "Cost": 4500,
+    "Cost": 6000,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "Solaris Arms",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x1.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 800"
+      "AmmoCost: 4000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 4000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 20000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x2.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 800"
+      "AmmoCost: 4000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 4000
     },
     "CarryLeftOverUsage": 1,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 44000,
+    "Cost": 40000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x3.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 800"
+      "AmmoCost: 4000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 4000
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 66000,
+    "Cost": 60000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x4.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 4",
-      "AmmoCost: 800"
+      "AmmoCost: 4000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 4000
     },
     "CarryLeftOverUsage": 2,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 88000,
+    "Cost": 80000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Cluster_x5.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 5",
-      "AmmoCost: 800"
+      "AmmoCost: 4000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 4000
     },
     "CarryLeftOverUsage": 2.5,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 110000,
+    "Cost": 100000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_DaisyCutter.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_DaisyCutter.json
@@ -17,10 +17,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 11500"
+      "AmmoCost: 15000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 11500
+      "PerUnitCost": 15000
     },
     "CarryLeftOverUsage": 2.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x1.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 2000"
+      "AmmoCost: 7500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 7500
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -107,7 +107,7 @@
   },
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 35000,
+    "Cost": 37500,
     "Rarity": 25,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_FAE_x2.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 2000"
+      "AmmoCost: 7500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 7500
     },
     "CarryLeftOverUsage": 1,
     "Flags": [
@@ -107,7 +107,7 @@
   },
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 70000,
+    "Cost": 75000,
     "Rarity": 25,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x1.json
@@ -21,10 +21,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 2000"
+      "AmmoCost: 5000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 5000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x2.json
@@ -21,10 +21,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 2000"
+      "AmmoCost: 5000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 5000
     },
     "CarryLeftOverUsage": 1,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x3.json
@@ -21,10 +21,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 2000"
+      "AmmoCost: 5000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 5000
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x4.json
@@ -21,10 +21,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 2000"
+      "AmmoCost: 5000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 5000
     },
     "CarryLeftOverUsage": 2,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Guided_x5.json
@@ -21,10 +21,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 5",
-      "AmmoCost: 2000"
+      "AmmoCost: 5000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 5000
     },
     "CarryLeftOverUsage": 2.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x1.json
@@ -17,10 +17,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 800"
+      "AmmoCost: 2500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 2500
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -63,7 +63,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 12500,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x2.json
@@ -17,10 +17,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 800"
+      "AmmoCost: 2500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 2500
     },
     "CarryLeftOverUsage": 1,
     "Flags": [
@@ -63,7 +63,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 44000,
+    "Cost": 25000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x3.json
@@ -17,10 +17,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 800"
+      "AmmoCost: 2500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 2500
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [
@@ -63,7 +63,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 66000,
+    "Cost": 37500,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x4.json
@@ -17,10 +17,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 4",
-      "AmmoCost: 800"
+      "AmmoCost: 2500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 2500
     },
     "CarryLeftOverUsage": 2,
     "Flags": [
@@ -63,7 +63,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 88000,
+    "Cost": 50000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_HE_x5.json
@@ -17,10 +17,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 5",
-      "AmmoCost: 800"
+      "AmmoCost: 2500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 2500
     },
     "CarryLeftOverUsage": 2.5,
     "Flags": [
@@ -63,7 +63,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 111000,
+    "Cost": 62500,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x1.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 1400"
+      "AmmoCost: 3000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1400
+      "PerUnitCost": 3000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 15000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x2.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 1400"
+      "AmmoCost: 3000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1400
+      "PerUnitCost": 3000
     },
     "CarryLeftOverUsage": 1,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 44000,
+    "Cost": 30000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x3.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 1400"
+      "AmmoCost: 3000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1400
+      "PerUnitCost": 3000
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 44000,
+    "Cost": 45000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x4.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 4",
-      "AmmoCost: 1400"
+      "AmmoCost: 3000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1400
+      "PerUnitCost": 3000
     },
     "CarryLeftOverUsage": 2,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 88000,
+    "Cost": 60000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Inferno_x5.json
@@ -20,10 +20,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 5",
-      "AmmoCost: 1400"
+      "AmmoCost: 3000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1400
+      "PerUnitCost": 3000
     },
     "CarryLeftOverUsage": 2.5,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 88000,
+    "Cost": 75000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_MOAB.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_MOAB.json
@@ -18,10 +18,10 @@
       "EjectableWeapon",
       "RestrictedLocations: CT",
       "InternalAmmoShots: 1",
-      "AmmoCost: 26250"
+      "AmmoCost: 33000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 10500
+      "PerUnitCost": 33000
     },
     "CarryLeftOverUsage": 5,
     "Flags": [
@@ -94,7 +94,7 @@
   },
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 346500,
+    "Cost": 345678,
     "Rarity": 100,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x1.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 1000"
+      "AmmoCost: 7200"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 7200
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 36000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x2.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 1000"
+      "AmmoCost: 7200"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 7200
     },
     "CarryLeftOverUsage": 1,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 72000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x3.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 1000"
+      "AmmoCost: 7200"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 7200
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 108000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x4.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 4",
-      "AmmoCost: 1000"
+      "AmmoCost: 7200"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 7200
     },
     "CarryLeftOverUsage": 2,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 144000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_Inferno_x5.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 5",
-      "AmmoCost: 1000"
+      "AmmoCost: 7200"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 7200
     },
     "CarryLeftOverUsage": 2.5,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 180000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x1.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 1000"
+      "AmmoCost: 6000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 22000,
+    "Cost": 30000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x2.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 1000"
+      "AmmoCost: 6000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "CarryLeftOverUsage": 1,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 44000,
+    "Cost": 60000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x3.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 1000"
+      "AmmoCost: 6000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 66000,
+    "Cost": 90000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x4.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 4",
-      "AmmoCost: 1000"
+      "AmmoCost: 6000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "CarryLeftOverUsage": 2,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 88000,
+    "Cost": 120000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x5.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Bombs/Weapon_WingMount_Bomb_Mine_x5.json
@@ -19,10 +19,10 @@
       "BombToss",
       "EjectableWeapon",
       "InternalAmmoShots: 5",
-      "AmmoCost: 1000"
+      "AmmoCost: 6000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "CarryLeftOverUsage": 2.5,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 110000,
+    "Cost": 150000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAA_Arrow.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAA_Arrow.json
@@ -21,10 +21,10 @@
       "AMSChance: -50%",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 2000"
+      "AmmoCost: 9000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 9000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -90,7 +90,7 @@
   "AdditionalImpactVFXScaleY": 2,
   "AdditionalImpactVFXScaleZ": 2,
   "Description": {
-    "Cost": 50000,
+    "Cost": 45000,
     "Rarity": 14,
     "Purchasable": true,
     "Manufacturer": "Tengo Aerospace",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAiATM_12_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AAiATM_12_x3.json
@@ -24,10 +24,10 @@
       "AMSChance: -33%",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 200"
+      "AmmoCost: 250"
     ],
     "AmmoCost": {
-      "PerUnitCost": 200
+      "PerUnitCost": 250
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [
@@ -71,7 +71,7 @@
   "Instability": 2,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 50000,
+    "Cost": 45000,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "Clan",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x1.json
@@ -19,10 +19,10 @@
       "NoAA",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 1000"
+      "AmmoCost: 4500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 4500
     },
     "CarryLeftOverUsage": 0.25,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 25000,
+    "Cost": 22500,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_AGM_10_x2.json
@@ -19,10 +19,10 @@
       "NoAA",
       "EjectableWeapon",
       "InternalAmmoShots: 2",
-      "AmmoCost: 1000"
+      "AmmoCost: 4500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 4500
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -65,7 +65,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 50000,
+    "Cost": 45000,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_ArrowIV.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_ArrowIV.json
@@ -23,10 +23,10 @@
       "AMSChance: -30%",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 2000"
+      "AmmoCost: 3000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 3000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -76,7 +76,7 @@
   "ProjectileSpeedMultiplier": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 50000,
+    "Cost": 15000,
     "Rarity": 14,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x1.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x1.json
@@ -19,10 +19,10 @@
       "MissileHP: 30",
       "AMSChance: -50%",
       "InternalAmmoShots: 1",
-      "AmmoCost: 1000"
+      "AmmoCost: 6000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "CarryLeftOverUsage": 0.25,
     "Flags": [
@@ -66,7 +66,7 @@
   "Instability": 10,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 25000,
+    "Cost": 22500,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x2.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_LightAA_x2.json
@@ -19,10 +19,10 @@
       "MissileHP: 30",
       "AMSChance: -50%",
       "InternalAmmoShots: 2",
-      "AmmoCost: 1000"
+      "AmmoCost: 6000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Phoenix_x3.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Phoenix_x3.json
@@ -17,10 +17,10 @@
       "AMSChance: -30%",
       "EjectableWeapon",
       "InternalAmmoShots: 3",
-      "AmmoCost: 500"
+      "AmmoCost: 3500"
     ],
     "AmmoCost": {
-      "PerUnitCost": 500
+      "PerUnitCost": 3500
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [
@@ -63,7 +63,7 @@
   "Instability": 15,
   "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
   "Description": {
-    "Cost": 50000,
+    "Cost": 37500,
     "Rarity": 7,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile.json
@@ -16,10 +16,10 @@
       "MissileHP: 10",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 444"
+      "AmmoCost: 1000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 444
+      "PerUnitCost": 1000
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_QuadMissile_x4.json
@@ -16,10 +16,10 @@
       "MissileHP: 10",
       "EjectableWeapon",
       "InternalAmmoShots: 4",
-      "AmmoCost: 444"
+      "AmmoCost: 1000"
     ],
     "AmmoCost": {
-      "PerUnitCost": 444
+      "PerUnitCost": 1000
     },
     "CarryLeftOverUsage": 2,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15.json
@@ -15,10 +15,10 @@
       "MissileHP: 3",
       "EjectableWeapon",
       "InternalAmmoShots: 1",
-      "AmmoCost: 20"
+      "AmmoCost: 50"
     ],
     "AmmoCost": {
-      "PerUnitCost": 20
+      "PerUnitCost": 50
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15_x4.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_15_x4.json
@@ -15,10 +15,10 @@
       "MissileHP: 3",
       "EjectableWeapon",
       "InternalAmmoShots: 4",
-      "AmmoCost: 20"
+      "AmmoCost: 50"
     ],
     "AmmoCost": {
-      "PerUnitCost": 20
+      "PerUnitCost": 50
     },
     "CarryLeftOverUsage": 2,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_AA_25.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Missiles/Weapon_WingMount_Rocket_AA_25.json
@@ -18,10 +18,10 @@
       "MissileHP: 3",
       "EjectableWeapon",
       "1shot",
-      "AmmoCost: 40"
+      "AmmoCost: 100"
     ],
     "AmmoCost": {
-      "PerUnitCost": 40
+      "PerUnitCost": 100
     },
     "CarryLeftOverUsage": 0.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_Vulcan.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_Vulcan.json
@@ -18,10 +18,10 @@
       "ReqLandAirMech",
       "EjectableWeapon",
       "InternalAmmoShots: 10",
-      "AmmoCost: 10"
+      "AmmoCost: 25"
     ],
     "AmmoCost": {
-      "PerUnitCost": 10
+      "PerUnitCost": 25
     },
     "CarryLeftOverUsage": 1.5,
     "Flags": [

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow.json
@@ -21,11 +21,11 @@
       "AMSChance: -50%",
       "MissileHP: 40",
       "AmmoCount: Missile, 1",
-      "AmmoCost: 2000",
+      "AmmoCost: 9000",
       "AmmoBoxExplosionDHS: 60, 25, 12.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 9000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 60.0,
@@ -44,7 +44,7 @@
   "AmmoID": "Ammunition_Bay_AAA_Arrow",
   "Capacity": 1,
   "Description": {
-    "Cost": 50000,
+    "Cost": 45000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AAA_Arrow_x2.json
@@ -21,11 +21,11 @@
       "AMSChance: -50%",
       "MissileHP: 40",
       "AmmoCount: Missile, 2",
-      "AmmoCost: 2000",
+      "AmmoCost: 9000",
       "AmmoBoxExplosionDHS: 60, 25, 12.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 9000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 60.0,
@@ -44,7 +44,7 @@
   "AmmoID": "Ammunition_Bay_AAA_Arrow",
   "Capacity": 2,
   "Description": {
-    "Cost": 100000,
+    "Cost": 90000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10.json
@@ -18,11 +18,11 @@
       "AMSChance: -30%",
       "NoAA",
       "AmmoCount: Missile, 2",
-      "AmmoCost: 1000",
+      "AmmoCost: 4500",
       "AmmoBoxExplosionDHS: 30, 15, 7.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 4500
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 30.0,
@@ -41,7 +41,7 @@
   "AmmoID": "Ammunition_Bay_AGM_10",
   "Capacity": 2,
   "Description": {
-    "Cost": 50000,
+    "Cost": 45000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_AGM_10_x2.json
@@ -18,11 +18,11 @@
       "AMSChance: -30%",
       "NoAA",
       "AmmoCount: Missile, 4",
-      "AmmoCost: 1000",
+      "AmmoCost: 4500",
       "AmmoBoxExplosionDHS: 30, 15, 7.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 4500
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 30.0,
@@ -41,7 +41,7 @@
   "AmmoID": "Ammunition_Bay_AGM_10",
   "Capacity": 4,
   "Description": {
-    "Cost": 100000,
+    "Cost": 90000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV.json
@@ -43,7 +43,7 @@
   "AmmoID": "Ammunition_Bay_ArrowIV",
   "Capacity": 1,
   "Description": {
-    "Cost": 50000,
+    "Cost": 10000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_ArrowIV_x2.json
@@ -43,7 +43,7 @@
   "AmmoID": "Ammunition_Bay_ArrowIV",
   "Capacity": 2,
   "Description": {
-    "Cost": 100000,
+    "Cost": 20000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster.json
@@ -18,11 +18,11 @@
       "MineClearanceBoom: 2",
       "BombToss",
       "AmmoCount: Bomb, 1",
-      "AmmoCost: 800",
+      "AmmoCost: 4000",
       "AmmoBoxExplosionDHS: 27.5, 3.8, 1.9"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 4000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 27.5,
@@ -41,7 +41,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_Cluster",
   "Capacity": 1,
   "Description": {
-    "Cost": 22000,
+    "Cost": 20000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Cluster_x2.json
@@ -18,11 +18,11 @@
       "MineClearanceBoom: 2",
       "BombToss",
       "AmmoCount: Bomb, 2",
-      "AmmoCost: 800",
+      "AmmoCost: 4000",
       "AmmoBoxExplosionDHS: 27.5, 3.8, 1.9"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 4000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 27.5,
@@ -41,7 +41,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_Cluster",
   "Capacity": 2,
   "Description": {
-    "Cost": 44000,
+    "Cost": 40000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided.json
@@ -21,11 +21,11 @@
       "MineClearanceBoom: 1",
       "BombToss",
       "AmmoCount: Guided, 1",
-      "AmmoCost: 2000",
+      "AmmoCost: 5000",
       "AmmoBoxExplosionDHS: 32.5, 12.5, 6.3"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 5000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 32.5,
@@ -44,7 +44,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_Guided",
   "Capacity": 1,
   "Description": {
-    "Cost": 50000,
+    "Cost": 25000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Guided_x2.json
@@ -21,11 +21,11 @@
       "MineClearanceBoom: 1",
       "BombToss",
       "AmmoCount: Bomb, 2",
-      "AmmoCost: 2000",
+      "AmmoCost: 5000",
       "AmmoBoxExplosionDHS: 32.5, 12.5, 6.3"
     ],
     "AmmoCost": {
-      "PerUnitCost": 2000
+      "PerUnitCost": 5000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 32.5,
@@ -44,7 +44,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_Guided",
   "Capacity": 2,
   "Description": {
-    "Cost": 100000,
+    "Cost": 50000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE.json
@@ -17,11 +17,11 @@
       "MineClearanceBoom: 2",
       "BombToss",
       "AmmoCount: HE, 1",
-      "AmmoCost: 800",
+      "AmmoCost: 2500",
       "AmmoBoxExplosionDHS: 37.5, 6.3, 3.1"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 2500
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 37.5,
@@ -40,7 +40,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_HE",
   "Capacity": 1,
   "Description": {
-    "Cost": 22000,
+    "Cost": 12500,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_HE_x2.json
@@ -17,11 +17,11 @@
       "MineClearanceBoom: 2",
       "BombToss",
       "AmmoCount: HE, 2",
-      "AmmoCost: 800",
+      "AmmoCost: 2500",
       "AmmoBoxExplosionDHS: 37.5, 6.3, 3.1"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 2500
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 37.5,
@@ -40,7 +40,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_HE",
   "Capacity": 2,
   "Description": {
-    "Cost": 44000,
+    "Cost": 25000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno.json
@@ -20,11 +20,11 @@
       "FireTerrainDuration: 3",
       "BombToss",
       "AmmoCount: Inferno, 1",
-      "AmmoCost: 800",
+      "AmmoCost: 3000",
       "AmmoBoxExplosionDHS: 7.5, 22.5, 1.3"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 3000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 7.5,
@@ -43,7 +43,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_Inferno",
   "Capacity": 1,
   "Description": {
-    "Cost": 22000,
+    "Cost": 15000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Inferno_x2.json
@@ -20,11 +20,11 @@
       "FireTerrainDuration: 3",
       "BombToss",
       "AmmoCount: Inferno, 2",
-      "AmmoCost: 800",
+      "AmmoCost: 3000",
       "AmmoBoxExplosionDHS: 7.5, 22.5, 1.3"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 3000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 7.5,
@@ -43,7 +43,7 @@
   "AmmoID": "Ammunition_Bay_Bomb_Inferno",
   "Capacity": 2,
   "Description": {
-    "Cost": 44000,
+    "Cost": 30000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine.json
@@ -16,11 +16,11 @@
       "MinefieldMove: N/A",
       "BombToss",
       "AmmoCount: Mine, 1",
-      "AmmoCost: 800",
+      "AmmoCost: 6000",
       "AmmoBoxExplosionDHS: 2.5, 1.3, 0.6"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 6000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 2.5,
@@ -39,7 +39,7 @@
   "AmmoID": "Ammunition_Bay_Minefield",
   "Capacity": 1,
   "Description": {
-    "Cost": 22000,
+    "Cost": 30000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno.json
@@ -16,11 +16,11 @@
       "MinefieldMove: N/A",
       "BombToss",
       "AmmoCount: Inferno Mine, 1",
-      "AmmoCost: 1000",
+      "AmmoCost: 7200",
       "AmmoBoxExplosionH: 2.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 7200
     },
     "ComponentExplosion": {
       "HeatDamagePerAmmo": 2.5
@@ -37,7 +37,7 @@
   "AmmoID": "Ammunition_Bay_Minefield_Inferno",
   "Capacity": 1,
   "Description": {
-    "Cost": 22000,
+    "Cost": 36000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_Inferno_x2.json
@@ -16,11 +16,11 @@
       "MinefieldMove: N/A",
       "BombToss",
       "AmmoCount: Inferno Mine, 2",
-      "AmmoCost: 1000",
+      "AmmoCost: 7200",
       "AmmoBoxExplosionH: 2.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 7200
     },
     "ComponentExplosion": {
       "HeatDamagePerAmmo": 2.5
@@ -37,7 +37,7 @@
   "AmmoID": "Ammunition_Bay_Minefield_Inferno",
   "Capacity": 2,
   "Description": {
-    "Cost": 44000,
+    "Cost": 72000,
     "Rarity": 2,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Bomb_Mine_x2.json
@@ -16,11 +16,11 @@
       "MinefieldMove: N/A",
       "BombToss",
       "AmmoCount: Mine, 2",
-      "AmmoCost: 800",
+      "AmmoCost: 6000",
       "AmmoBoxExplosionDHS: 2.5, 1.3, 0.6"
     ],
     "AmmoCost": {
-      "PerUnitCost": 800
+      "PerUnitCost": 6000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 2.5,
@@ -39,7 +39,7 @@
   "AmmoID": "Ammunition_Bay_Minefield",
   "Capacity": 2,
   "Description": {
-    "Cost": 44000,
+    "Cost": 60000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Flare.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Flare.json
@@ -17,10 +17,10 @@
       "MunitionsRange: 0,30,60,90,120",
       "ShotsFiredAmmo: 10",
       "AmmoCount: Missile, 50",
-      "AmmoCost: 300"
+      "AmmoCost: 250"
     ],
     "AmmoCost": {
-      "PerUnitCost": 300
+      "PerUnitCost": 250
     },
     "Flags": [
       "not_broken"
@@ -34,7 +34,7 @@
   "AmmoID": "Ammunition_Bay_Flare",
   "Capacity": 50,
   "Description": {
-    "Cost": 10000,
+    "Cost": 62500,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Hellfire.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Hellfire.json
@@ -15,11 +15,11 @@
       "ShotsFiredAmmo: 20",
       "MissileHP: 2",
       "AmmoCount: Missile, 20",
-      "AmmoCost: 150",
+      "AmmoCost: 300",
       "AmmoBoxExplosionDHS: 5, 2.5, 1.3"
     ],
     "AmmoCost": {
-      "PerUnitCost": 150
+      "PerUnitCost": 300
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 5.0,
@@ -38,7 +38,7 @@
   "AmmoID": "Ammunition_Bay_Hellfire",
   "Capacity": 20,
   "Description": {
-    "Cost": 300000,
+    "Cost": 30000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA.json
@@ -19,11 +19,11 @@
       "MissileHP: 30",
       "AMSChance: -50%",
       "AmmoCount: Missile, 2",
-      "AmmoCost: 1000",
+      "AmmoCost: 6000",
       "AmmoBoxExplosionDHS: 25, 10, 5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 25.0,
@@ -42,7 +42,7 @@
   "AmmoID": "Ammunition_Bay_LightAA",
   "Capacity": 2,
   "Description": {
-    "Cost": 50000,
+    "Cost": 60000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_LightAA_x2.json
@@ -19,11 +19,11 @@
       "MissileHP: 30",
       "AMSChance: -50%",
       "AmmoCount: Missile, 4",
-      "AmmoCost: 1000",
+      "AmmoCost: 6000",
       "AmmoBoxExplosionDHS: 25, 10, 5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 1000
+      "PerUnitCost": 6000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 25.0,
@@ -42,7 +42,7 @@
   "AmmoID": "Ammunition_Bay_LightAA",
   "Capacity": 4,
   "Description": {
-    "Cost": 100000,
+    "Cost": 120000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix.json
@@ -17,11 +17,11 @@
       "MissileHP: 20",
       "AMSChance: -30%",
       "AmmoCount: Missile, 3",
-      "AmmoCost: 500",
+      "AmmoCost: 3500",
       "AmmoBoxExplosionDHS: 22.5, 11.3, 5.6"
     ],
     "AmmoCost": {
-      "PerUnitCost": 500
+      "PerUnitCost": 3500
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 22.5,
@@ -40,7 +40,7 @@
   "AmmoID": "Ammunition_Bay_Phoenix",
   "Capacity": 3,
   "Description": {
-    "Cost": 50000,
+    "Cost": 37500,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_Phoenix_x2.json
@@ -17,11 +17,11 @@
       "MissileHP: 20",
       "AMSChance: -30%",
       "AmmoCount: Missile, 6",
-      "AmmoCost: 500",
+      "AmmoCost: 3500",
       "AmmoBoxExplosionDHS: 22.5, 11.3, 5.6"
     ],
     "AmmoCost": {
-      "PerUnitCost": 500
+      "PerUnitCost": 3500
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 22.5,
@@ -40,7 +40,7 @@
   "AmmoID": "Ammunition_Bay_Phoenix",
   "Capacity": 6,
   "Description": {
-    "Cost": 100000,
+    "Cost": 75000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile.json
@@ -17,11 +17,11 @@
       "DoesCluster",
       "MissileHP: 10",
       "AmmoCount: Missile, 1",
-      "AmmoCost: 444",
+      "AmmoCost: 1000",
       "AmmoBoxExplosionDHS: 50, 25, 12.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 444
+      "PerUnitCost": 1000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 50.0,
@@ -40,7 +40,7 @@
   "AmmoID": "Ammunition_Bay_QuadMissile",
   "Capacity": 1,
   "Description": {
-    "Cost": 25000,
+    "Cost": 5000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile_x2.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_QuadMissile_x2.json
@@ -17,11 +17,11 @@
       "DoesCluster",
       "MissileHP: 10",
       "AmmoCount: Missile, 2",
-      "AmmoCost: 444",
+      "AmmoCost: 1000",
       "AmmoBoxExplosionDHS: 50, 25, 12.5"
     ],
     "AmmoCost": {
-      "PerUnitCost": 444
+      "PerUnitCost": 1000
     },
     "ComponentExplosion": {
       "ExplosionDamagePerAmmo": 50.0,
@@ -40,7 +40,7 @@
   "AmmoID": "Ammunition_Bay_QuadMissile",
   "Capacity": 2,
   "Description": {
-    "Cost": 50000,
+    "Cost": 10000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "Generic",

--- a/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_TBM5.json
+++ b/Core/RogueModuleTech/Aircraft/InternalArmament/AmmoBox/Ammo_AmmunitionBox_Bay_TBM5.json
@@ -37,7 +37,7 @@
   "AmmoID": "Ammunition_Bay_TBM5",
   "Capacity": 4,
   "Description": {
-    "Cost": 50000,
+    "Cost": 3000,
     "Rarity": 1,
     "Purchasable": true,
     "Manufacturer": "NAIS",

--- a/Core/RogueModuleTech/Weapons/Weapon_Pod_M.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Pod_M.json
@@ -80,7 +80,7 @@
   "DamageNotDivided": true,
   "WeaponEffectID": "WeaponEffect-Weapon_LB20X",
   "Description": {
-    "Cost": 4500,
+    "Cost": 6000,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "Solaris Arms",


### PR DESCRIPTION
These are mostly canonical prices since these items are mostly canonical. Aircraft weapons are expensive. Yay for simgame preasure on powerful units.

The weapon/box prices are 5 times the ammo price. Expect for Daisy Cutter and MOAB which are about 10x.

This is a long time coming, a lot of prices after the big LAM rework were hasty placeholders. This may need balance tweaking but it's at least more systematic.