### PR TITLE
Event for SAR Escort

### DIFF
--- a/Core/RogueTechCore/cargosevents/event_co_SAR_thankful_prisoners.json
+++ b/Core/RogueTechCore/cargosevents/event_co_SAR_thankful_prisoners.json
@@ -1,0 +1,105 @@
+{
+    "Description": {
+        "Id": "event_co_SAR_thankful_prisoners",
+        "Name": "The Friends We Made Along The Way",
+        "Details": "You get a message from your Chief MechTech [[DM.BaseDescriptionDefs[Wulf_Lore_Yang],Yang]]:\r\n\r\n\"Commander {Commander.LastName}, those other other prisoners we gave a ride off planet when we rescued our pilot liberated a few items. Let's see what they left us.\"",
+        "Icon": "uixTxrSpot_YangTalking.png"
+    },
+    "Scope": "Company",
+    "Weight": 1,
+    "Requirements": {
+        "Scope": "Company",
+        "RequirementTags": {
+            "items": [
+                "DONOTFIRE"
+            ],
+            "tagSetSourceFile": ""
+        },
+        "ExclusionTags": {
+            "items": [],
+            "tagSetSourceFile": ""
+        },
+        "RequirementComparisons": []
+    },
+    "AdditionalRequirements": [],
+    "AdditionalObjects": [],
+    "Options": [
+        {
+            "Description": {
+                "Id": "outcome_0",
+                "Name": "Ok",
+                "Details": "I'll be right down.",
+                "Icon": null
+            },
+            "RequirementList": [],
+            "ResultSets": [
+                {
+                    "Description": {
+                        "Id": "outcome_0_0",
+                        "Name": "FreeAmmo",
+                        "Details": "[[DM.BaseDescriptionDefs[Wulf_Lore_Yang],Yang]] continues: \"Who knows what random junk people leave in transports parked at military detention facilities. But I bet it's ammo.\"\r\n\r\n\r\nYou reply: \"Hope springs eternal, Yang\"\r\n\r\n\r\n",
+                        "Icon": null
+                    },
+                    "Weight": 100,
+                    "Results": [
+                        {
+                            "Scope": "Company",
+                            "Requirements": {
+                                "Scope": "",
+                                "RequirementTags": {
+                                    "tagSetSourceFile": "",
+                                    "items": []
+                                },
+                                "ExclusionTags": {
+                                    "tagSetSourceFile": "",
+                                    "items": []
+                                },
+                                "RequirementComparisons": []
+                            },
+                            "AddedTags": {
+                                "items": [],
+                                "tagSetSourceFile": ""
+                            },
+                            "RemovedTags": {
+                                "items": [],
+                                "tagSetSourceFile": ""
+                            },
+                            "Stats": null,
+                            "Actions": [
+                                {
+                                    "Type": "System_ShowRewards",
+                                    "value": "itemcollection_SAR_ExtractionLoot",
+                                    "valueConstant": null,
+                                    "additionalValues": null
+                                }
+                            ],
+                            "ForceEvents": null,
+                            "TemporaryResult": false,
+                            "ResultDuration": 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements": {
+                "Scope": "Company",
+                "RequirementTags": {
+                    "items": [],
+                    "tagSetSourceFile": ""
+                },
+                "ExclusionTags": {
+                    "items": [],
+                    "tagSetSourceFile": ""
+                },
+                "RequirementComparisons": []
+            }
+        }
+    ],
+    "PublishState": "UNPUBLISHED",
+    "ValidationState": "UNTESTED",
+    "EventType": "UNSELECTABLE",
+    "OneTimeEvent": false,
+    "Tags": {
+        "items": [],
+        "tagSetSourceFile": "tags/EventTags"
+    }
+}

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Easy.json
@@ -181,37 +181,26 @@
             {
               "typeString": "System.Single",
               "name": "ContractBonusRewardFlat",
-              "value": "150000",
+              "value": "200000",
               "set": false,
               "valueConstant": null
             }
           ],
           "Actions": [],
-          "ForceEvents": [],
-          "TemporaryResult": false,
-          "ResultDuration": 0
-        },
-        {
-          "Scope": "Company",
-          "Requirements": null,
-          "AddedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RemovedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "Stats": null,
-          "Actions": [
+          "ForceEvents": [
             {
-              "Type": "System_ShowRewards",
-              "value": "itemcollection_SAR_ExtractionLoot",
-              "valueConstant": null,
-              "additionalValues": null
+              "ForceEvents": [
+                {
+                  "Scope": "Company",
+                  "EventID": "event_co_SAR_thankful_prisoners",
+                  "MinDaysWait": 0,
+                  "MaxDaysWait": 2,
+                  "Probability": 100,
+                  "RetainPilot": false
+                }
+              ]
             }
           ],
-          "ForceEvents": null,
           "TemporaryResult": false,
           "ResultDuration": 0
         }

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Hard.json
@@ -181,37 +181,26 @@
             {
               "typeString": "System.Single",
               "name": "ContractBonusRewardFlat",
-              "value": "150000",
+              "value": "200000",
               "set": false,
               "valueConstant": null
             }
           ],
           "Actions": [],
-          "ForceEvents": [],
-          "TemporaryResult": false,
-          "ResultDuration": 0
-        },
-        {
-          "Scope": "Company",
-          "Requirements": null,
-          "AddedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RemovedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "Stats": null,
-          "Actions": [
+          "ForceEvents": [
             {
-              "Type": "System_ShowRewards",
-              "value": "itemcollection_SAR_ExtractionLoot",
-              "valueConstant": null,
-              "additionalValues": null
+              "ForceEvents": [
+                {
+                  "Scope": "Company",
+                  "EventID": "event_co_SAR_thankful_prisoners",
+                  "MinDaysWait": 0,
+                  "MaxDaysWait": 2,
+                  "Probability": 100,
+                  "RetainPilot": false
+                }
+              ]
             }
           ],
-          "ForceEvents": null,
           "TemporaryResult": false,
           "ResultDuration": 0
         }

--- a/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
+++ b/Core/SearchAndRescue/SAR_Contracts/CaptureEscort_SAR_Med.json
@@ -181,37 +181,26 @@
             {
               "typeString": "System.Single",
               "name": "ContractBonusRewardFlat",
-              "value": "150000",
+              "value": "200000",
               "set": false,
               "valueConstant": null
             }
           ],
           "Actions": [],
-          "ForceEvents": [],
-          "TemporaryResult": false,
-          "ResultDuration": 0
-        },
-        {
-          "Scope": "Company",
-          "Requirements": null,
-          "AddedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "RemovedTags": {
-            "items": [],
-            "tagSetSourceFile": ""
-          },
-          "Stats": null,
-          "Actions": [
+          "ForceEvents": [
             {
-              "Type": "System_ShowRewards",
-              "value": "itemcollection_SAR_ExtractionLoot",
-              "valueConstant": null,
-              "additionalValues": null
+              "ForceEvents": [
+                {
+                  "Scope": "Company",
+                  "EventID": "event_co_SAR_thankful_prisoners",
+                  "MinDaysWait": 0,
+                  "MaxDaysWait": 2,
+                  "Probability": 100,
+                  "RetainPilot": false
+                }
+              ]
             }
           ],
-          "ForceEvents": null,
           "TemporaryResult": false,
           "ResultDuration": 0
         }


### PR DESCRIPTION
This is a brief event reminding players were the flavor loot box from the other prisoners comes from. Also might resolve issues with the loot box not dropping sometimes.

And pay bump for the secondary objective, closer to pay for Rescue type