### PR TITLE
Prefab adjustments

### DIFF
--- a/Core/CustomUnits/mod.json
+++ b/Core/CustomUnits/mod.json
@@ -287,97 +287,6 @@
         }
       },
       {
-        "PrefabIdentifier": "LBX2",
-        "HardpointCandidates": {
-          "lbx2": 1.0,
-          "lbx5": 0.95,
-          "ac2": 0.9,
-          "ac5": 0.85,
-          "lbx": 0.8,
-          "ac": 0.75,
-
-          "uac2": 0.7,
-          "rac2": 0.65,
-          "uac5": 0.6,
-          "rac5": 0.55,
-          "uac": 0.5,
-          "rac": 0.45,
-
-          "mg": 0.05,
-          "ppc": 0.05,
-          "laser": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "UAC2",
-        "HardpointCandidates": {
-          "uac2": 1.0,
-          "rac2": 0.95,
-          "uac5": 0.9,
-          "rac5": 0.85,
-          "rac": 0.8,
-          "uac": 0.75,
-
-          "lbx2": 0.7,
-          "lbx5": 0.65,
-          "ac2": 0.6,
-          "ac5": 0.55,
-          "lbx": 0.5,
-          "ac": 0.45,
-
-          "mg": 0.05,
-          "ppc": 0.05,
-          "laser": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "AMS",
-        "HardpointCandidates": {
-          "ams": 1.0,
-          "laser": 0.95,
-          "mg": 0.9,
-          "machinegun": 0.85,
-          "flamer": 0.8,
-
-          "ac2": 0.05,
-          "ppc": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "Flamer",
-        "HardpointCandidates": {
-          "flamer": 1.0,
-          "laser": 0.9,
-          "mg": 0.85,
-          "machinegun": 0.8,
-
-          "ac2": 0.05,
-          "ppc": 0.05,
-          "ac": 0.05,
-          "lbx": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "Laser",
-        "HardpointCandidates": {
-          "laser": 1.0,
-          "ppc": 0.95,
-          "flamer": 0.9,
-          "mg": 0.85,
-          "machinegun": 0.8,
-
-          "ac2": 0.05,
-          "ac": 0.05,
-          "lbx": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
         "PrefabIdentifier": "AC5",
         "HardpointCandidates": {
           "ac5": 1.0,
@@ -406,86 +315,6 @@
         }
       },
       {
-        "PrefabIdentifier": "LBX5",
-        "HardpointCandidates": {
-          "lbx5": 1.0,
-          "lbx10": 0.95,
-          "lbx2": 0.9,
-          "ac5": 0.85,
-          "ac10": 0.8,
-          "ac2": 0.75,
-          "lbx": 0.7,
-          "ac": 0.65,
-
-          "uac5": 0.6,
-          "rac5": 0.55,
-          "uac10": 0.5,
-          "rac10": 0.45,
-          "uac2": 0.4,
-          "rac2": 0.35,
-          "uac": 0.3,
-          "rac": 0.25,
-
-          "ppc": 0.05,
-          "laser": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "UAC5",
-        "HardpointCandidates": {
-          "uac5": 1.0,
-          "rac5": 0.95,
-          "uac10": 0.9,
-          "rac10": 0.85,
-          "uac2": 0.8,
-          "rac2": 0.75,
-          "uac": 0.7,
-          "rac": 0.65,
-
-          "lbx5": 0.6,
-          "lbx10": 0.55,
-          "lbx2": 0.5,
-          "ac5": 0.45,
-          "ac10": 0.4,
-          "ac2": 0.35,
-          "lbx": 0.3,
-          "ac": 0.25,
-
-          "ppc": 0.05,
-          "laser": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "RAC2",
-        "HardpointCandidates": {
-          "rac2": 1.0,
-          "uac2": 0.95,
-          "rac5": 0.9,
-          "uac5": 0.85,
-          "rac": 0.8,
-          "uac": 0.75,
-
-          "lbx2": 0.7,
-          "lbx5": 0.65,
-          "ac2": 0.6,
-          "ac5": 0.55,
-          "lbx": 0.5,
-          "ac": 0.45,
-
-          "ppc": 0.05,
-          "laser": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
         "PrefabIdentifier": "AC10",
         "HardpointCandidates": {
           "ac10": 1.0,
@@ -503,6 +332,88 @@
           "rac20": 0.45,
           "uac10": 0.4,
           "rac10": 0.35,
+          "uac": 0.3,
+          "rac": 0.25,
+
+          "ppc": 0.05,
+          "laser": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "AC20",
+        "HardpointCandidates": {
+          "ac20": 1.0,
+          "ac10": 0.95,
+          "lbx20": 0.9,
+          "lbx10": 0.85,
+          "ac": 0.8,
+          "lbx": 0.75,
+
+          "ac5": 0.7,
+          "lbx5": 0.65,
+
+          "uac20": 0.6,
+          "rac20": 0.55,
+          "rac10": 0.5,
+          "uac10": 0.45,
+          "uac": 0.4,
+          "rac": 0.35,
+
+          "uac5": 0.3,
+          "rac5": 0.25,
+
+          "ppc": 0.05,
+          "laser": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "LBX2",
+        "HardpointCandidates": {
+          "lbx2": 1.0,
+          "lbx5": 0.95,
+          "ac2": 0.9,
+          "ac5": 0.85,
+          "lbx": 0.8,
+          "ac": 0.75,
+
+          "uac2": 0.7,
+          "rac2": 0.65,
+          "uac5": 0.6,
+          "rac5": 0.55,
+          "uac": 0.5,
+          "rac": 0.45,
+
+          "mg": 0.05,
+          "ppc": 0.05,
+          "laser": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "LBX5",
+        "HardpointCandidates": {
+          "lbx5": 1.0,
+          "lbx10": 0.95,
+          "lbx2": 0.9,
+          "ac5": 0.85,
+          "ac10": 0.8,
+          "ac2": 0.75,
+          "lbx": 0.7,
+          "ac": 0.65,
+
+          "uac5": 0.6,
+          "rac5": 0.55,
+          "uac10": 0.5,
+          "rac10": 0.45,
+          "uac2": 0.4,
+          "rac2": 0.35,
           "uac": 0.3,
           "rac": 0.25,
 
@@ -542,108 +453,6 @@
         }
       },
       {
-        "PrefabIdentifier": "UAC10",
-        "HardpointCandidates": {
-          "uac10": 1.0,
-          "rac10": 0.95,
-          "uac20": 0.9,
-          "rac20": 0.85,
-          "uac5": 0.8,
-          "rac5": 0.75,
-          "uac": 0.7,
-          "rac": 0.65,
-
-          "lbx10": 0.6,
-          "lbx20": 0.55,
-          "lbx5": 0.5,
-          "ac10": 0.45,
-          "ac20": 0.4,
-          "ac5": 0.35,
-          "lbx": 0.3,
-          "ac": 0.25,
-
-          "ppc": 0.05,
-          "laser": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "RAC5",
-        "HardpointCandidates": {
-          "rac5": 1.0,
-          "uac5": 0.95,
-          "rac10": 0.9,
-          "uac10": 0.85,
-          "rac2": 0.8,
-          "uac2": 0.75,
-          "rac": 0.7,
-          "uac": 0.65,
-
-          "lbx5": 0.6,
-          "lbx10": 0.55,
-          "lbx2": 0.5,
-          "ac5": 0.45,
-          "ac10": 0.4,
-          "ac2": 0.35,
-          "lbx": 0.3,
-          "ac": 0.25,
-
-          "ppc": 0.05,
-          "laser": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "PPC",
-        "HardpointCandidates": {
-          "ppc": 1.0,
-
-          "ac10": 0.95,
-          "laser": 0.9,
-          "ac20": 0.85,
-          "ac5": 0.8,
-          "ac": 0.75,
-
-          "flamer": 0.05,
-          "mg": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "AC20",
-        "HardpointCandidates": {
-          "ac20": 1.0,
-          "ac10": 0.95,
-          "lbx20": 0.9,
-          "lbx10": 0.85,
-          "ac": 0.8,
-          "lbx": 0.75,
-
-          "ac5": 0.7,
-          "lbx5": 0.65,
-
-          "uac20": 0.6,
-          "rac20": 0.55,
-          "rac10": 0.5,
-          "uac10": 0.45,
-          "uac": 0.4,
-          "rac": 0.35,
-
-          "uac5": 0.3,
-          "rac5": 0.25,
-
-          "ppc": 0.05,
-          "laser": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
         "PrefabIdentifier": "LBX20",
         "HardpointCandidates": {
           "lbx20": 1.0,
@@ -674,6 +483,86 @@
         }
       },
       {
+        "PrefabIdentifier": "UAC2",
+        "HardpointCandidates": {
+          "uac2": 1.0,
+          "rac2": 0.95,
+          "uac5": 0.9,
+          "rac5": 0.85,
+          "rac": 0.8,
+          "uac": 0.75,
+
+          "lbx2": 0.7,
+          "lbx5": 0.65,
+          "ac2": 0.6,
+          "ac5": 0.55,
+          "lbx": 0.5,
+          "ac": 0.45,
+
+          "mg": 0.05,
+          "ppc": 0.05,
+          "laser": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "UAC5",
+        "HardpointCandidates": {
+          "uac5": 1.0,
+          "rac5": 0.95,
+          "uac10": 0.9,
+          "rac10": 0.85,
+          "uac2": 0.8,
+          "rac2": 0.75,
+          "uac": 0.7,
+          "rac": 0.65,
+
+          "lbx5": 0.6,
+          "lbx10": 0.55,
+          "lbx2": 0.5,
+          "ac5": 0.45,
+          "ac10": 0.4,
+          "ac2": 0.35,
+          "lbx": 0.3,
+          "ac": 0.25,
+
+          "ppc": 0.05,
+          "laser": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "UAC10",
+        "HardpointCandidates": {
+          "uac10": 1.0,
+          "rac10": 0.95,
+          "uac20": 0.9,
+          "rac20": 0.85,
+          "uac5": 0.8,
+          "rac5": 0.75,
+          "uac": 0.7,
+          "rac": 0.65,
+
+          "lbx10": 0.6,
+          "lbx20": 0.55,
+          "lbx5": 0.5,
+          "ac10": 0.45,
+          "ac20": 0.4,
+          "ac5": 0.35,
+          "lbx": 0.3,
+          "ac": 0.25,
+
+          "ppc": 0.05,
+          "laser": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
         "PrefabIdentifier": "UAC20",
         "HardpointCandidates": {
           "uac20": 1.0,
@@ -695,6 +584,58 @@
 
           "lbx5": 0.3,
           "ac5": 0.25,
+
+          "ppc": 0.05,
+          "laser": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "RAC2",
+        "HardpointCandidates": {
+          "rac2": 1.0,
+          "uac2": 0.95,
+          "rac5": 0.9,
+          "uac5": 0.85,
+          "rac": 0.8,
+          "uac": 0.75,
+
+          "lbx2": 0.7,
+          "lbx5": 0.65,
+          "ac2": 0.6,
+          "ac5": 0.55,
+          "lbx": 0.5,
+          "ac": 0.45,
+
+          "ppc": 0.05,
+          "laser": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "RAC5",
+        "HardpointCandidates": {
+          "rac5": 1.0,
+          "uac5": 0.95,
+          "rac10": 0.9,
+          "uac10": 0.85,
+          "rac2": 0.8,
+          "uac2": 0.75,
+          "rac": 0.7,
+          "uac": 0.65,
+
+          "lbx5": 0.6,
+          "lbx10": 0.55,
+          "lbx2": 0.5,
+          "ac5": 0.45,
+          "ac10": 0.4,
+          "ac2": 0.35,
+          "lbx": 0.3,
+          "ac": 0.25,
 
           "ppc": 0.05,
           "laser": 0.05,
@@ -762,25 +703,6 @@
         }
       },
       {
-        "PrefabIdentifier": "BFG",
-        "HardpointCandidates": {
-          "bfg": 1.0,
-
-          "artillery": 0.95,
-          "gauss": 0.9,
-          "ac20": 0.85,
-          "lbx20": 8,
-          "ppc": 0.75,
-          "ac": 0.7,
-          "lbx": 0.65,
-
-          "laser": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
         "PrefabIdentifier": "Gauss",
         "HardpointCandidates": {
           "gauss": 1.0,
@@ -817,101 +739,39 @@
         }
       },
       {
-        "PrefabIdentifier": "lrm5",
+        "PrefabIdentifier": "BFG",
         "HardpointCandidates": {
-          "lrm5": 1.0,
-          "lrm10": 0.95,
-          "lrm15": 0.9,
-          "lrm20": 0.85,
-          "srm20": 0.8,
-          "srm6": 0.75,
-          "srm4": 0.7,
-          "srm2": 0.65,
+          "bfg": 1.0,
 
-          "machinegun": 0.05,
+          "artillery": 0.95,
+          "gauss": 0.9,
+          "ac20": 0.85,
+          "lbx20": 8,
+          "ppc": 0.75,
+          "ac": 0.7,
+          "lbx": 0.65,
+
+          "laser": 0.05,
           "mg": 0.05,
           "flamer": 0.05,
-          "laser": 0.05,
           "ams": 0.05
         }
       },
       {
-        "PrefabIdentifier": "lrm10",
+        "PrefabIdentifier": "railgun",
         "HardpointCandidates": {
-          "lrm10": 1.0,
-          "lrm15": 0.95,
-          "lrm20": 0.9,
-          "srm20": 0.85,
-          "lrm5": 0.8,
-          "srm6": 0.75,
-          "srm4": 0.7,
-          "srm2": 0.65,
+          "railgun": 1.0,
 
-          "machinegun": 0.05,
+          "gauss": 0.95,
+          "ac20": 0.9,
+          "lbx20": 0.85,
+          "ppc": 0.8,
+          "ac": 0.75,
+          "lbx": 0.65,
+
+          "laser": 0.05,
           "mg": 0.05,
           "flamer": 0.05,
-          "laser": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "lrm15",
-        "HardpointCandidates": {
-          "lrm15": 1.0,
-          "lrm20": 0.95,
-          "srm20": 0.9,
-          "lrm10": 0.85,
-          "lrm5": 0.8,
-          "srm6": 0.75,
-          "srm4": 0.7,
-          "srm2": 0.65,
-
-          "machinegun": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "laser": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "arrow",
-        "HardpointCandidates": {
-          "arrow": 1.0,
-
-          "lrm5": 0.95,
-          "lrm20": 0.9,
-          "srm20": 0.85,
-          "lrm15": 0.8,
-          "lrm10": 0.75,
-          "srm6": 0.7,
-          "srm4": 0.65,
-          "srm2": 0.6,
-
-          "ppc": 0.05,
-          "gauss": 0.05,
-          "machinegun": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "laser": 0.05,
-          "ams": 0.05
-        }
-      },
-      {
-        "PrefabIdentifier": "lrm20",
-        "HardpointCandidates": {
-          "lrm20": 1.0,
-          "srm20": 0.95,
-          "lrm15": 0.9,
-          "lrm10": 0.85,
-          "lrm5": 0.8,
-          "srm6": 0.75,
-          "srm4": 0.7,
-          "srm2": 0.65,
-
-          "machinegun": 0.05,
-          "mg": 0.05,
-          "flamer": 0.05,
-          "laser": 0.05,
           "ams": 0.05
         }
       },
@@ -928,16 +788,210 @@
         }
       },
       {
+        "PrefabIdentifier": "mortar",
+        "HardpointCandidates": {
+          "mortar": 1.0,
+
+          "lrm10": 0.95,
+          "missile10": 0.9,
+          "mml9": 0.85,
+          "mml7": 0.8,
+          "srm6": 0.75,
+          "missile6": 0.7,
+          "lrm5": 0.65,
+          "mml5": 0.6,
+          "missile5": 0.55,
+          "srm4": 0.5,
+          "missile4": 0.45,
+          "mml3": 0.4,
+          "srm2": 0.35,
+          "missile2": 0.3,
+          "ac2": 0.25,
+
+          "mg": 0.05,
+          "machinegun": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "Laser",
+        "HardpointCandidates": {
+          "laser": 1.0,
+          "ppc": 0.95,
+          "flamer": 0.9,
+          "mg": 0.85,
+          "machinegun": 0.8,
+
+          "ac2": 0.05,
+          "ac": 0.05,
+          "lbx": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "PPC",
+        "HardpointCandidates": {
+          "ppc": 1.0,
+
+          "ac10": 0.95,
+          "laser": 0.9,
+          "ac20": 0.85,
+          "ac5": 0.8,
+          "ac": 0.75,
+
+          "flamer": 0.05,
+          "mg": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "Flamer",
+        "HardpointCandidates": {
+          "flamer": 1.0,
+          "laser": 0.9,
+          "mg": 0.85,
+          "machinegun": 0.8,
+
+          "ac2": 0.05,
+          "ppc": 0.05,
+          "ac": 0.05,
+          "lbx": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "lrm5",
+        "HardpointCandidates": {
+          "lrm5": 1.0,
+          "mml5": 0.95,
+          "missile5": 0.9,
+
+          "srm4": 0.85,
+          "missile4": 0.8,
+
+          "srm6": 0.75,
+          "missile6": 0.7,
+
+          "mml7": 0.65,
+
+          "srm2": 0.6,
+          "missile2": 0.55,
+
+          "mml9": 0.5,
+
+          "lrm10": 0.45,
+          "missile10": 0.4,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "lrm10",
+        "HardpointCandidates": {
+          "lrm10": 1.0,
+          "missile10": 0.95,
+
+          "mml9": 0.9,
+
+          "mml7": 0.85,
+
+          "srm6": 0.8,
+          "missile6": 0.75,
+
+          "lrm5": 0.7,
+          "mml5": 0.65,
+          "missile5": 0.6,
+
+          "lrm15": 0.55,
+          "missile15": 0.5,
+
+          "srm4": 0.45,
+          "missile4": 0.4,
+          "mml3": 0.35,
+          "srm2": 0.3,
+          "missile2": 0.25,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "lrm15",
+        "HardpointCandidates": {
+          "lrm15": 1.0,
+          "missile15": 0.95,
+
+          "lrm10": 0.9,
+          "missile10": 0.85,
+
+          "lrm20": 0.8,
+          "srm20": 0.75,
+          "missile20": 0.7,
+
+          "mml9": 0.65,
+          "srm6": 0.6,
+          "missile6": 0.55,
+          "lrm5": 0.5,
+          "mml5": 0.45,
+          "missile5": 0.4,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "lrm20",
+        "HardpointCandidates": {
+          "lrm20": 1.0,
+          "srm20": 0.95,
+          "missile20": 0.9,
+
+          "lrm15": 0.85,
+          "missile15": 0.8,
+          "lrm10": 0.75,
+          "missile10": 0.7,
+          "mml9": 0.65,
+          "mml7": 0.6,
+          "srm6": 0.55,
+          "missile6": 0.5,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+       {
         "PrefabIdentifier": "srm2",
         "HardpointCandidates": {
           "srm2": 1.0,
-          "srm4": 0.95,
-          "srm6": 0.9,
-          "lrm5": 0.85,
-          "lrm10": 0.8,
-          "lrm15": 0.75,
-          "lrm20": 0.7,
-          "srm20": 0.65,
+          "missile2": 0.95,
+
+          "mml3": 0.9,
+          "srm4": 0.85,
+          "missile4": 0.8,
+          "lrm5": 0.75,
+          "mml5": 0.7,
+          "missile5": 0.65,
+          "srm6": 0.6,
+          "missile6": 0.55,
+          "mml7": 0.5,
+          "mml9": 0.45,
+          "lrm10": 0.4,
+          "missile10": 0.35,
 
           "machinegun": 0.05,
           "mg": 0.05,
@@ -950,13 +1004,24 @@
         "PrefabIdentifier": "srm4",
         "HardpointCandidates": {
           "srm4": 1.0,
-          "srm6": 0.95,
-          "srm2": 0.9,
+          "missile4": 0.95,
+
+          "mml3": 0.9,
+
           "lrm5": 0.85,
-          "lrm10": 0.8,
-          "lrm15": 0.75,
-          "lrm20": 0.7,
-          "srm20": 0.65,
+          "mml5": 0.8,
+          "missile5": 0.75,
+
+          "srm2": 0.7,
+          "missile2": 0.65,
+
+          "srm6": 0.6,
+          "missile6": 0.55,
+
+          "mml7": 0.5,
+          "mml9": 0.45,
+          "lrm10": 0.4,
+          "missile10": 0.35,
 
           "machinegun": 0.05,
           "mg": 0.05,
@@ -969,13 +1034,218 @@
         "PrefabIdentifier": "srm6",
         "HardpointCandidates": {
           "srm6": 1.0,
-          "srm4": 0.95,
+          "missile6": 0.95,
+
+          "lrm5": 0.9,
+          "mml5": 0.85,
+          "missile5": 0.8,
+
+          "mml7": 0.75,
+
+          "srm4": 0.7,
+          "missile4": 0.65,
+
+          "mml3": 0.6,
+
+          "mml9": 0.55,
+
+          "srm2": 0.5,
+          "missile2": 0.45,
+
+          "lrm10": 0.4,
+          "missile10": 0.35,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "mml3",
+        "HarpointCandidates": {
+          "mml3": 1.0,
+
+          "srm2": 0.95,
+          "missile2": 0.9,
+
+          "srm4": 0.85,
+          "missile4": 0.8,
+
+          "mml5": 0.75,
+          "lrm5": 0.7,
+          "missile5": 0.65,
+
+          "srm6": 0.6,
+          "missile6": 0.55,
+
+          "mml7": 0.5,
+          "mml9": 0.45,
+          "lrm10": 0.4,
+          "missile10": 0.35,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "mml5",
+        "HarpointCandidates": {
+          "mml5": 1.0,
+          "lrm5": 0.95,
+          "missile5": 0.9,
+
+          "srm4": 0.85,
+          "missile4": 0.8,
+
+          "srm6": 0.75,
+          "missile6": 0.7,
+
+          "mml3": 0.65,
+
+          "mml7": 0.6,
+
+          "srm2": 0.55,
+          "missile2": 0.5,
+
+          "mml9": 0.45,
+
+          "lrm10": 0.4,
+          "missile10": 0.35,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "mml7",
+        "HarpointCandidates": {
+          "mml7": 1.0,
+
+          "srm6": 0.95,
+          "missile6": 0.9,
+
+          "mml5": 0.85,
+          "lrm5": 0.8,
+          "missile5": 0.75,
+
+          "mml9": 0.7,
+
+          "srm4": 0.65,
+          "missile4": 0.6,
+
+          "mml10": 0.55,
+          "lrm10": 0.5,
+          "missile10": 0.45,
+
+          "mml3": 0.4,
+          "srm2": 0.35,
+          "missile2": 0.3,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "mml9",
+        "HarpointCandidates": {
+          "mml9": 1.0,
+
+          "lrm10": 0.95,
+          "missile10": 0.9,
+
+          "mml7": 0.85,
+
+          "srm6": 0.8,
+          "missle6": 0.75,
+
+          "mml5": 0.7,
+          "lrm5": 0.65,
+          "missile5": 0.6,
+
+          "srm4": 0.55,
+          "missile4": 0.5,
+
+          "mml3": 0.45,
+
+          "lrm15": 0.4,
+          "missile15": 0.35,
+
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "arrow",
+        "HardpointCandidates": {
+          "arrow": 1.0,
+          "arrowiv": 0.95,
+
           "srm2": 0.9,
-          "lrm5": 0.85,
-          "lrm10": 0.8,
-          "lrm15": 0.75,
-          "lrm20": 0.7,
-          "srm20": 0.65,
+          "missile2": 0.85,
+
+          "mml3": 0.8,
+
+          "srm4": 0.75,
+          "missile4": 0.7,
+
+          "lrm5": 0.65,
+          "mml5": 0.6,
+          "missile5": 0.55,
+
+          "srm6": 0.5,
+          "missile6": 0.45,
+
+          "lrm10": 0.4,
+          "missile10": 0.35,
+
+          "ppc": 0.05,
+          "gauss": 0.05,
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "AMS",
+        "HardpointCandidates": {
+          "ams": 1.0,
+          "laser": 0.95,
+          "mg": 0.9,
+          "machinegun": 0.85,
+          "flamer": 0.8,
+
+          "ac2": 0.05,
+          "ppc": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "narc",
+        "HardpointCandidates": {
+          "narc": 1.0,
+
+          "srm2": 0.95,
+          "missile2": 0.9,
+          "mml3": 0.85,
+          "srm4": 0.8,
+          "missile4": 0.75,
+          "lrm5": 0.7,
+          "missile5": 0.65,
 
           "machinegun": 0.05,
           "mg": 0.05,
@@ -988,10 +1258,11 @@
         "PrefabIdentifier": "hatchet",
         "HardpointCandidates": {
           "hatchet": 1.0,
-          "mace": 0.95,
-          "sword": 0.9,
-          "spear": 0.85,
-          "blade": 0.8
+          "axe": 0.95,
+          "mace": 0.9,
+          "sword": 0.85,
+          "spear": 0.8,
+          "blade": 0.75
         }
       },
       {
@@ -999,9 +1270,10 @@
         "HardpointCandidates": {
           "sword": 1.0,
           "hatchet": 0.95,
-          "spear": 0.9,
-          "blade": 0.85,
-          "mace": 0.8
+          "axe": 0.9,
+          "spear": 0.85,
+          "blade": 0.8,
+          "mace": 0.75
         }
       },
       {
@@ -1009,8 +1281,9 @@
         "HardpointCandidates": {
           "mace": 1.0,
           "hatchet": 0.95,
-          "sword": 0.9,
-          "spear": 0.85
+          "axe": 0.9,
+          "sword": 0.85,
+          "spear": 0.8
         }
       },
       {
@@ -1020,7 +1293,8 @@
           "lance": 0.95,
           "sword": 0.9,
           "mace": 0.85,
-          "hatchet": 0.8
+          "hatchet": 0.8,
+          "axe": 0.75
         }
       },
       {
@@ -1041,20 +1315,34 @@
       {
         "PrefabIdentifier": "piledriver",
         "HardpointCandidates": {
-          "piledriver": 1.0,
-          "lance": 0.95,
-          "mace": 0.9,
-
-          "ac20": 0.05,
-          "ac": 0.05
+          "piledriver": 1.0
         }
       },
       {
         "PrefabIdentifier": "chainsaw",
         "HardpointCandidates": {
           "chainsaw": 1.0,
-          "blade": 0.95,
-          "lance": 0.9,
+          "saw": 0.95,
+          "miner": 0.9,
+          "blade": 0.8,
+          "lance": 0.75,
+
+          "ac20": 0.05,
+          "machinegun": 0.05,
+          "ac": 0.05,
+          "mg": 0.05
+        }
+      },
+      {
+        "PrefabIdentifier": "drill",
+        "HardpointCandidates": {
+          "drill": 1.0,
+          "grinder": 0.95,
+          "chainsaw": 0.9,
+          "saw": 0.9,
+          "lance": 0.85,
+          "hatchet": 0.8,
+          "axe": 0.75,
 
           "ac20": 0.05,
           "machinegun": 0.05,
@@ -1066,6 +1354,18 @@
         "PrefabIdentifier": "shield",
         "HardpointCandidates": {
           "shield": 1.0
+        }
+      },
+      {
+        "PrefabIdentifier": "mask",
+        "HardpointCandidates": {
+          "mask": 1.0
+        }
+      },
+      {
+        "PrefabIdentifier": "crane",
+        "HardpointCandidates": {
+          "crane": 1.0
         }
       }
     ]

--- a/Core/MechEngineer/Settings.json
+++ b/Core/MechEngineer/Settings.json
@@ -473,95 +473,6 @@
 				]
 			},
 			{
-				"PrefabIdentifier": "LBX2",
-				"HardpointCandidates": [
-					"lbx2",
-					"lbx5",
-					"ac2",
-					"ac5",
-					"lbx",
-					"ac",
-
-					"uac2",
-					"rac2",
-					"uac5",
-					"rac5",
-					"uac",
-					"rac",
-
-					"mg",
-					"ppc",
-					"laser",
-					"flamer",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "UAC2",
-				"HardpointCandidates": [
-					"uac2",
-					"rac2",
-					"uac5",
-					"rac5",
-					"rac",
-					"uac",
-
-					"lbx2",
-					"lbx5",
-					"ac2",
-					"ac5",
-					"lbx",
-					"ac",
-
-					"mg",
-					"ppc",
-					"laser",
-					"flamer",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "AMS",
-				"HardpointCandidates": [
-					"ams",
-					"laser",
-					"mg",
-					"machinegun",
-					"flamer",
-					"ac2",
-					"ppc"
-				]
-			},
-			{
-				"PrefabIdentifier": "Flamer",
-				"HardpointCandidates": [
-					"flamer",
-					"laser",
-					"ppc",
-					"mg",
-					"machinegun",
-					"ac2",
-					"ppc",
-					"ac",
-					"lbx",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "Laser",
-				"HardpointCandidates": [
-					"laser",
-					"ppc",
-					"flamer",
-					"mg",
-					"machinegun",
-					"ac2",
-					"ac",
-					"lbx",
-					"ams"
-				]
-			},
-			{
 				"PrefabIdentifier": "AC5",
 				"HardpointCandidates": [
 					"ac5",
@@ -590,86 +501,6 @@
 				]
 			},
 			{
-				"PrefabIdentifier": "LBX5",
-				"HardpointCandidates": [
-					"lbx5",
-					"lbx10",
-					"lbx2",
-					"ac5",
-					"ac10",
-					"ac2",
-					"lbx",
-					"ac",
-
-					"uac5",
-					"rac5",
-					"uac10",
-					"rac10",
-					"uac2",
-					"rac2",
-					"uac",
-					"rac",
-
-					"ppc",
-					"laser",
-					"mg",
-					"flamer",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "UAC5",
-				"HardpointCandidates": [
-					"uac5",
-					"rac5",
-					"uac10",
-					"rac10",
-					"uac2",
-					"rac2",
-					"uac",
-					"rac",
-
-					"lbx5",
-					"lbx10",
-					"lbx2",
-					"ac5",
-					"ac10",
-					"ac2",
-					"lbx",
-					"ac",
-
-					"ppc",
-					"laser",
-					"mg",
-					"flamer",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "RAC2",
-				"HardpointCandidates": [
-					"rac2",
-					"uac2",
-					"rac5",
-					"uac5",
-					"rac",
-					"uac",
-
-					"lbx2",
-					"lbx5",
-					"ac2",
-					"ac5",
-					"lbx",
-					"ac",
-
-					"ppc",
-					"laser",
-					"mg",
-					"flamer",
-					"ams"
-				]
-			},
-			{
 				"PrefabIdentifier": "AC10",
 				"HardpointCandidates": [
 					"ac10",
@@ -687,6 +518,88 @@
 					"rac20",
 					"uac10",
 					"rac10",
+					"uac",
+					"rac",
+
+					"ppc",
+					"laser",
+					"mg",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "AC20",
+				"HardpointCandidates": [
+					"ac20",
+					"ac10",
+					"lbx20",
+					"lbx10",
+					"ac",
+					"lbx",
+
+					"ac5",
+					"lbx5",
+
+					"uac20",
+					"rac20",
+					"rac10",
+					"uac10",
+					"uac",
+					"rac",
+
+					"uac5",
+					"rac5",
+
+					"ppc",
+					"laser",
+					"mg",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "LBX2",
+				"HardpointCandidates": [
+					"lbx2",
+					"lbx5",
+					"ac2",
+					"ac5",
+					"lbx",
+					"ac",
+
+					"uac2",
+					"rac2",
+					"uac5",
+					"rac5",
+					"uac",
+					"rac",
+
+					"mg",
+					"ppc",
+					"laser",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "LBX5",
+				"HardpointCandidates": [
+					"lbx5",
+					"lbx10",
+					"lbx2",
+					"ac5",
+					"ac10",
+					"ac2",
+					"lbx",
+					"ac",
+
+					"uac5",
+					"rac5",
+					"uac10",
+					"rac10",
+					"uac2",
+					"rac2",
 					"uac",
 					"rac",
 
@@ -725,6 +638,88 @@
 					"ams"
 				]
 			},
+				{
+				"PrefabIdentifier": "LBX20",
+				"HardpointCandidates": [
+					"lbx20",
+					"lbx10",
+					"ac20",
+					"ac10",
+					"lbx",
+					"ac",
+
+					"lbx5",
+					"ac5",
+
+					"uac20",
+					"rac20",
+					"uac10",
+					"rac10",
+					"uac",
+					"rac",
+
+					"uac5",
+					"rac5",
+
+					"ppc",
+					"laser",
+					"mg",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "UAC2",
+				"HardpointCandidates": [
+					"uac2",
+					"rac2",
+					"uac5",
+					"rac5",
+					"rac",
+					"uac",
+
+					"lbx2",
+					"lbx5",
+					"ac2",
+					"ac5",
+					"lbx",
+					"ac",
+
+					"mg",
+					"ppc",
+					"laser",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "UAC5",
+				"HardpointCandidates": [
+					"uac5",
+					"rac5",
+					"uac10",
+					"rac10",
+					"uac2",
+					"rac2",
+					"uac",
+					"rac",
+
+					"lbx5",
+					"lbx10",
+					"lbx2",
+					"ac5",
+					"ac10",
+					"ac2",
+					"lbx",
+					"ac",
+
+					"ppc",
+					"laser",
+					"mg",
+					"flamer",
+					"ams"
+				]
+			},
 			{
 				"PrefabIdentifier": "UAC10",
 				"HardpointCandidates": [
@@ -742,6 +737,60 @@
 					"lbx5",
 					"ac10",
 					"ac20",
+					"ac5",
+					"lbx",
+					"ac",
+
+					"ppc",
+					"laser",
+					"mg",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "UAC20",
+				"HardpointCandidates": [
+					"uac20",
+					"rac20",
+					"uac10",
+					"rac10",
+					"uac",
+					"rac",
+
+					"uac5",
+					"rac5",
+
+					"lbx20",
+					"ac20",
+					"lbx10",
+					"ac10",
+					"ac",
+					"lbx",
+
+					"lbx5",
+					"ac5",
+
+					"ppc",
+					"laser",
+					"mg",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "RAC2",
+				"HardpointCandidates": [
+					"rac2",
+					"uac2",
+					"rac5",
+					"uac5",
+					"rac",
+					"uac",
+
+					"lbx2",
+					"lbx5",
+					"ac2",
 					"ac5",
 					"lbx",
 					"ac",
@@ -773,112 +822,6 @@
 					"ac2",
 					"lbx",
 					"ac",
-
-					"ppc",
-					"laser",
-					"mg",
-					"flamer",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "PPC",
-				"HardpointCandidates": [
-					"ppc",
-
-					"ac10",
-					"laser",
-					"ac20",
-					"ac5",
-					"ac",
-
-					"flamer",
-					"mg",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "AC20",
-				"HardpointCandidates": [
-					"ac20",
-					"ac10",
-					"lbx20",
-					"lbx10",
-					"ac",
-					"lbx",
-
-					"ac5",
-					"lbx5",
-
-					"uac20",
-					"rac20",
-					"rac10",
-					"uac10",
-					"uac",
-					"rac",
-
-					"uac5",
-					"rac5",
-
-					"ppc",
-					"laser",
-					"mg",
-					"flamer",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "LBX20",
-				"HardpointCandidates": [
-					"lbx20",
-					"lbx10",
-					"ac20",
-					"ac10",
-					"lbx",
-					"ac",
-
-					"lbx5",
-					"ac5",
-
-					"uac20",
-					"rac20",
-					"uac10",
-					"rac10",
-					"uac",
-					"rac",
-
-					"uac5",
-					"rac5",
-
-					"ppc",
-					"laser",
-					"mg",
-					"flamer",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "UAC20",
-				"HardpointCandidates": [
-					"uac20",
-					"rac20",
-					"uac10",
-					"rac10",
-					"uac",
-					"rac",
-
-					"uac5",
-					"rac5",
-
-					"lbx20",
-					"ac20",
-					"lbx10",
-					"ac10",
-					"ac",
-					"lbx",
-
-					"lbx5",
-					"ac5",
 
 					"ppc",
 					"laser",
@@ -946,25 +889,6 @@
 				]
 			},
 			{
-				"PrefabIdentifier": "BFG",
-				"HardpointCandidates": [
-					"bfg",
-
-					"artillery",
-					"gauss",
-					"ac20",
-					"lbx20",
-					"ppc",
-					"ac",
-					"lbx",
-
-					"laser",
-					"mg",
-					"flamer",
-					"ams"
-				]
-			},
-			{
 				"PrefabIdentifier": "Gauss",
 				"HardpointCandidates": [
 					"gauss",
@@ -1000,105 +924,43 @@
 					"laser"
 				]
 			},
-			{
-				"PrefabIdentifier": "lrm5",
+				{
+				"PrefabIdentifier": "BFG",
 				"HardpointCandidates": [
-					"lrm5",
-					"lrm10",
-					"lrm15",
-					"lrm20",
-					"srm20",
-					"srm6",
-					"srm4",
-					"srm2",
+					"bfg",
 
-					"machinegun",
-					"mg",
-					"flamer",
-					"laser",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "lrm10",
-				"HardpointCandidates": [
-					"lrm10",
-					"lrm15",
-					"lrm20",
-					"srm20",
-					"lrm5",
-					"srm6",
-					"srm4",
-					"srm2",
-
-					"machinegun",
-					"mg",
-					"flamer",
-					"laser",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "lrm15",
-				"HardpointCandidates": [
-					"lrm15",
-					"lrm20",
-					"srm20",
-					"lrm10",
-					"lrm5",
-					"srm6",
-					"srm4",
-					"srm2",
-
-					"machinegun",
-					"mg",
-					"flamer",
-					"laser",
-					"ams"
-				]
-			},
-			{
-				"PrefabIdentifier": "arrow",
-				"HardpointCandidates": [
-					"arrow",
-
-					"lrm5",
-					"lrm20",
-					"srm20",
-					"lrm15",
-					"lrm10",
-					"srm6",
-					"srm4",
-					"srm2",
-
-					"ppc",
+					"artillery",
 					"gauss",
-					"machinegun",
+					"ac20",
+					"lbx20",
+					"ppc",
+					"ac",
+					"lbx",
+
+					"laser",
 					"mg",
 					"flamer",
-					"laser",
 					"ams"
 				]
 			},
 			{
-				"PrefabIdentifier": "lrm20",
-				"HardpointCandidates": [
-					"lrm20",
-					"srm20",
-					"lrm15",
-					"lrm10",
-					"lrm5",
-					"srm6",
-					"srm4",
-					"srm2",
+        "PrefabIdentifier": "railgun",
+        "HardpointCandidates": [
+          "railgun",
 
-					"machinegun",
-					"mg",
-					"flamer",
-					"laser",
-					"ams"
-				]
-			},
+          "gauss",
+          "ac20",
+          "lbx20",
+          "ppc",
+          "ac",
+          "lbx",
+
+          "laser",
+          "mg",
+          "flamer",
+          "ams"
+        ]
+      },
 			{
 				"PrefabIdentifier": "MachineGun",
 				"HardpointCandidates": [
@@ -1111,17 +973,210 @@
 					"laser"
 				]
 			},
+			 {
+        "PrefabIdentifier": "mortar",
+        "HardpointCandidates": [
+          "mortar",
+
+          "lrm10",
+          "missile10",
+          "mml9",
+          "mml7",
+          "srm6",
+          "missile6",
+          "lrm5",
+          "mml5",
+          "missile5",
+          "srm4",
+          "missile4",
+          "mml3",
+          "srm2",
+          "missile2",
+          "ac2",
+
+          "mg",
+          "machinegun",
+          "flamer",
+          "laser",
+          "ams"
+        ]
+      },
+			{
+				"PrefabIdentifier": "Laser",
+				"HardpointCandidates": [
+					"laser",
+					"ppc",
+					"flamer",
+					"mg",
+					"machinegun",
+					"ac2",
+					"ac",
+					"lbx",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "PPC",
+				"HardpointCandidates": [
+					"ppc",
+
+					"ac10",
+					"laser",
+					"ac20",
+					"ac5",
+					"ac",
+
+					"flamer",
+					"mg",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "Flamer",
+				"HardpointCandidates": [
+					"flamer",
+					"laser",
+					"ppc",
+					"mg",
+					"machinegun",
+					"ac2",
+					"ppc",
+					"ac",
+					"lbx",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "lrm5",
+				"HardpointCandidates": [
+					"lrm5",
+          "mml5",
+          "missile5",
+
+          "srm4",
+          "missile4",
+
+          "srm6",
+          "missile6",
+
+          "mml7",
+
+          "srm2",
+          "missile2",
+
+          "mml9",
+
+          "lrm10",
+          "missile10",
+
+          "machinegun",
+          "mg",
+          "flamer",
+          "laser",
+          "ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "lrm10",
+				"HardpointCandidates": [
+					"lrm10",
+          "missile10",
+
+          "mml9",
+
+          "mml7",
+
+          "srm6",
+          "missile6",
+
+          "lrm5",
+          "mml5",
+          "missile5",
+
+          "lrm15",
+          "missile15",
+
+          "srm4",
+          "missile4",
+          "mml3",
+          "srm2",
+          "missile2",
+
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "lrm15",
+				"HardpointCandidates": [
+					"lrm15",
+          "missile15",
+
+          "lrm10",
+          "missile10",
+
+          "lrm20",
+          "srm20",
+          "missile20",
+
+          "mml9",
+          "srm6",
+          "missile6",
+          "lrm5",
+          "mml5",
+          "missile5",
+
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "lrm20",
+				"HardpointCandidates": [
+					"lrm20",
+          "srm20",
+          "missile20",
+
+          "lrm15",
+          "missile15",
+          "lrm10",
+          "missile10",
+          "mml9",
+          "mml7",
+          "srm6",
+          "missile6",
+
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
+				]
+			},
 			{
 				"PrefabIdentifier": "srm2",
 				"HardpointCandidates": [
 					"srm2",
-					"srm4",
-					"srm6",
-					"lrm5",
-					"lrm10",
-					"lrm15",
-					"lrm20",
-					"srm20",
+          "missile2",
+
+          "mml3",
+          "srm4",
+          "missile4",
+          "lrm5",
+          "mml5",
+          "missile5",
+          "srm6",
+          "missile6",
+          "mml7",
+          "mml9",
+          "lrm10",
+          "missile10",
 
 					"machinegun",
 					"mg",
@@ -1134,13 +1189,24 @@
 				"PrefabIdentifier": "srm4",
 				"HardpointCandidates": [
 					"srm4",
-					"srm6",
-					"srm2",
-					"lrm5",
-					"lrm10",
-					"lrm15",
-					"lrm20",
-					"srm20",
+          "missile4",
+
+          "mml3",
+
+          "lrm5",
+          "mml5",
+          "missile5",
+
+          "srm2",
+          "missile2",
+
+          "srm6",
+          "missile6",
+
+          "mml7",
+          "mml9",
+          "lrm10",
+          "missile10",
 
 					"machinegun",
 					"mg",
@@ -1153,13 +1219,26 @@
 				"PrefabIdentifier": "srm6",
 				"HardpointCandidates": [
 					"srm6",
-					"srm4",
-					"srm2",
-					"lrm5",
-					"lrm10",
-					"lrm15",
-					"lrm20",
-					"srm20",
+          "missile6",
+
+          "lrm5",
+          "mml5",
+          "missile5",
+
+          "mml7",
+
+          "srm4",
+          "missile4",
+
+          "mml3",
+
+          "mml9",
+
+          "srm2",
+          "missile2",
+
+          "lrm10",
+          "missile10",
 
 					"machinegun",
 					"mg",
@@ -1169,9 +1248,201 @@
 				]
 			},
 			{
+        "PrefabIdentifier": "mml3",
+        "HarpointCandidates": [
+          "mml3",
+
+          "srm2",
+          "missile2",
+
+          "srm4",
+          "missile4",
+
+          "mml5",
+          "lrm5",
+          "missile5",
+
+          "srm6",
+          "missile6",
+
+          "mml7",
+          "mml9",
+          "lrm10",
+          "missile10",
+
+          "machinegun",
+          "mg",
+          "flamer",
+          "laser",
+          "ams"
+        ]
+      },
+      {
+        "PrefabIdentifier": "mml5",
+        "HarpointCandidates": [
+          "mml5",
+          "lrm5",
+          "missile5",
+
+          "srm4",
+          "missile4",
+
+          "srm6",
+          "missile6",
+
+          "mml3",
+
+          "mml7",
+
+          "srm2",
+          "missile2",
+
+          "mml9",
+
+          "lrm10",
+          "missile10",
+
+          "machinegun",
+          "mg",
+          "flamer",
+          "laser",
+          "ams"
+        ]
+      },
+      {
+        "PrefabIdentifier": "mml7",
+        "HarpointCandidates": [
+          "mml7",
+
+          "srm6",
+          "missile6",
+
+          "mml5",
+          "lrm5",
+          "missile5",
+
+          "mml9",
+
+          "srm4",
+          "missile4",
+
+          "mml10",
+          "lrm10",
+          "missile10",
+
+          "mml3",
+          "srm2",
+          "missile2",
+
+          "machinegun",
+          "mg",
+          "flamer",
+          "laser",
+          "ams"
+        ]
+      },
+      {
+        "PrefabIdentifier": "mml9",
+        "HarpointCandidates": [
+          "mml9",
+
+          "lrm10",
+          "missile10",
+
+          "mml7",
+
+          "srm6",
+          "missle6",
+
+          "mml5",
+          "lrm5",
+          "missile5",
+
+          "srm4",
+          "missile4",
+
+          "mml3",
+
+          "lrm15",
+          "missile15",
+
+          "machinegun",
+          "mg",
+          "flamer",
+          "laser",
+          "ams"
+        ]
+      },
+			{
+				"PrefabIdentifier": "arrow",
+				"HardpointCandidates": [
+					"arrow",
+          "arrowiv",
+
+          "srm2",
+          "missile2",
+
+          "mml3",
+
+          "srm4",
+          "missile4",
+
+          "lrm5",
+          "mml5",
+          "missile5",
+
+          "srm6",
+          "missile6",
+
+          "lrm10",
+          "missile10",
+
+					"ppc",
+					"gauss",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "AMS",
+				"HardpointCandidates": [
+					"ams",
+					"laser",
+					"mg",
+					"machinegun",
+					"flamer",
+					"ac2",
+					"ppc"
+				]
+			},
+			{
+        "PrefabIdentifier": "narc",
+        "HardpointCandidates": [
+          "narc",
+
+          "srm2",
+          "missile2",
+          "mml3",
+          "srm4",
+          "missile4",
+          "lrm5",
+          "missile5",
+
+          "machinegun",
+          "mg",
+          "flamer",
+          "laser",
+          "ams"
+        ]
+      },
+			{
 				"PrefabIdentifier": "hatchet",
 				"HardpointCandidates": [
 					"hatchet",
+					"axe",
 					"mace",
 					"sword",
 					"spear",
@@ -1183,6 +1454,7 @@
 				"HardpointCandidates": [
 					"sword",
 					"hatchet",
+					"axe",
 					"spear",
 					"blade",
 					"mace"
@@ -1193,6 +1465,7 @@
 				"HardpointCandidates": [
 					"mace",
 					"hatchet",
+					"axe",
 					"sword",
 					"spear"
 				]
@@ -1204,7 +1477,8 @@
 					"lance",
 					"sword",
 					"mace",
-					"hatchet"
+					"hatchet",
+					"axe"
 				]
 			},
 			{
@@ -1219,25 +1493,21 @@
 				"PrefabIdentifier": "blade",
 				"HardpointCandidates": [
 					"blade",
-					"lance",
-					"sword"
+					"lance"
 				]
 			},
 			{
 				"PrefabIdentifier": "piledriver",
 				"HardpointCandidates": [
-					"piledriver",
-					"lance",
-					"mace",
-
-					"ac20",
-					"ac"
+					"piledriver"
 				]
 			},
 			{
 				"PrefabIdentifier": "chainsaw",
 				"HardpointCandidates": [
 					"chainsaw",
+					"saw",
+					"miner",
 					"blade",
 					"lance",
 
@@ -1248,11 +1518,40 @@
 				]
 			},
 			{
+        "PrefabIdentifier": "drill",
+        "HardpointCandidates": [
+          "drill",
+          "grinder",
+          "chainsaw",
+          "saw",
+          "lance",
+          "hatchet",
+          "axe",
+
+          "ac20",
+          "machinegun",
+          "ac",
+          "mg"
+        ]
+      },
+			{
 				"PrefabIdentifier": "shield",
 				"HardpointCandidates": [
 					"shield"
 				]
-			}
+			},
+			{
+        "PrefabIdentifier": "mask",
+        "HardpointCandidates": [
+          "mask"
+        ]
+      },
+      {
+        "PrefabIdentifier": "crane",
+        "HardpointCandidates": [
+          "crane"
+        ]
+      }
 		]
 	},
 	"HeatSinkCapacityStat": {

--- a/Core/RogueModuleTech/AddOn/BoltOn/BoltOn_Weapon_GrenadeLauncher_5.json
+++ b/Core/RogueModuleTech/AddOn/BoltOn/BoltOn_Weapon_GrenadeLauncher_5.json
@@ -98,7 +98,7 @@
     "Model": "Mortar",
     "UIName": "BoltOn MTR/5",
     "Id": "BoltOn_Weapon_GrenadeLauncher_5",
-    "Name": "MTR/6",
+    "Name": "MTR/5",
     "Details": "Based on the weapon used by infantry for centuries, the Mech Mortar fires a small shell in a high arc that falls onto the target. Though the Mech Mortar was created by the Terran Hegemony, by 2835 the Succession Wars had relegated it to history. With the reintroduction of the Anti-Missile System, engineers revived the Mech Mortar concept. The munitions used by the mortars, though often possessing limited guidance packages, weren't destroyed by AMS systems in tests. Mortar shells also proved very adaptable, accepting several types of payloads.",
     "Icon": "mortar"
   },
@@ -106,7 +106,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC10",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_NARC.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_NARC.json
@@ -94,7 +94,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "srm2",
+  "PrefabIdentifier": "narc",
   "BattleValue": 60,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_2_Clan.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_2_Clan.json
@@ -77,7 +77,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC2",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 55,
   "InventorySize": 1,
   "Tonnage": 1,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_4_Clan.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_4_Clan.json
@@ -77,7 +77,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC5",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 109,
   "InventorySize": 1,
   "Tonnage": 2.5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_6_Clan.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_6_Clan.json
@@ -80,7 +80,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC10",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 164,
   "InventorySize": 2,
   "Tonnage": 3.5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_8_Clan.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_Mortar_8_Clan.json
@@ -80,7 +80,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 220,
   "InventorySize": 2,
   "Tonnage": 5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_NARC_Clan.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_NARC_Clan.json
@@ -69,7 +69,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "srm2",
+  "PrefabIdentifier": "narc",
   "BattleValue": 30,
   "InventorySize": 1,
   "Tonnage": 1,

--- a/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Chainsword.json
+++ b/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Chainsword.json
@@ -81,7 +81,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "chainsaw",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_Chainsaw.json
+++ b/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_Chainsaw.json
@@ -90,7 +90,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "chainsaw",
   "BattleValue": 7,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_Cultivator.json
+++ b/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_Cultivator.json
@@ -85,7 +85,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "chainsaw",
   "BattleValue": 5,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_JackHammer.json
+++ b/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_JackHammer.json
@@ -85,7 +85,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "piledriver",
+  "PrefabIdentifier": "drill",
   "BattleValue": 5,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_MiningDrill.json
+++ b/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_MiningDrill.json
@@ -85,7 +85,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "drill",
   "BattleValue": 12,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_3.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_3.json
@@ -88,7 +88,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "mml3",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_5.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_5.json
@@ -88,7 +88,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "mml5",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_7.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_7.json
@@ -88,7 +88,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "mml7",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_9.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_MML_9.json
@@ -88,7 +88,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "mml9",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_VehicleGrenadeLauncher.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_VehicleGrenadeLauncher.json
@@ -104,7 +104,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC2",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_Grenade_Launcher.json
+++ b/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_Grenade_Launcher.json
@@ -33,7 +33,7 @@
   },
   "weaponCategoryID": "BattleArmor",
   "Type": "Autocannon",
-  "WeaponSubType": "AC2",
+  "WeaponSubType": "mortar",
   "MinRange": 0,
   "MaxRange": 240,
   "RangeSplit": [

--- a/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_Mortar.json
+++ b/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_Mortar.json
@@ -92,7 +92,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC2",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0.3,

--- a/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_Mortar_Heavy.json
+++ b/Core/RogueModuleTech/PowerArmor/PAWeapons/Weapon_PowerArmor_Mortar_Heavy.json
@@ -92,7 +92,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC2",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 0.44,

--- a/Core/RogueModuleTech/SuperHeavy/Weapon/Weapon_Railgun_Clan.json
+++ b/Core/RogueModuleTech/SuperHeavy/Weapon/Weapon_Railgun_Clan.json
@@ -86,7 +86,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 18,
   "Tonnage": 25,

--- a/Core/RogueModuleTech/SuperHeavy/Weapon/Weapon_Railgun_Light.json
+++ b/Core/RogueModuleTech/SuperHeavy/Weapon/Weapon_Railgun_Light.json
@@ -85,7 +85,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 15,
   "Tonnage": 20,

--- a/Core/RogueModuleTech/SuperHeavy/Weapon/Weapon_Railgun_SLDF.json
+++ b/Core/RogueModuleTech/SuperHeavy/Weapon/Weapon_Railgun_SLDF.json
@@ -87,7 +87,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 18,
   "Tonnage": 30,

--- a/Core/RogueModuleTech/SuperHeavy/Weapon_Railgun_Snubnose.json
+++ b/Core/RogueModuleTech/SuperHeavy/Weapon_Railgun_Snubnose.json
@@ -81,7 +81,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 12,
   "Tonnage": 20,

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_GrenadeLauncher_Ivan.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_GrenadeLauncher_Ivan.json
@@ -75,7 +75,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC2",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 1,

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_IndustrialCrane_LoaderKing.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_IndustrialCrane_LoaderKing.json
@@ -71,7 +71,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "crane",
   "BattleValue": 0,
   "InventorySize": 4,
   "Tonnage": 0,

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_Mortar_Broadside.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_Mortar_Broadside.json
@@ -79,7 +79,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 0,
   "InventorySize": 4,
   "Tonnage": 10,

--- a/Core/RogueModuleTech/Vehicle/Upgrades/Gear_Vehicle_LiftHoist.json
+++ b/Core/RogueModuleTech/Vehicle/Upgrades/Gear_Vehicle_LiftHoist.json
@@ -29,7 +29,7 @@
   "BonusValueB": "",
   "ComponentType": "Upgrade",
   "ComponentSubType": "NotSet",
-  "PrefabIdentifier": "",
+  "PrefabIdentifier": "crane",
   "BattleValue": 0,
   "InventorySize": 4,
   "Tonnage": 12,

--- a/Core/RogueModuleTech/Weapons/Weapon_LiftHoist_30ton.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LiftHoist_30ton.json
@@ -70,7 +70,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "crane",
   "BattleValue": 0,
   "InventorySize": 3,
   "Tonnage": 3,

--- a/Core/RogueModuleTech/Weapons/Weapon_MML_7.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_MML_7.json
@@ -74,7 +74,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm15",
+  "PrefabIdentifier": "mml7",
   "BattleValue": 67,
   "InventorySize": 3,
   "Tonnage": 4.5,

--- a/Core/RogueModuleTech/Weapons/Weapon_MML_9.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_MML_9.json
@@ -74,7 +74,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm20",
+  "PrefabIdentifier": "mml9",
   "BattleValue": 86,
   "InventorySize": 4,
   "Tonnage": 6,

--- a/Core/RogueModuleTech/Weapons/Weapon_Mortar_4.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Mortar_4.json
@@ -80,7 +80,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC5",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 90,
   "InventorySize": 2,
   "Tonnage": 5,

--- a/Core/RogueModuleTech/Weapons/Weapon_Mortar_6.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Mortar_6.json
@@ -80,7 +80,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC10",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 136,
   "InventorySize": 3,
   "Tonnage": 7,

--- a/Core/RogueModuleTech/Weapons/Weapon_Mortar_8.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Mortar_8.json
@@ -80,7 +80,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC20",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 181,
   "InventorySize": 4,
   "Tonnage": 10,

--- a/Core/RogueModuleTech/Weapons/Weapon_NARC.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_NARC.json
@@ -71,7 +71,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "srm2",
+  "PrefabIdentifier": "narc",
   "BattleValue": 30,
   "InventorySize": 1,
   "Tonnage": 2,

--- a/Core/RogueModuleTech/Weapons/Weapon_NARC_iNARC.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_NARC_iNARC.json
@@ -71,7 +71,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "srm2",
+  "PrefabIdentifier": "narc",
   "BattleValue": 75,
   "InventorySize": 3,
   "Tonnage": 4,

--- a/Core/RogueModuleTech/Weapons/Weapon_VehicleGrenadeLauncher.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_VehicleGrenadeLauncher.json
@@ -74,7 +74,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "AC2",
+  "PrefabIdentifier": "mortar",
   "BattleValue": 25,
   "InventorySize": 1,
   "Tonnage": 1,

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_dig_lord_RCL-Z1.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_dig_lord_RCL-Z1.json
@@ -50,7 +50,7 @@
   "ChassisTags": {
     "items": [
       "IndustrialMech",
-      "mr-resize-1.6"
+      "mr-resize-1.1"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/ExperimentalWeapons/Base/Unique/Weapon/Unique_Weapon_Railgun_Downscaled.json
+++ b/Optionals/ExperimentalWeapons/Base/Unique/Weapon/Unique_Weapon_Railgun_Downscaled.json
@@ -83,7 +83,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 5,
   "Tonnage": 22,

--- a/Optionals/ExperimentalWeapons/Base/Unique/Weapon/Unique_Weapon_Railgun_StoneRhino.json
+++ b/Optionals/ExperimentalWeapons/Base/Unique/Weapon/Unique_Weapon_Railgun_StoneRhino.json
@@ -77,7 +77,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 2,
   "Tonnage": 22,

--- a/Optionals/ExperimentalWeapons/Base/weapon/Weapon_Railgun_Helical.json
+++ b/Optionals/ExperimentalWeapons/Base/weapon/Weapon_Railgun_Helical.json
@@ -96,7 +96,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 20,
   "Tonnage": 35,

--- a/Optionals/ExperimentalWeapons/Base/weapon/Weapon_Railgun_Improved.json
+++ b/Optionals/ExperimentalWeapons/Base/weapon/Weapon_Railgun_Improved.json
@@ -81,7 +81,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 18,
   "Tonnage": 22,

--- a/Optionals/ExperimentalWeapons/Base/weapon/Weapon_Railgun_Plasma.json
+++ b/Optionals/ExperimentalWeapons/Base/weapon/Weapon_Railgun_Plasma.json
@@ -98,7 +98,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "Gauss",
+  "PrefabIdentifier": "railgun",
   "BattleValue": 0,
   "InventorySize": 18,
   "Tonnage": 28,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_5_Streak.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_5_Streak.json
@@ -81,7 +81,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "mml5",
   "BattleValue": 0,
   "InventorySize": 2,
   "Tonnage": 4,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_7_Streak.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_7_Streak.json
@@ -81,7 +81,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "mml7",
   "BattleValue": 0,
   "InventorySize": 3,
   "Tonnage": 6,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_9_Streak.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_9_Streak.json
@@ -81,7 +81,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "mml9",
   "BattleValue": 0,
   "InventorySize": 4,
   "Tonnage": 8,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_NARC_RISC.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_NARC_RISC.json
@@ -76,7 +76,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "srm2",
+  "PrefabIdentifier": "narc",
   "BattleValue": 40,
   "InventorySize": 2,
   "Tonnage": 2,

--- a/Optionals/RogueSociety/Base/weapons/Weapon_NARC_Streak_Society.json
+++ b/Optionals/RogueSociety/Base/weapons/Weapon_NARC_Streak_Society.json
@@ -73,7 +73,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "srm2",
+  "PrefabIdentifier": "narc",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 2,


### PR DESCRIPTION
Went through CAB and included all unused prefabs in fallbacks. Some were prevalent enough to warrant their own hierarchies.

### Missiles
**General Hierarchy Changes**
Retooled missile fallbacks. Missile hierarchy now tries the following in order:

1. Match number of tubes (LRM5 = LRM5 > MML5 > Missile5)
2. If no match, round DOWN to next tier (LRM5 = SRM4 > Missile4)
3. If no match, round UP to next tier (LRM5 = SRM6 > Missile6)
4. If still no match, round DOWN further (LRM5 = MML3),
5. etc

Most of the fallbacks cut off at LRM10 or SRM6 since those are very commonly used prefabs and I wanted to avoid bloating the hierarchies too much.

**Arrow IV**
Several 'Mechs called for "arrowiv" instead of just "arrow", so it has been added to the "arrow" fallbacks.

**MMLs**
Several 'Mechs called for specific MML launchers. I added all canon MML launchers (3 through 9) as their own hierarchies and included them in the fallbacks for more granular tube count matches.

**MissileN**
Various 'Mechs called for non-specific missile hardpoints (ex: missile2, missile4, missile5, missile6, etc). These seem to just be ammunition-agnostic missile launchers, and have just been included in the fallbacks as a matter of course.

**Narc Launchers**
As with MMLs, some 'Mechs called for a Narc prefab. It's been added as a hierarchy with a few tiers of tubes upwards as fallbacks.

### Ballistics
**Railguns**
The Great Turtle calls a railgun prefab. I've added it as a hierarchy and converted all railguns over to use it. The fallbacks should mean that there is no change to 'Mechs that were using it before the change.

**Mortars**
Several 'Mechs call for mortar prefab, so as with railguns it's been added as a hierarchy and the existing mortar weapons have been converted over. The previous hierarchy didn't really make much sense considering that mortars are rated by number of tubes, not by size of shell, so I've used missiles as the main fallbacks as opposed to autocannons. Previously we were using ACs 2 through 20 as the prefabs for mortars.

### Melee
**Drills**
A few of the industrial 'Mechs call for drills, so it's been added as a hierarchy and various handheld drills now use it.

**Jackhammers**
I misunderstood what a piledriver is, so jackhammer handhelds have been changed to drills. Honestly this probably doesn't make any difference.

### Misc
**Unique Items**
Some of the industrial items or other unique prefab calls have been added. None of these are used currently, but with the upcoming Kiso 'Mech, we'll have an opportunity to use several of these.

**Size Adjustments**
The Dig Lord was a DUMMY THICC BOI. For some reason it was taller and wider than a 100T Annihilator while only being a 65T IndustrialMech. Scale has been reduced from a whopping 1.6 to a more reasonable 1.1.