### PR TITLE
Fix Gear Naming Error

### DIFF
--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialExtensive.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialExtensive.json
@@ -54,19 +54,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
@@ -116,21 +116,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -194,21 +194,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -272,21 +272,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -350,21 +350,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -428,21 +428,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -506,21 +506,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -584,21 +584,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -662,21 +662,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -740,21 +740,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -818,21 +818,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -895,19 +895,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialMajor.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialMajor.json
@@ -54,19 +54,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
@@ -116,21 +116,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -194,21 +194,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -272,21 +272,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -350,21 +350,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -428,21 +428,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -506,21 +506,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -584,21 +584,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -662,21 +662,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -740,21 +740,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -818,21 +818,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -895,19 +895,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialMinor.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialMinor.json
@@ -54,19 +54,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
@@ -116,21 +116,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -194,21 +194,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -272,21 +272,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -350,21 +350,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -428,21 +428,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -506,21 +506,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -584,21 +584,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -662,21 +662,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -740,21 +740,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -818,21 +818,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -895,19 +895,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialModerate.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCPartialModerate.json
@@ -54,19 +54,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "GreaterThan",
                             "val" : 0,
                             "valueConstant" : "0"
@@ -116,21 +116,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -194,21 +194,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -272,21 +272,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -350,21 +350,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -428,21 +428,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -506,21 +506,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -584,21 +584,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -662,21 +662,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -740,21 +740,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -818,21 +818,21 @@
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                                    "name" : "Item.UpgradeDef.Gear_KerbyInjectors",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                                    "name" : "Item.UpgradeDef.Gear_FuCapacitor",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
                                 },
                                 {
                                     "typeString" : "System.Int32",
-                                    "name" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                                    "name" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                                     "value" : "-1",
                                     "set" : false,
                                     "valueConstant" : null
@@ -895,19 +895,19 @@
                     },
                     "RequirementComparisons" : [
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCKerbyInjectors",
+                            "obj" : "Item.UpgradeDef.Gear_KerbyInjectors",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCFuCapacitor",
+                            "obj" : "Item.UpgradeDef.Gear_FuCapacitor",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"
                         },
                         {
-                            "obj" : "Item.UpgradeDef.Gear_KFCCheatahNavComputer",
+                            "obj" : "Item.UpgradeDef.Gear_CheatahNavComputer",
                             "op" : "LessThan",
                             "val" : 1,
                             "valueConstant" : "1"


### PR DESCRIPTION
Fixed x3 incorrectly named Gear Items in 4 events of the WHERETHAFUQAWE event chain