### PR TITLE
New settings for RTS (again)

### DIFF
--- a/Core/RarityTiedSpawner/settings.json
+++ b/Core/RarityTiedSpawner/settings.json
@@ -2,23 +2,20 @@
 	"debug": true,
 	"trace": true,
 	"moreCommonTags": {
-		"unit_totem": 3,
-		"unit_command": 3,
-		"unit_primitive": 3,
-		"unit_generic": 3,
-		"unit_legendary": -2,
-		"unit_rare": -1,
-		"unit_pirate": 3,
-		"unit_predator": 1,
-		"unit_singleton": 3,
-		"unit_release": 1,
-		"unit_vehicle_transport": 1,
-		"unit_vehicle_apc": 2,
-		"unit_protomech_standard": 6,
-		"unit_powerarmor": 3,
-		"unit_LAM": 3,
-		"unit_vehicle": 1,
-		"unit_mech": 1,
-		"unit_quad": 3
+		"unit_release": 10,
+
+		"unit_primitive": -5,
+		"unit_generic": 1,
+		"unit_advanced": -5,
+		"unit_rare": -8,
+
+		"unit_command": -20,
+		"unit_legendary": -20,
+		"unit_totem": 5,
+		"unit_predator": 5,
+		"unit_singleton": 5,
+
+		"unit_protomech_standard": 5,
+		"unit_powerarmor": 5
 	}
 }

--- a/Core/RarityTiedSpawner/settings.json
+++ b/Core/RarityTiedSpawner/settings.json
@@ -3,18 +3,9 @@
 	"trace": true,
 	"moreCommonTags": {
 		"unit_release": 10,
-
-		"unit_primitive": -5,
-		"unit_generic": 1,
-		"unit_advanced": -5,
-		"unit_rare": -8,
-
-		"unit_command": -20,
 		"unit_legendary": -20,
 		"unit_totem": 5,
-		"unit_predator": 5,
 		"unit_singleton": 5,
-
 		"unit_protomech_standard": 5,
 		"unit_powerarmor": 5
 	}

--- a/Core/RarityTiedSpawner/settings.json
+++ b/Core/RarityTiedSpawner/settings.json
@@ -4,17 +4,9 @@
 	"moreCommonTags": {
 		"unit_release": 10,
 
-		"unit_primitive": -5,
-		"unit_generic": 1,
-		"unit_advanced": -5,
-		"unit_rare": -8,
-
-		"unit_command": -20,
 		"unit_legendary": -20,
 		"unit_totem": 5,
-		"unit_predator": 5,
 		"unit_singleton": 5,
-
 		"unit_protomech_standard": 5,
 		"unit_powerarmor": 5
 	}


### PR DESCRIPTION
Trying desperately to decouple type tags from rarity spawning. This is a bandaid fix that should result in much fewer legendaries except when explicitly called by lancedef.

Highly recommend redoing this later with a full rarity scale entirely independent of type-based tags used for lancedefs.