### PR TITLE
Flipped Red Reaper X2

### DIFF
--- a/Optionals/RogueElites/Base/chassis/chassisdef_red_reaper_BL-X2-KNT.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_red_reaper_BL-X2-KNT.json
@@ -11,7 +11,7 @@
     "ChassisDefaults": [],
     "ChassisCategory": [
       {
-        "CategoryID": "SpecialShield",
+        "CategoryID": "SpecialMelee",
         "Limits": [
           {
             "Location": "All",
@@ -25,7 +25,7 @@
         ]
       },
       {
-        "CategoryID": "SpecialMelee",
+        "CategoryID": "SpecialShield",
         "Limits": [
           {
             "Location": "All",
@@ -42,19 +42,19 @@
     "MultiDefaults": [
       {
         "Location": "LeftArm",
-        "DefID": "Default_HandHeld_Shield_7tons",
+        "DefID": "Default_HandHeld_Melee_VibroSword_7tons",
         "ComponentType": "Upgrade",
         "Categories": [
-          "SpecialShield",
+          "SpecialMelee",
           "HandHeld"
         ]
       },
       {
         "Location": "RightArm",
-        "DefID": "Default_HandHeld_Melee_VibroSword_7tons",
+        "DefID": "Default_HandHeld_Shield_7tons",
         "ComponentType": "Upgrade",
         "Categories": [
-          "SpecialMelee",
+          "SpecialShield",
           "HandHeld"
         ]
       }
@@ -152,18 +152,6 @@
       "Location": "LeftArm",
       "Hardpoints": [
         {
-          "WeaponMountID": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMountID": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMountID": "Ballistic",
-          "Omni": false
-        },
-        {
           "WeaponMountID": "SpecialHandHeld",
           "Omni": false
         }
@@ -177,16 +165,16 @@
     {
       "Location": "LeftTorso",
       "Hardpoints": [
+	    {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
         {
           "WeaponMountID": "Energy",
           "Omni": false
         },
         {
-          "WeaponMountID": "Missile",
-          "Omni": false
-        },
-        {
-          "WeaponMountID": "Missile",
+          "WeaponMountID": "Energy",
           "Omni": false
         },
         {
@@ -217,16 +205,16 @@
     {
       "Location": "RightTorso",
       "Hardpoints": [
-        {
+		{
           "WeaponMountID": "Energy",
           "Omni": false
         },
         {
-          "WeaponMountID": "Energy",
+          "WeaponMountID": "Missile",
           "Omni": false
         },
         {
-          "WeaponMountID": "Energy",
+          "WeaponMountID": "Missile",
           "Omni": false
         },
         {
@@ -243,6 +231,18 @@
     {
       "Location": "RightArm",
       "Hardpoints": [
+	   {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
         {
           "WeaponMountID": "SpecialHandHeld",
           "Omni": false

--- a/Optionals/RogueElites/Base/mech/mechdef_red_reaper_BL-X2-KNT.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_red_reaper_BL-X2-KNT.json
@@ -277,28 +277,10 @@
       "HardpointSlot": -1,
       "IsFixed": false,
       "DamageLevel": "Functional",
-      "TargetComponentGUID": "WeaponAttachment0"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Weapon_Laser_VSPL_Large",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "IsFixed": false,
-      "DamageLevel": "Functional",
-      "LocalGUID": "WeaponAttachment0"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_Attachment_LaserInsulator",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional",
       "TargetComponentGUID": "WeaponAttachment1"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_Attachment_LaserInsulator",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -307,7 +289,7 @@
       "TargetComponentGUID": "WeaponAttachment2"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_Attachment_LaserInsulator",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -316,7 +298,7 @@
       "TargetComponentGUID": "WeaponAttachment3"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Laser_VSPL_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
@@ -325,7 +307,7 @@
       "LocalGUID": "WeaponAttachment1"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Laser_VSPL_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
@@ -334,13 +316,31 @@
       "LocalGUID": "WeaponAttachment2"
     },
     {
-      "MountedLocation": "RightTorso",
+      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Laser_VSPL_Small",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "IsFixed": false,
       "DamageLevel": "Functional",
       "LocalGUID": "WeaponAttachment3"
+    },
+	{
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Attachment_LaserInsulator",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "TargetComponentGUID": "WeaponAttachment0"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_VSPL_Large",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "LocalGUID": "WeaponAttachment0"
     }
   ]
 }


### PR DESCRIPTION
Changes the hardpoints and weapons on the BLK-X2-KNT to the opposite sides in order for them to better match the model used.
In addition i noticed that the hardpoints do not let you recreate the Carolina Reaper build however i didnt want to change them without asking first. 
