### PR TITLE
Remove ArtemisIV from Behemoth II Custom

### DIFF
--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_BEHEMOTH_II_Custom.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_BEHEMOTH_II_Custom.json
@@ -94,8 +94,14 @@
       "ComponentDefID": "Weapon_LRM_15_Delta",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
-      "DamageLevel": "Functional",
-      "LocalGUID": "WeaponAttachment0"
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_MagnaVI",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
@@ -134,7 +140,7 @@
     },
     {
       "MountedLocation": "Left",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -263,14 +269,6 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Turret",
-      "ComponentDefID": "Gear_Attachment_ArtemisIV",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional",
-      "TargetComponentGUID": "WeaponAttachment0"
     },
     {
       "MountedLocation": "Left",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_BEHEMOTH_II_Custom.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_BEHEMOTH_II_Custom.json
@@ -134,7 +134,7 @@
     },
     {
       "MountedLocation": "Left",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Artemis",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"


### PR DESCRIPTION
Tank had ArtIV attachment but no ammo for it. Removed attachment and added extra ER MedLas.