### PR TITLE
Fixed missing Tags in misjump events

### DIFF
--- a/Optionals/Eventualities/Wherethafuqawe/events/aurigancoalition/event_co_misjump_aurigancoalition.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/aurigancoalition/event_co_misjump_aurigancoalition.json
@@ -2661,6 +2661,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -5003,6 +5063,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/castile/event_co_misjump_castile.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/castile/event_co_misjump_castile.json
@@ -1308,6 +1308,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Psi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }

--- a/Optionals/Eventualities/Wherethafuqawe/events/chainelane/event_co_misjump_chainelane.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/chainelane/event_co_misjump_chainelane.json
@@ -1166,6 +1166,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Kappa"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -2169,6 +2229,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Kappa"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/circinus/event_co_misjump_circinus.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/circinus/event_co_misjump_circinus.json
@@ -1166,6 +1166,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Kappa"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -2169,6 +2229,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Kappa"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/clan/event_co_misjump_clan.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/clan/event_co_misjump_clan.json
@@ -4988,6 +4988,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Psi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -9436,6 +9496,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Psi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/comstar/event_co_misjump_comstar.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/comstar/event_co_misjump_comstar.json
@@ -706,6 +706,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Tau"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -1297,6 +1357,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Tau"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_01_davion.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_01_davion.json
@@ -9676,6 +9676,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18301,6 +18361,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_02_davion.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_02_davion.json
@@ -9676,6 +9676,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Theta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18301,6 +18361,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Theta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_03_davion.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_03_davion.json
@@ -9676,6 +9676,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Kappa"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18301,6 +18361,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Kappa"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_04_davion.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_04_davion.json
@@ -9676,6 +9676,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Theta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18301,6 +18361,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Theta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_05_davion.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_05_davion.json
@@ -9677,6 +9677,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Psi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18302,6 +18362,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Psi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_06_davion.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/davion/event_co_misjump_06_davion.json
@@ -9931,6 +9931,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18808,6 +18868,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/delphi/event_co_misjump_delphi.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/delphi/event_co_misjump_delphi.json
@@ -1422,6 +1422,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Omicron"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }

--- a/Optionals/Eventualities/Wherethafuqawe/events/elysia/event_co_misjump_elysia.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/elysia/event_co_misjump_elysia.json
@@ -476,6 +476,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Tau"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -861,6 +921,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Tau"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/hanse/event_co_misjump_hanse.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/hanse/event_co_misjump_hanse.json
@@ -3607,6 +3607,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Epsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -6819,6 +6879,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Epsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/illyrian/event_co_misjump_illyrian.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/illyrian/event_co_misjump_illyrian.json
@@ -476,6 +476,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -861,6 +921,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/ives/event_co_misjump_ives.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/ives/event_co_misjump_ives.json
@@ -1971,6 +1971,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Mu"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -3695,6 +3755,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Mu"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/jarnfolk/event_co_misjump_jarnfolk.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/jarnfolk/event_co_misjump_jarnfolk.json
@@ -476,6 +476,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -861,6 +921,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_01_kurita.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_01_kurita.json
@@ -9446,6 +9446,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Mu"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -17865,6 +17925,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Mu"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_02_kurita.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_02_kurita.json
@@ -9702,6 +9702,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Epsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18373,6 +18433,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Epsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_03_kurita.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_03_kurita.json
@@ -9561,6 +9561,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18083,6 +18143,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_04_kurita.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/kurita/event_co_misjump_04_kurita.json
@@ -9561,6 +9561,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18083,6 +18143,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/liao/event_co_misjump_02_liao.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/liao/event_co_misjump_02_liao.json
@@ -7146,6 +7146,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Tau"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -13505,6 +13565,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Tau"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/locals/event_co_misjump_01_locals.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/locals/event_co_misjump_01_locals.json
@@ -9246,6 +9246,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Iota"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -17753,6 +17813,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Iota"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/locals/event_co_misjump_02_locals.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/locals/event_co_misjump_02_locals.json
@@ -3135,6 +3135,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -6036,6 +6096,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/lothian/event_co_misjump_lothian.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/lothian/event_co_misjump_lothian.json
@@ -821,6 +821,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Theta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -1515,6 +1575,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Theta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/magistracyofcanopus/event_co_misjump_magistracyofcanopus.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/magistracyofcanopus/event_co_misjump_magistracyofcanopus.json
@@ -5217,6 +5217,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -9871,6 +9931,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/marian/event_co_misjump_marian.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/marian/event_co_misjump_marian.json
@@ -1281,6 +1281,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Gamma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -2387,6 +2447,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Gamma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_01_marik.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_01_marik.json
@@ -9561,6 +9561,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18083,6 +18143,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_02_marik.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_02_marik.json
@@ -9446,6 +9446,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Omicron"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -17865,6 +17925,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Omicron"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_03_marik.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_03_marik.json
@@ -9446,6 +9446,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Epsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -17865,6 +17925,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Epsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_04_marik.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/marik/event_co_misjump_04_marik.json
@@ -9587,6 +9587,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18155,6 +18215,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_02_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_02_nofaction.json
@@ -10700,6 +10700,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20357,6 +20417,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_03_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_03_nofaction.json
@@ -10496,6 +10496,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Rho"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -19999,6 +20059,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Rho"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_04_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_04_nofaction.json
@@ -10496,6 +10496,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -19993,6 +20053,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Phi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05L_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05L_nofaction.json
@@ -11312,6 +11312,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Iota"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21425,6 +21485,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Iota"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05M_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05M_nofaction.json
@@ -11312,6 +11312,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Chi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21425,6 +21485,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Chi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05N_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05N_nofaction.json
@@ -11312,6 +11312,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Lambda"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21425,6 +21485,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Lambda"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05O_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05O_nofaction.json
@@ -11312,6 +11312,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Iota"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21425,6 +21485,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Iota"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05P_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05P_nofaction.json
@@ -11312,6 +11312,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Gamma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21425,6 +21485,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Gamma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05Q_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05Q_nofaction.json
@@ -2776,6 +2776,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Eta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -5221,6 +5281,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Eta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_05_nofaction.json
@@ -11516,6 +11516,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21789,6 +21849,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_06_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_06_nofaction.json
@@ -11516,6 +11516,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Chi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21798,6 +21858,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Chi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_07_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_07_nofaction.json
@@ -10496,6 +10496,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -19989,6 +20049,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_08_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_08_nofaction.json
@@ -9884,6 +9884,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Delta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18909,6 +18969,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Delta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_09_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_09_nofaction.json
@@ -10292,6 +10292,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Delta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -19629,6 +19689,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Delta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_10_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_10_nofaction.json
@@ -9680,6 +9680,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Rho"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -13508,6 +13568,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Rho"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
@@ -18489,6 +18609,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Rho"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_11_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_11_nofaction.json
@@ -11313,6 +11313,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Psi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -21430,6 +21490,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Psi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_12_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_12_nofaction.json
@@ -10699,6 +10699,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Zeta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma", 
+                                    "Misjumped_Eta",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20348,6 +20408,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Zeta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma", 
+                                    "Misjumped_Eta",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_13_nofaction.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/nofaction/event_co_misjump_13_nofaction.json
@@ -10904,6 +10904,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Eta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20715,6 +20775,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Eta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/outworld/event_co_misjump_outworld.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/outworld/event_co_misjump_outworld.json
@@ -4412,6 +4412,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -8345,6 +8405,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/rasalhague/event_co_misjump_rasalhague.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/rasalhague/event_co_misjump_rasalhague.json
@@ -9790,6 +9790,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Zeta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma", 
+                                    "Misjumped_Eta",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -18518,6 +18578,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Zeta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma", 
+                                    "Misjumped_Eta",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_01_steiner.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_01_steiner.json
@@ -10596,6 +10596,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20045,6 +20105,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Xi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_02_steiner.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_02_steiner.json
@@ -10596,6 +10596,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Sigma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20045,6 +20105,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Sigma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_03_steiner.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_03_steiner.json
@@ -10596,6 +10596,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Rho"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20045,6 +20105,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Rho"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_05_steiner.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_05_steiner.json
@@ -10596,6 +10596,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Sigma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20045,6 +20105,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Sigma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_06_steiner.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/steiner/event_co_misjump_06_steiner.json
@@ -10596,6 +10596,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Gamma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -20045,6 +20105,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Gamma"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/taurianconcordat/event_co_misjump_taurianconcordat.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/taurianconcordat/event_co_misjump_taurianconcordat.json
@@ -7517,6 +7517,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Chi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -14231,6 +14291,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Chi"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/tortuga/event_co_misjump_tortuga.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/tortuga/event_co_misjump_tortuga.json
@@ -706,6 +706,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -1297,6 +1357,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Upsilon"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Eta", 
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/valkyrate/event_co_misjump_valkyrate.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/valkyrate/event_co_misjump_valkyrate.json
@@ -705,6 +705,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Zeta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma", 
+                                    "Misjumped_Eta",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -1296,6 +1356,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Zeta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma", 
+                                    "Misjumped_Eta",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0

--- a/Optionals/Eventualities/Wherethafuqawe/events/wordofblake/event_co_misjump_wordofblake.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/wordofblake/event_co_misjump_wordofblake.json
@@ -1281,6 +1281,66 @@
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Eta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
                         }
                     ]
                 }
@@ -2387,6 +2447,66 @@
                                     "additionalValues" : null
                                 }
                             ],
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : [],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : true,
+                            "ResultDuration" : 150
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Eta"
+                                ]
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : [
+                                    "Misjumped_Alpha", 
+                                    "Misjumped_Beta", 
+                                    "Misjumped_Gamma", 
+                                    "Misjumped_Delta", 
+                                    "Misjumped_Epsilon", 
+                                    "Misjumped_Theta", 
+                                    "Misjumped_Zeta", 
+                                    "Misjumped_Kappa", 
+                                    "Misjumped_Lambda", 
+                                    "Misjumped_Omicron", 
+                                    "Misjumped_Sigma",
+                                    "Misjumped_Iota", 
+                                    "Misjumped_Mu", 
+                                    "Misjumped_Rho", 
+                                    "Misjumped_Tau", 
+                                    "Misjumped_Upsilon", 
+                                    "Misjumped_Phi", 
+                                    "Misjumped_Chi", 
+                                    "Misjumped_Psi", 
+                                    "Misjumped_Xi", 
+                                    "Misjumped_Omega"
+                                ]
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
                             "ForceEvents" : null,
                             "TemporaryResult" : false,
                             "ResultDuration" : 0


### PR DESCRIPTION
Fixed numerous missing "time delay" tags that slow down the frequency of misjumps.