### PR TITLE
Integrated Laser AMS and Apollo Laser AMS Fixes

### DIFF
--- a/Core/RogueModuleTech/Unique/Linked/Linked_Weapon_AMS_Laser_Apollo.json
+++ b/Core/RogueModuleTech/Unique/Linked/Linked_Weapon_AMS_Laser_Apollo.json
@@ -16,7 +16,6 @@
     "CriticalEffects": {
       "LinkedStatisticName": "Laser AMS Apollo"
     },
-    "CustomWidget": "TopLeft",
     "Flags": [
       "default",
       "not_broken",
@@ -46,7 +45,7 @@
   "ComponentSubType": "NotSet",
   "PrefabIdentifier": "",
   "BattleValue": 0,
-  "InventorySize": 1,
+  "InventorySize": 2,
   "Tonnage": 0,
   "AllowedLocations": "All",
   "DisallowedLocations": "All",

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_AMS_Laser_Apollo.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_AMS_Laser_Apollo.json
@@ -130,7 +130,7 @@
   "ComponentSubType": "Weapon",
   "PrefabIdentifier": "AMS",
   "BattleValue": 0,
-  "InventorySize": 2,
+  "InventorySize": 1,
   "Tonnage": 2.5,
   "AllowedLocations": "CenterTorso",
   "DisallowedLocations": "All",

--- a/Core/RogueModuleTech/Upgrade/Linked_Armor_AMS_Laser_Integrated.json
+++ b/Core/RogueModuleTech/Upgrade/Linked_Armor_AMS_Laser_Integrated.json
@@ -16,7 +16,6 @@
     "CriticalEffects": {
       "LinkedStatisticName": "Laser AMS Integrated"
     },
-    "CustomWidget": "TopLeft",
     "Flags": [
       "default",
       "not_broken",


### PR DESCRIPTION
Fixes these having the Widget being more than 1 slot in all situations, returning the linked slot (s) to Center Torso.