### PR TITLE
Fix inconsistent variant naming

### DIFF
--- a/Eras/CivilWar3062-3067/Uniques/chassis/chassisdef_wolfhound_WLF-1_Allard.json
+++ b/Eras/CivilWar3062-3067/Uniques/chassis/chassisdef_wolfhound_WLF-1_Allard.json
@@ -34,7 +34,7 @@
     "Details": "Personal 'Mech of Daniel Allard, commander of the Kell Hounds mercenary unit. With close ties to Clan Wolf-in-Exile, this Wolfhound was built in 3062 using Clan technology. It includes a Clan extralight engine, twelve double heat sinks and Clan weaponry: an ER PPC in the right arm and three ER medium lasers split between the torso, while the rear-center torso mounts an ER small laser. All of these weapons are tied to a Targeting Computer for superior accuracy.\n\n<b><color=#e62e00>Quirk: Accurate Weapon - Energy</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.01</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Right Lower</color>",
     "Icon": "uixTxrIcon_wolfhound"
   },
-  "VariantName": "WLF-1_Allard",
+  "VariantName": "WLF-1-A",
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",


### PR DESCRIPTION
Minor inconsistency on Wolfhound 1 'Allard' VariantName.