### PR TITLE
Remove proxy model from Rampage Mechs

### DIFF
--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rampage_RMP-2G.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rampage_RMP-2G.json
@@ -31,13 +31,12 @@
     "Id": "chassisdef_rampage_RMP-2G",
     "Name": "Rampage",
     "Details": "Produced by the Rim Worlds Republic in 2735, the <i>Rampage</i> 2G was a standard line unit in the Rim Worlds Army. The 2G model was basic, but effective in its role, carrying a wide assortment of weapons to handle threats at any range of engagement.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.13</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "VariantName": "RMP-2G",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerLeft",
-      "mr-resize-1.1"
+      "ArmLimitLowerLeft"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +44,9 @@
   "YangsThoughts": "I know this is an old 'Mech and all, Boss, but ... c'mon. This thing is like somebody looked at the Victor and went \"hey, let me copy your homework,\" and then didn't even improve on the design.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_victor",
-  "PrefabIdentifier": "chrPrfMech_victorBase-001",
-  "PrefabBase": "victor",
+  "HardpointDataDefID": "hardpointdatadef_rampage",
+  "PrefabIdentifier": "chrprfmech_rampagebase-001",
+  "PrefabBase": "rampage",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rampage_RMP-4G.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rampage_RMP-4G.json
@@ -31,13 +31,12 @@
     "Id": "chassisdef_rampage_RMP-4G",
     "Name": "Rampage",
     "Details": "Built in 2750, the <i>Rampage</i> 4G was a massive overhaul to the original 2G model, upgrading many of the components to modern equivalents. Most notable was the addition of a Gauss rifle at the expense of the missile tubes, giving the 4G considerable punch at longer ranges.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.13</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "VariantName": "RMP-4G",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerLeft",
-      "mr-resize-1.1"
+      "ArmLimitLowerLeft"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +44,9 @@
   "YangsThoughts": "The <i>Rampage</i> 4G is a long range powerhouse. It's not very often that you see 'Mechs come off the factory line capable of the same one-two punch that the Gauss Rifle and LB 10-X AC can manage here.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_victor",
-  "PrefabIdentifier": "chrPrfMech_victorBase-001",
-  "PrefabBase": "victor",
+  "HardpointDataDefID": "hardpointdatadef_rampage",
+  "PrefabIdentifier": "chrprfmech_rampagebase-001",
+  "PrefabBase": "rampage",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rampage_RMP-5G.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rampage_RMP-5G.json
@@ -31,13 +31,12 @@
     "Id": "chassisdef_rampage_RMP-5G",
     "Name": "Rampage",
     "Details": "While the original <i>Rampage</i> had its debut in 2735 as a standard line unit, it saw a large scale redesign following the Amaris Coup in 2767. Taking advantage of the newly acquired SLDF R&D facilities, the <i>Rampage</i> 5G was outfitted with state-of-the-art weaponry previously unheard of in the Rim Worlds Republic.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.13</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "VariantName": "RMP-5G",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerLeft",
-      "mr-resize-1.1"
+      "ArmLimitLowerLeft"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +44,9 @@
   "YangsThoughts": "Origins aside, the <i>Rampage</i> 5G is a solid assault 'mech. Big slabs of armor, weapons leagues ahead of its peers at the time. The tally marks next to the flamer do make me a little nervous, though. I think we'll just buff those out.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_victor",
-  "PrefabIdentifier": "chrPrfMech_victorBase-001",
-  "PrefabBase": "victor",
+  "HardpointDataDefID": "hardpointdatadef_rampage",
+  "PrefabIdentifier": "chrprfmech_rampagebase-001",
+  "PrefabBase": "rampage",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_rampage_RMP-2G.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_rampage_RMP-2G.json
@@ -1,8 +1,6 @@
 {
   "MechTags": {
     "items": [
-      "unit_proxy_model",
-      "unit_proxy_icon",
       "unit_mech",
       "unit_assault",
       "unit_release",
@@ -44,7 +42,7 @@
     "Id": "mechdef_rampage_RMP-2G",
     "Name": "Rampage RMP-2G",
     "Details": "Produced by the Rim Worlds Republic in 2735, the <i>Rampage</i> 2G was a standard line unit in the Rim Worlds Army. The 2G model was basic, but effective in its role, carrying a wide assortment of weapons to handle threats at any range of engagement.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.13</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "simGameMechPartCost": 476415,
   "Locations": [

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_rampage_RMP-4G.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_rampage_RMP-4G.json
@@ -1,8 +1,6 @@
 {
   "MechTags": {
     "items": [
-      "unit_proxy_model",
-      "unit_proxy_icon",
       "unit_mech",
       "unit_assault",
       "unit_release",
@@ -42,7 +40,7 @@
     "Id": "mechdef_rampage_RMP-4G",
     "Name": "Rampage RMP-4G",
     "Details": "Built in 2750, the <i>Rampage</i> 4G was a massive overhaul to the original 2G model, upgrading many of the components to modern equivalents. Most notable was the addition of a Gauss rifle at the expense of the missile tubes, giving the 4G considerable punch at longer ranges.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.13</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "simGameMechPartCost": 475933,
   "Locations": [

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_rampage_RMP-5G.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_rampage_RMP-5G.json
@@ -1,8 +1,6 @@
 {
   "MechTags": {
     "items": [
-      "unit_proxy_model",
-      "unit_proxy_icon",
       "unit_mech",
       "unit_assault",
       "unit_release",
@@ -44,7 +42,7 @@
     "Id": "mechdef_rampage_RMP-5G",
     "Name": "Rampage RMP-5G",
     "Details": "While the original <i>Rampage</i> had its debut in 2735 as a standard line unit, it saw a large scale redesign following the Amaris Coup in 2767. Taking advantage of the newly acquired SLDF R&D facilities, the <i>Rampage</i> 5G was outfitted with state-of-the-art weaponry previously unheard of in the Rim Worlds Republic.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.13</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "simGameMechPartCost": 477318,
   "Locations": [

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_rampage_RMP-4G-B.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_rampage_RMP-4G-B.json
@@ -31,13 +31,12 @@
     "Id": "chassisdef_rampage_RMP-4G-B",
     "Name": "Rampage",
     "Details": "The personal BattleMech of Rim Worlds Army General Viktoria Benbaoudaoud. Based on the <i>Rampage</i> 5G, the 4G \"Benbaoudaoud\" was a minor custom refit, most notably removing the MASC for additional missile tubes.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.18</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "VariantName": "RMP-4G-B",
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "mr-resize-1.1",
       "UniqueMech"
     ],
     "tagSetSourceFile": ""
@@ -46,9 +45,9 @@
   "YangsThoughts": "Small touch-ups like these aren't too unheard of, even back from the Star League days. Every MechWarrior's got their preferences, and some of them have the pull and the cash to make them happen. Sound familiar, Boss?",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_victor",
-  "PrefabIdentifier": "chrPrfMech_victorBase-001",
-  "PrefabBase": "victor",
+  "HardpointDataDefID": "hardpointdatadef_rampage",
+  "PrefabIdentifier": "chrprfmech_rampagebase-001",
+  "PrefabBase": "rampage",
   "Tonnage": 85,
   "InitialTonnage": 8.5,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Uniques/mech/mechdef_rampage_RMP-4G-B.json
+++ b/Eras/ClanInvasion3061/Uniques/mech/mechdef_rampage_RMP-4G-B.json
@@ -1,8 +1,6 @@
 {
   "MechTags": {
     "items": [
-      "unit_proxy_model",
-      "unit_proxy_icon",
       "unit_mech",
       "unit_assault",
       "unit_release",
@@ -43,7 +41,7 @@
     "Id": "mechdef_rampage_RMP-4G-B",
     "Name": "Rampage RMP-4G",
     "Details": "The personal BattleMech of Rim Worlds Army General Viktoria Benbaoudaoud. Based on the <i>Rampage</i> 5G, the 4G \"Benbaoudaoud\" was a minor custom refit, most notably removing the MASC for additional missile tubes.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.18</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limit: Left Lower</color>",
-    "Icon": "uixTxrIcon_victor"
+    "Icon": "Rampage"
   },
   "simGameMechPartCost": 524692,
   "Locations": [


### PR DESCRIPTION
Noticed we had a model in CAB. Scale is good.