### PR TITLE
Janaszar solitaire patch 1

### DIFF
--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_solitaire_sie.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_solitaire_sie.json
@@ -38,8 +38,6 @@
   "VariantName": "SIE",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerRight",
-      "ArmLimitLowerLeft",
       "ClanMech",
       "mr-resize-0.6-0.7-0.65"
     ],

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_solitaire_SIE-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_solitaire_SIE-2.json
@@ -38,8 +38,6 @@
   "VariantName": "SIE-2",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerRight",
-      "ArmLimitLowerLeft",
       "ClanMech",
       "mr-resize-0.6-0.7-0.65"
     ],


### PR DESCRIPTION
Updating the Solitaire's hands per RT Ticket 9696
Record Sheets indicate it has left and right hands, but when the mech was originally added, it was not given them, only lower actuators. Long term oversight finally caught.