### PR TITLE
Fix jumbled prefab indentifiers in CU

### DIFF
--- a/Core/CustomUnits/mod.json
+++ b/Core/CustomUnits/mod.json
@@ -1034,6 +1034,13 @@
       {
         "PrefabIdentifier": "blade",
         "HardpointCandidates": {
+          "blade": 1.0,
+          "lance": 0.95
+        }
+      },
+      {
+        "PrefabIdentifier": "piledriver",
+        "HardpointCandidates": {
           "piledriver": 1.0,
           "lance": 0.95,
           "mace": 0.9,


### PR DESCRIPTION
Going to assume I committed the original config while half asleep.