### PR TITLE
Hotfix Rollback of Broken SAR Config

### DIFF
--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
@@ -179,12 +179,12 @@
           },
           "Stats": [
             {
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardFlat",
-							"value": "150000",
-							"set": false,
-							"valueConstant": null
-						}
+              "typeString": "System.Single",
+              "name": "ContractBonusRewardFlat",
+              "value": "150000",
+              "set": false,
+              "valueConstant": null
+            }
           ],
           "Actions": [],
           "ForceEvents": [],
@@ -238,7 +238,7 @@
       },
       "title": "Get to the Evac Zone",
       "description": "The objective to escape with all the player units.",
-      "isPrimary": false,
+      "isPrimary": true,
       "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
@@ -286,7 +286,7 @@
       "encounterChunk": {
         "EncounterObjectGuid": "66728491-3cff-4ba8-b173-a6a386ce2c73"
       },
-      "enableChunkFromContract": true,
+      "enableChunkFromContract": false,
       "controlledByContractChunkGroupList": [],
       "requirementList": []
     }
@@ -1345,9 +1345,11 @@
           "EncounterObjectGuid": "8a365fc5-d25b-4d64-afbb-4ebf423721a9"
         },
         "name": "Lance_Enemy_Hunter",
-        "lanceDefId": "Manual",
+        "lanceDefId": "Tagged",
         "lanceTagSet": {
-          "items": [],
+          "items": [
+            "lance_type_battle"
+          ],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {
@@ -1369,7 +1371,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1402,7 +1404,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1435,7 +1437,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1468,7 +1470,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -873,7 +873,7 @@
           ],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 1,
+        "lanceDifficultyAdjustment": -1,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1042,7 +1042,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 2,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -238,7 +238,7 @@
       },
       "title": "Get to the Evac Zone",
       "description": "The objective to escape with all the player units.",
-      "isPrimary": false,
+      "isPrimary": true,
       "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
@@ -286,7 +286,7 @@
       "encounterChunk": {
         "EncounterObjectGuid": "66728491-3cff-4ba8-b173-a6a386ce2c73"
       },
-      "enableChunkFromContract": true,
+      "enableChunkFromContract": false,
       "controlledByContractChunkGroupList": [],
       "requirementList": []
     }
@@ -873,7 +873,7 @@
           ],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": -1,
+        "lanceDifficultyAdjustment": 1,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1042,7 +1042,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 0,
+        "lanceDifficultyAdjustment": 2,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1187,7 +1187,9 @@
         "name": "Lance_Enemy_Reinforcement",
         "lanceDefId": "Tagged",
         "lanceTagSet": {
-          "items": [],
+          "items": [
+            "lance_type_battle"
+          ],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {
@@ -1198,7 +1200,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 2,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1341,9 +1343,11 @@
           "EncounterObjectGuid": "8a365fc5-d25b-4d64-afbb-4ebf423721a9"
         },
         "name": "Lance_Enemy_Hunter",
-        "lanceDefId": "Manual",
+        "lanceDefId": "Tagged",
         "lanceTagSet": {
-          "items": [],
+          "items": [
+            "lance_type_battle"
+          ],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {
@@ -1365,7 +1369,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1398,7 +1402,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1431,7 +1435,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1464,7 +1468,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -167,30 +167,30 @@
       "isPrimary": false,
       "OnSuccessResults": [
         {
-					"Scope": "Company",
-					"Requirements": null,
-					"AddedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"RemovedTags": {
-						"items": [],
-						"tagSetSourceFile": ""
-					},
-					"Stats": [
-						{
-							"typeString": "System.Single",
-							"name": "ContractBonusRewardFlat",
-							"value": "150000",
-							"set": false,
-							"valueConstant": null
-						}
-					],
-					"Actions": [],
-					"ForceEvents": [],
-					"TemporaryResult": false,
-					"ResultDuration": 0
-				},
+          "Scope": "Company",
+          "Requirements": null,
+          "AddedTags": {
+            "items": [],
+            "tagSetSourceFile": ""
+          },
+          "RemovedTags": {
+            "items": [],
+            "tagSetSourceFile": ""
+          },
+          "Stats": [
+            {
+              "typeString": "System.Single",
+              "name": "ContractBonusRewardFlat",
+              "value": "150000",
+              "set": false,
+              "valueConstant": null
+            }
+          ],
+          "Actions": [],
+          "ForceEvents": [],
+          "TemporaryResult": false,
+          "ResultDuration": 0
+        },
         {
           "Scope": "Company",
           "Requirements": null,
@@ -238,7 +238,7 @@
       },
       "title": "Get to the Evac Zone",
       "description": "The objective to escape with all the player units.",
-      "isPrimary": false,
+      "isPrimary": true,
       "OnSuccessResults": [],
       "OnFailureResults": [],
       "OnSuccessDialogueGUID": "",
@@ -286,7 +286,7 @@
       "encounterChunk": {
         "EncounterObjectGuid": "66728491-3cff-4ba8-b173-a6a386ce2c73"
       },
-      "enableChunkFromContract": true,
+      "enableChunkFromContract": false,
       "controlledByContractChunkGroupList": [],
       "requirementList": []
     }
@@ -873,7 +873,7 @@
           ],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 0,
+        "lanceDifficultyAdjustment": 1,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1188,8 +1188,7 @@
         "lanceDefId": "Tagged",
         "lanceTagSet": {
           "items": [
-            "lance_type_battle",
-            "lance_type_notallvehicles"
+            "lance_type_battle"
           ],
           "tagSetSourceFile": "tags/LanceTags"
         },
@@ -1201,7 +1200,7 @@
           "items": [],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 1,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [
@@ -1344,9 +1343,11 @@
           "EncounterObjectGuid": "8a365fc5-d25b-4d64-afbb-4ebf423721a9"
         },
         "name": "Lance_Enemy_Hunter",
-        "lanceDefId": "Manual",
+        "lanceDefId": "Tagged",
         "lanceTagSet": {
-          "items": [],
+          "items": [
+            "lance_type_battle"
+          ],
           "tagSetSourceFile": "tags/LanceTags"
         },
         "lanceExcludedTagSet": {
@@ -1368,7 +1369,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1401,7 +1402,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1434,7 +1435,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1467,7 +1468,7 @@
             "customUnitName": "",
             "customHeraldryDefId": "",
             "unitType": "Mech",
-            "unitDefId": "mechDef_None",
+            "unitDefId": "UseLance",
             "unitTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -873,7 +873,7 @@
           ],
           "tagSetSourceFile": "tags/SpawnEffectTags"
         },
-        "lanceDifficultyAdjustment": 1,
+        "lanceDifficultyAdjustment": 0,
         "selectedLanceDefId": null,
         "selectedLanceDifficulty": 0,
         "unitSpawnPointOverrideList": [


### PR DESCRIPTION
One of the config options in the contract template doesn't work. So the 1.3 setup broke. Reverting to previous for now:

Capture Escort SAR Ambush lance disabled again, Hunter Lance re-enabled. Player has to clean up or move to evac.