### PR TITLE
Enables FUNERAL EVENT and DeadMW scope

### DIFF
--- a/Core/RogueTechCore/SimGame/SimGameConstants.json
+++ b/Core/RogueTechCore/SimGame/SimGameConstants.json
@@ -203,6 +203,8 @@
     "MechMothballTime": 0,
     "CompanyEventStartingChance": -2.5,
     "CompanyEventIncreaseRate": 0.5,
+    "DeadEventStartingChance": -2.5,
+    "DeadEventIncreaseRate": 0.5,
     "MoraleEventStartingChance": -15.0,
     "MoraleEventIncreaseRate": 0.0,
     "StartingReputation": 0,


### PR DESCRIPTION
Adds two lines to enable use of FUNERAL based events using the DeadMechWarrior scope.