### PR TITLE
Tweak Destroy Base Pay Presentation

### DIFF
--- a/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_MRM_1_x8.json
+++ b/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_MRM_1_x8.json
@@ -7,8 +7,9 @@
     ],
     "BonusDescriptions": [
       "BAWEAPON",
-      "MissileHP: 3",
+      "WpnAccuracy: -1",
       "AMSChance: -40%",
+      "MissileHP: 3",
       "AmmoCost: 20"
     ],
     "Flags": [
@@ -28,7 +29,7 @@
   "Type": "LRM",
   "WeaponSubType": "LRM5",
   "MinRange": 0,
-  "MaxRange": 510,
+  "MaxRange": 540,
   "RangeSplit": [
     180,
     270,
@@ -41,7 +42,7 @@
   "HeatDamage": 0,
   "Instability": 1,
   "DamageVariance": 0,
-  "AccuracyModifier": 0,
+  "AccuracyModifier": 1,
   "EvasivePipsIgnored": 0,
   "RefireModifier": 0,
   "OverheatedDamageMultiplier": 0,
@@ -67,7 +68,7 @@
   "AttackRecoil": 1,
   "FireDelayMultiplier": 0.1,
   "ProjectileSpeedMultiplier": 1.3,
-  "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
+  "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
   "Description": {
     "Cost": 5168,
     "Rarity": 3,
@@ -85,9 +86,9 @@
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
   "PrefabIdentifier": "lrm5",
-  "BattleValue": 0,
+  "BattleValue": 9,
   "InventorySize": 1,
-  "Tonnage": 0.2,
+  "Tonnage": 0.1,
   "AllowedLocations": "All",
   "DisallowedLocations": "All",
   "CriticalComponent": false,

--- a/Core/RogueTechCore/ContractType.json
+++ b/Core/RogueTechCore/ContractType.json
@@ -29,7 +29,7 @@
       "IsMultiplayer": false,
       "UsesFury": false,
       "UsesSecondScaledStructureValues": false,
-      "ContractRewardMultiplier": 0.9,
+      "ContractRewardMultiplier": 1.1,
       "Illustration": "uixTxrSpot_destroyBaseContract",
       "Icon": "uixSvgIcon_contract_DestroyBase",
       "IsPublished": true

--- a/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_CeaseAndDesist.json
+++ b/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_CeaseAndDesist.json
@@ -115,8 +115,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_DeniableDestruction.json
+++ b/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_DeniableDestruction.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_SendingAMessage.json
+++ b/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_SendingAMessage.json
@@ -115,8 +115,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_Smugglers.json
+++ b/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_Smugglers.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_StopTheSignal.json
+++ b/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_StopTheSignal.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_SupplyBase.json
+++ b/Core/RogueTechCore/Contracts/destroybase/2/DestroyBase_SupplyBase.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_Eviction.json
+++ b/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_Eviction.json
@@ -115,8 +115,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_FactoryRecall.json
+++ b/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_FactoryRecall.json
@@ -105,8 +105,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_FactoryRecall_Alt.json
+++ b/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_FactoryRecall_Alt.json
@@ -105,8 +105,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_ICanDestroy.json
+++ b/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_ICanDestroy.json
@@ -110,8 +110,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_IncompleteIntel.json
+++ b/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_IncompleteIntel.json
@@ -104,8 +104,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_Liberation.json
+++ b/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_Liberation.json
@@ -116,8 +116,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_Pirate_HideTheEvidence.json
+++ b/Core/RogueTechCore/Contracts/destroybase/5/DestroyBase_Pirate_HideTheEvidence.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_BrokenChain.json
+++ b/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_BrokenChain.json
@@ -103,8 +103,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Contagion.json
+++ b/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Contagion.json
@@ -103,8 +103,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Eviction_Hard.json
+++ b/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Eviction_Hard.json
@@ -112,8 +112,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_LeaveAMark.json
+++ b/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_LeaveAMark.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Liberation_Hard.json
+++ b/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Liberation_Hard.json
@@ -116,8 +116,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Pirate_BloodFeud.json
+++ b/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Pirate_BloodFeud.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Pirate_HideTheEvidence_Hard.json
+++ b/Core/RogueTechCore/Contracts/destroybase/8/DestroyBase_Pirate_HideTheEvidence_Hard.json
@@ -109,8 +109,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Documents/Patch Notes Scratch Pad.txt
+++ b/Documents/Patch Notes Scratch Pad.txt
@@ -36,6 +36,7 @@ BA Small VSPL - New. Battle Armor version of the small Variable Speed Pulse Lase
 BA Grenade Launcher - New. A light, 0.1 ton, weapon intended primarily for fighting other infantry.
 
 BA Medium VSPL - Added missing to-hit bonuses that are characteristic of VSPL.
+BA MRM-1 - Max range +30, gains -1 Accuracy, Weight from 0.2 to 0.1
 BA Pop-Up Mine - Range 30 to 45.
 BoltOn AMS - Ammunition now costs 5 cbills per shot.
 Bomb FAE [WM] - Smoke effect fixed.

--- a/Documents/Patch Notes Scratch Pad.txt
+++ b/Documents/Patch Notes Scratch Pad.txt
@@ -1,5 +1,9 @@
 1.3.x
 
+Contracts
+
+Destroy Base - Bonus pay for destroying buildings reduced, base pay for contract type increased so it's clearer up front how much these contracts pay.
+
 Shops:
 
 Changes to availability of Battle Armor items in Shops:

--- a/Eras/ClanInvasion3061/Base/vehicle/carrier/vehicledef_CARRIER_MK2_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/carrier/vehicledef_CARRIER_MK2_SRM.json
@@ -111,35 +111,35 @@
     "Id": "vehicledef_CARRIER_MK2_SRM",
     "Name": "SRM Carrier",
     "Details": "Not designed for traditional combat, the Carrier is a force multiplier. Deadly at mid to short ranged combat, the Carrier is armed with a mix of heavy weapons tailored for mech busting.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        70     30\n<b>Left</b>          70     30\n<b>Right</b>        70     30\n<b>Rear</b>         70     30\n<b>Turret</b>       60     30\n\n<b>Total</b>      340    150</color>\n\n<color=#ff0000>Quirk: Accurate Weapon - Missiles</color>",
-    "Icon": "SRMcarrier"
+    "Icon": "LRMcarrier"
   },
   "Locations": [
     {
       "Location": "Front",
-      "CurrentArmor": 70,
+      "CurrentArmor": 75,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 70,
+      "AssignedArmor": 75,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Left",
-      "CurrentArmor": 70,
+      "CurrentArmor": 75,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 70,
+      "AssignedArmor": 75,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Right",
-      "CurrentArmor": 70,
+      "CurrentArmor": 75,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 70,
+      "AssignedArmor": 75,
       "DamageLevel": "Functional"
     },
     {
       "Location": "Rear",
-      "CurrentArmor": 70,
+      "CurrentArmor": 75,
       "CurrentInternalStructure": 30,
-      "AssignedArmor": 70,
+      "AssignedArmor": 75,
       "DamageLevel": "Functional"
     },
     {
@@ -209,9 +209,30 @@
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_SRM_6",
+      "ComponentDefID": "Weapon_AMS",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Weapon_AMS",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Right",
+      "ComponentDefID": "Ammo_AmmunitionBox_AMS",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Left",
+      "ComponentDefID": "Ammo_AmmunitionBox_AMS",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {

--- a/Eras/ClanInvasion3061/Base/vehicle/carrier/vehicledef_CARRIER_Mk2_MTR.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/carrier/vehicledef_CARRIER_Mk2_MTR.json
@@ -105,14 +105,14 @@
     ],
     "tagSetSourceFile": ""
   },
-  "ChassisID": "vehiclechassisdef_CARRIER_Mk2_LRM",
+  "ChassisID": "vehiclechassisdef_CARRIER_Mk2_MTR",
   "Description": {
     "Cost": 2368000,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "LRM Carrier Mk2",
-    "Id": "vehicledef_CARRIER_Mk2_LRM",
-    "Name": "LRM Carrier",
+    "UIName": "MTR Carrier Mk2",
+    "Id": "vehicledef_CARRIER_Mk2_MTR",
+    "Name": "MTR Carrier",
     "Details": "Not designed for traditional combat, the Carrier is a force multiplier. Designed to support allies from range, the Carrier can hang back behind friendly lines where its lack of armor isn't a concern.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        75     30\n<b>Left</b>          75     30\n<b>Right</b>        75     30\n<b>Rear</b>         75     30\n<b>Turret</b>       60     30\n\n<b>Total</b>      360    150</color>\n\n<color=#ff0000>Quirk: Accurate Weapon - Missiles</color>",
     "Icon": "LRMcarrier"
   },
@@ -170,21 +170,21 @@
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_LRM_15",
+      "ComponentDefID": "Weapon_Mortar_6",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_LRM_15",
+      "ComponentDefID": "Weapon_Mortar_6",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_LRM_15",
+      "ComponentDefID": "Weapon_Mortar_6",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
@@ -198,7 +198,7 @@
     },
     {
       "MountedLocation": "Left",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_SAM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Mortar_Airburst",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -212,28 +212,35 @@
     },
     {
       "MountedLocation": "Right",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_SAM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Mortar_Airburst",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Mortar",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_Mortar",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Double",
+      "ComponentDefID": "Ammo_AmmunitionBox_Mortar",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_Mortar",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -247,14 +254,14 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_FCS_Missile_HP",
+      "ComponentDefID": "Gear_FCS_Scatter",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Sensors_MissileRange",
+      "ComponentDefID": "Gear_Sensors_BallisticRange",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -296,7 +303,7 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Quirk_AccurateWeaponCategory_Missiles",
+      "ComponentDefID": "Quirk_AccurateWeaponCategory_Ballistics",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CARRIER_MK2_SRM.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CARRIER_MK2_SRM.json
@@ -14,11 +14,11 @@
     "Cost": 2144800,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "SRM Carrier",
+    "UIName": "SRM Carrier Mk2",
     "Id": "vehiclechassisdef_CARRIER_MK2_SRM",
     "Name": "Carrier",
     "Details": "Not designed for traditional combat, the Carrier is a force multiplier. Deadly at mid to short ranged combat, the Carrier is armed with a mix of heavy weapons tailored for mech busting.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        70     30\n<b>Left</b>          70     30\n<b>Right</b>        70     30\n<b>Rear</b>         70     30\n<b>Turret</b>       60     30\n\n<b>Total</b>      340    150</color>\n\n<color=#ff0000>Quirk: Accurate Weapon - Missiles</color>",
-    "Icon": "SRMcarrier"
+    "Icon": "LRMcarrier"
   },
   "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
   "MovementCapDefID": "movedef_3-5cv",

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CARRIER_Mk2_MTR.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CARRIER_Mk2_MTR.json
@@ -14,8 +14,8 @@
     "Cost": 2368000,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "LRM Carrier Mk2",
-    "Id": "vehiclechassisdef_CARRIER_Mk2_LRM",
+    "UIName": "MTR Carrier Mk2",
+    "Id": "vehiclechassisdef_CARRIER_Mk2_MTR",
     "Name": "Carrier",
     "Details": "Not designed for traditional combat, the Carrier is a force multiplier. Designed to support allies from range, the Carrier can hang back behind friendly lines where its lack of armor isn't a concern.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 3/5 Hex: 90/150 Meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>        75     30\n<b>Left</b>          75     30\n<b>Right</b>        75     30\n<b>Rear</b>         75     30\n<b>Turret</b>       60     30\n\n<b>Total</b>      360    150</color>\n\n<color=#ff0000>Quirk: Accurate Weapon - Missiles</color>",
     "Icon": "LRMcarrier"

--- a/Optionals/RISCtech/Base/mech/mechdef_inner_sphere_standard_IS-RX.json
+++ b/Optionals/RISCtech/Base/mech/mechdef_inner_sphere_standard_IS-RX.json
@@ -148,14 +148,14 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_PowerArmor_Rifle_Light",
+      "ComponentDefID": "Weapon_PowerArmor_Rifle_Medium",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Weapon_PowerArmor_SRM_2",
+      "ComponentDefID": "Weapon_PowerArmor_SRM_3",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"

--- a/Optionals/Superheavys/Base/contract/conflicts/DestroyBase_Superheavy_TheFactory.json
+++ b/Optionals/Superheavys/Base/contract/conflicts/DestroyBase_Superheavy_TheFactory.json
@@ -151,8 +151,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Optionals/Superheavys/Base/contract/conflicts/DestroyBase_itsatrap_BRUTAL.json
+++ b/Optionals/Superheavys/Base/contract/conflicts/DestroyBase_itsatrap_BRUTAL.json
@@ -167,8 +167,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }

--- a/Optionals/Superheavys/Base/contract/conflicts/DestroyBase_itsatrap_NEW.json
+++ b/Optionals/Superheavys/Base/contract/conflicts/DestroyBase_itsatrap_NEW.json
@@ -180,8 +180,8 @@
           "Stats": [
             {
               "typeString": "System.Single",
-              "name": "ContractBonusRewardPct",
-              "value": "0.20",
+              "name": "ContractBonusRewardFlat",
+              "value": "50000",
               "set": false,
               "valueConstant": null
             }


### PR DESCRIPTION
Not a significant change in actual pay. But puts the payout up from in the contract select screen instead of +20% as a bonus for completeing the primary objective. A few Flashpoint contracts left alone because flashpoints.