### PR TITLE
Remove UAV from EMP-GSR

### DIFF
--- a/Optionals/RogueElites/Base/mech/mechdef_emperor_EMP-GSR.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_emperor_EMP-GSR.json
@@ -214,14 +214,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Special_AddOn_UAV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_CASE",
       "ComponentDefType": "Upgrade",


### PR DESCRIPTION
SLDF-era factions have too many units throwing out UAVs at d10+. EMP-GSR is one of the more common units at this diff range, so removing the UAV should go some way in reducing total unit count and thereby not make missions take 100 extra years from additional unit turns.