### PR TITLE
Thunderbolt Weapon Prefab Grouping

### DIFF
--- a/Core/CustomUnits/mod.json
+++ b/Core/CustomUnits/mod.json
@@ -1189,28 +1189,63 @@
         }
       },
       {
+        "PrefabIdentifier": "thunderbolt",
+        "HardpointCandidates": {
+          "thunderbolt": 1.0,
+          "arrow": 0.95,
+          "arrowiv": 0.9,
+
+          "srm2": 0.85,
+          "missile2": 0.8,
+
+          "mml3": 0.75,
+
+          "srm4": 0.7,
+          "missile4": 0.65,
+
+          "lrm5": 0.6,
+          "mml5": 0.55,
+          "missile5": 0.5,
+
+          "srm6": 0.45,
+          "missile6": 0.4,
+
+          "lrm10": 0.35,
+          "missile10": 0.3,
+
+          "ppc": 0.05,
+          "gauss": 0.05,
+          "machinegun": 0.05,
+          "mg": 0.05,
+          "flamer": 0.05,
+          "laser": 0.05,
+          "ams": 0.05
+        }
+      },
+      {
         "PrefabIdentifier": "arrow",
         "HardpointCandidates": {
           "arrow": 1.0,
           "arrowiv": 0.95,
+          "thunderbolt": 0.9,
 
-          "srm2": 0.9,
-          "missile2": 0.85,
+          "srm2": 0.85,
+          "missile2": 0.8,
 
-          "mml3": 0.8,
+          "mml3": 0.75,
 
-          "srm4": 0.75,
-          "missile4": 0.7,
+          "srm4": 0.7,
+          "missile4": 0.65,
 
-          "lrm5": 0.65,
-          "mml5": 0.6,
-          "missile5": 0.55,
+          "lrm5": 0.6,
+          "mml5": 0.55,
+          "missile5": 0.5,
 
-          "srm6": 0.5,
-          "missile6": 0.45,
+          "srm6": 0.45,
+          "missile6": 0.4,
 
-          "lrm10": 0.4,
-          "missile10": 0.35,
+          "lrm10": 0.35,
+          "missile10": 0.3,
 
           "ppc": 0.05,
           "gauss": 0.05,

--- a/Core/MechEngineer/Settings.json
+++ b/Core/MechEngineer/Settings.json
@@ -1378,6 +1378,41 @@
 				"HardpointCandidates": [
 					"arrow",
           "arrowiv",
+					"thunderbolt",
+
+          "srm2",
+          "missile2",
+
+          "mml3",
+
+          "srm4",
+          "missile4",
+
+          "lrm5",
+          "mml5",
+          "missile5",
+
+          "srm6",
+          "missile6",
+
+          "lrm10",
+          "missile10",
+
+					"ppc",
+					"gauss",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "thunderbolt",
+				"HardpointCandidates": [
+					"thunderbolt",
+					"arrow",
+          "arrowiv",
 
           "srm2",
           "missile2",

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_Thunderstorm.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_Thunderstorm.json
@@ -83,7 +83,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm15",
+  "PrefabIdentifier": "thunderbolt",
   "BattleValue": 768,
   "InventorySize": 12,
   "Tonnage": 25,

--- a/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_10.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_10.json
@@ -75,7 +75,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "thunderbolt",
   "BattleValue": 127,
   "InventorySize": 2,
   "Tonnage": 6,

--- a/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_15.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_15.json
@@ -75,7 +75,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm15",
+  "PrefabIdentifier": "thunderbolt",
   "BattleValue": 229,
   "InventorySize": 3,
   "Tonnage": 9,

--- a/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_20.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_20.json
@@ -75,7 +75,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm20",
+  "PrefabIdentifier": "thunderbolt",
   "BattleValue": 305,
   "InventorySize": 5,
   "Tonnage": 12,

--- a/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_5.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Thunderbolt_5.json
@@ -72,7 +72,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "thunderbolt",
   "BattleValue": 64,
   "InventorySize": 1,
   "Tonnage": 3,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_Thunderbolt_30_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_Thunderbolt_30_Pirate.json
@@ -82,7 +82,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "thunderbolt",
   "BattleValue": 381,
   "InventorySize": 5,
   "Tonnage": 17,


### PR DESCRIPTION
Quick update to separate Thunderbolts, since we had a few 'Mechs models designed with TBM launchers in mind (IE: Bombard) that weren't able to access the model due to the way TBMs were set up previously. Follows standard convention for "tube" style weapons in that the fallback attempts to match tube size (in this instance, 1) before falling back to checking up, then down, etc.

If this does end up looking really weird on some 'Mechs then I can try using regular autocannons since they're only 1 "tube", but some 'Mechs have some really odd AC models that wouldn't work, so opted to avoid it on initial commit.