### PR TITLE
Fix Clever Girl Codeword

### DIFF
--- a/Core/CodeWords/mod.json
+++ b/Core/CodeWords/mod.json
@@ -35,7 +35,6 @@
       "story_8_locura",
       "story_9_downfall",
       "Assassinate_OverlordFight",
-      "DestroyBase_CleverGirl",
       "SimpleBattle_TestDrive_VTOL_2_NEW",
       "SimpleBattle_TestDrive_VTOL_2_ALT_NEW",
       "ThreeWayBattle_TestDrive_VTOL_2_NEW",
@@ -135,8 +134,10 @@
       "Rescue_SAR_Easy",
       "CaptureEscort_SAR_Med",
       "CaptureEscort_SAR_Easy",
-      "CaptureEscort_SAR_Hard",
-      "DestroyBase_CleverGirl"
-    ]
+      "CaptureEscort_SAR_Hard"
+    ],
+    "ExcludeContractsWithName": [
+      "Clever Girl"
+      ]
   }
 }


### PR DESCRIPTION
With recent new DLL for CodeWords version 2.1.0, Clever Girl name added to new setting "ExcludeContractWithName"