### PR TITLE
Event fix for Isorla Bondsman pilots - REQUIRES MechAfiinity.dll upda…

### DIFF
--- a/Core/Isorla/events/event_co_Isorla_Medium.json
+++ b/Core/Isorla/events/event_co_Isorla_Medium.json
@@ -1,240 +1,671 @@
 {
-  "Description": {
-    "Id": "event_co_Isorla_Medium",
-    "Name": "Isorla Medium",
-    "Details": "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
-    "Icon": "uixTxrSpot_Isorla.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "items": [],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_co_Isorla_Medium",
+        "Name" : "Isorla Medium",
+        "Details" : "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": "Tags/CompanyTags"
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
     },
-    "RequirementComparisons": []
-  },
-  "AdditionalRequirements": [],
-  "AdditionalObjects": [],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
-        "Details": "Non Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
         {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "Reject MechWarrior",
-            "Details": "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 100,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "That surat has no place with us.",
+                "Details" : "Reject MechWarrior [Neg.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "GreaterThanOrEqual",
+                            "val" : 0,
+                            "valueConstant" : "0"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Reject MechWarrior",
+                        "Details" : "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Alpha Pod < 8 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "argo_pod1"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 8,
+                            "valueConstant" : "8"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_N",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_E",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_L",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_D",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_2",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Alpha Pod < 16 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "argo_pod1",
+                            "argo_pod2"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 16,
+                            "valueConstant" : "16"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_0",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_N",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_1",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_E",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_2",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_L",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_3",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_D",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_3",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Alpha Pod < 24 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "argo_pod1",
+                            "argo_pod2",
+                            "argo_pod3"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 24,
+                            "valueConstant" : "24"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_0",
+                        "Name" : "Take Bondsman Niles",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_N",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_1",
+                        "Name" : "Take Bondswoman Erin",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_E",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_2",
+                        "Name" : "Take Bondswoman Lateekah",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_L",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_3",
+                        "Name" : "Take Bondsman Dante",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Medium_D",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
-        "Details": "Claim bondsman",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "Take Bondsman Niles",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Medium_N",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Take Bondswoman Erin",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Medium_E",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Take Bondswoman Lateekah",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Medium_L",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Take Bondsman Dante",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Medium_D",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "UNSELECTABLE",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [
-      "BLACKLISTED"
     ],
-    "tagSetSourceFile": "tags/EventTags"
-  }
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
 }

--- a/Core/Isorla/events/event_co_Isorla_Mild.json
+++ b/Core/Isorla/events/event_co_Isorla_Mild.json
@@ -1,240 +1,671 @@
 {
-  "Description": {
-    "Id": "event_co_Isorla_Mild",
-    "Name": "Isorla Mild",
-    "Details": "The Trial is over and you have proven yourself in the ways of the Clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
-    "Icon": "uixTxrSpot_Isorla.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "items": [],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_co_Isorla_Mild",
+        "Name" : "Isorla Mild",
+        "Details" : "The Trial is over and you have proven yourself in the ways of the Clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": "Tags/CompanyTags"
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "tagSetSourceFile" : "",
+            "items" : []
+        },
+        "ExclusionTags" : {
+            "tagSetSourceFile" : "Tags/CompanyTags",
+            "items" : []
+        },
+        "RequirementComparisons" : []
     },
-    "RequirementComparisons": []
-  },
-  "AdditionalRequirements": [],
-  "AdditionalObjects": [],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
-        "Details": "Non Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
         {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "Reject MechWarrior",
-            "Details": "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 100,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "That surat has no place with us.",
+                "Details" : "Reject MechWarrior [Neg.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : []
+                    },
+                    "ExclusionTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : []
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "GreaterThanOrEqual",
+                            "val" : 0,
+                            "valueConstant" : "0"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Reject MechWarrior",
+                        "Details" : "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "ExclusionTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Alpha Pod < 8 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : [
+                            "argo_pod1"
+                        ]
+                    },
+                    "ExclusionTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : []
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 8,
+                            "valueConstant" : "8"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_0",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_F",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_1",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_2",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_T",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_1_3",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_S",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "ExclusionTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_2",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Beta Pod < 16 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : [
+                            "argo_pod1",
+                            "argo_pod2"
+                        ]
+                    },
+                    "ExclusionTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : []
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 16,
+                            "valueConstant" : "16"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_0",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_F",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_1",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_2",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_T",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_2_3",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_S",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "ExclusionTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_3",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Gamma Pod < 24 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : [
+                            "argo_pod1",
+                            "argo_pod2",
+                            "argo_pod3"
+                        ]
+                    },
+                    "ExclusionTags" : {
+                        "tagSetSourceFile" : "",
+                        "items" : []
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 24,
+                            "valueConstant" : "24"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_0",
+                        "Name" : "Take Bondsman Fergus",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_F",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_1",
+                        "Name" : "Take Bondswoman Mychel",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_2",
+                        "Name" : "Take Bondsman Tyler",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_T",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_3",
+                        "Name" : "Take Bondswoman Synthia",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 25,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "RemovedTags" : {
+                                "tagSetSourceFile" : "",
+                                "items" : []
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Mild_S",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "ExclusionTags" : {
+                    "tagSetSourceFile" : "",
+                    "items" : []
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
-        "Details": "Claim bondsman",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "Take Bondsman Fergus",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Mild_F",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Take Bondswoman Mychel",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Mild_M",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Take Bondsman Tyler",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Mild_T",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Take Bondswoman Synthia",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 25,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Mild_S",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "UNSELECTABLE",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [
-      "BLACKLISTED"
     ],
-    "tagSetSourceFile": "tags/EventTags"
-  }
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "tagSetSourceFile" : "tags/EventTags",
+        "items" : [
+            "BLACKLISTED"
+        ]
+    }
 }

--- a/Core/Isorla/events/event_co_Isorla_Spicy.json
+++ b/Core/Isorla/events/event_co_Isorla_Spicy.json
@@ -1,314 +1,893 @@
 {
-  "Description": {
-    "Id": "event_co_Isorla_Spicy",
-    "Name": "Isorla Spicy",
-    "Details": "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
-    "Icon": "uixTxrSpot_Isorla.png"
-  },
-  "Scope": "Company",
-  "Weight": 10,
-  "Requirements": {
-    "Scope": "Company",
-    "RequirementTags": {
-      "items": [],
-      "tagSetSourceFile": ""
+    "Description" : {
+        "Id" : "event_co_Isorla_Spicy",
+        "Name" : "Isorla Spicy",
+        "Details" : "The Trial is over and you have proven yourself in the ways of the clans.\r\n\r\nDarius approaches, \"Commander, do you wish to enact your rights to claim your opponent as a [[DM.BaseDescriptionDefs[LoreBondsman],bondsman]]?\"",
+        "Icon" : "uixTxrSpot_Isorla.png"
     },
-    "ExclusionTags": {
-      "items": [],
-      "tagSetSourceFile": "Tags/CompanyTags"
+    "Scope" : "Company",
+    "Weight" : 10,
+    "Requirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
     },
-    "RequirementComparisons": []
-  },
-  "AdditionalRequirements": [],
-  "AdditionalObjects": [],
-  "Options": [
-    {
-      "Description": {
-        "Id": "outcome_0",
-        "Name": "<b><color=#00ccff>[Neg.] </color></b>That surat has no place with us.",
-        "Details": "Non Participation Option",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
+    "AdditionalRequirements" : [],
+    "AdditionalObjects" : [],
+    "Options" : [
         {
-          "Description": {
-            "Id": "outcome_0_0",
-            "Name": "Reject MechWarrior",
-            "Details": "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
-            "Icon": null
-          },
-          "Weight": 100,
-          "Results": []
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "That surat has no place with us.",
+                "Details" : "Reject MechWarrior [Neg.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "GreaterThanOrEqual",
+                            "val" : 0,
+                            "valueConstant" : "0"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Reject MechWarrior",
+                        "Details" : "You turn from Darius to look at the wreckage of your former opponent's mech,  \"That Mechwarrior failed the Trial, and failed to impress me.  I have no need of one such as them within our ranks.\"",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : []
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_1",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Alpha Pod < 8 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "argo_pod1"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 8,
+                            "valueConstant" : "8"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_0",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_1",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_H",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_2",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_P",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_3",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_A",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_4",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LM",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_5",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LF",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_2",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Alpha Pod < 16 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "argo_pod1",
+                            "argo_pod2"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 16,
+                            "valueConstant" : "16"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_0",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_1",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_H",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_2",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_P",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_3",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_A",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_4",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LM",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_5",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LF",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        },
+        {
+            "Description" : {
+                "Id" : "outcome_3",
+                "Name" : "We could use another MechWarrior.",
+                "Details" : "Alpha Pod < 24 [Aff.]",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [
+                            "argo_pod1",
+                            "argo_pod2",
+                            "argo_pod3"
+                        ],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "MaPilotCount",
+                            "op" : "LessThan",
+                            "val" : 24,
+                            "valueConstant" : "24"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_0",
+                        "Name" : "Take Bondsman Mytch Hoff",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_M",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_1",
+                        "Name" : "Take Bondswoman Holli Jones",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_H",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_2",
+                        "Name" : "Take Bondswoman Pheona OReilly",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_P",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_3",
+                        "Name" : "Take Bondsman Alek Yanev",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 20,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_A",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_4",
+                        "Name" : "Take Bondsman Lukas Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LM",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                },
+                {
+                    "Description" : {
+                        "Id" : "outcome_3_5",
+                        "Name" : "Take Bondswoman Lumen Furey",
+                        "Details" : "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
+                        "Icon" : null
+                    },
+                    "Weight" : 10,
+                    "Results" : [
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : "Tags/CompanyTags"
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : [
+                                {
+                                    "Scope" : "Company",
+                                    "EventID" : "event_co_Isorla_Spicy_LF",
+                                    "MinDaysWait" : 0,
+                                    "MaxDaysWait" : 0,
+                                    "Probability" : 100,
+                                    "RetainPilot" : false
+                                }
+                            ],
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
         }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    },
-    {
-      "Description": {
-        "Id": "outcome_1",
-        "Name": "<b><color=#00ccff>[Aff.] </color></b>We could use another MechWarrior.",
-        "Details": "Claim bondsman",
-        "Icon": null
-      },
-      "RequirementList": [],
-      "ResultSets": [
-        {
-          "Description": {
-            "Id": "outcome_1_0",
-            "Name": "Take Bondsman Mytch Hoff",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 20,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Spicy_M",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_1",
-            "Name": "Take Bondswoman Holli Jones",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 20,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Spicy_H",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_2",
-            "Name": "Take Bondswoman Pheona OReilly",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 20,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Spicy_P",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_3",
-            "Name": "Take Bondsman Alek Yanev",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 20,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Spicy_A",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_4",
-            "Name": "Take Bondsman Lukas Furey",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 10,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Spicy_LM",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        },
-        {
-          "Description": {
-            "Id": "outcome_1_5",
-            "Name": "Take Bondswoman Lumen Furey",
-            "Details": "You look at Darius, \"Find out where my opponent is now and bring me a bondscord.  We will do this the Clan way.\"\r\n\r\nDarius heads off to look for the fallen MechWarrior.\r\n\r\n<color=#ff0000><i>Advance a day to get the results</i></color>",
-            "Icon": null
-          },
-          "Weight": 10,
-          "Results": [
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": null,
-              "Actions": null,
-              "ForceEvents": [
-                {
-                  "Scope": "Company",
-                  "EventID": "event_co_Isorla_Spicy_LF",
-                  "MinDaysWait": 0,
-                  "MaxDaysWait": 0,
-                  "Probability": 100,
-                  "RetainPilot": false
-                }
-              ],
-              "TemporaryResult": false,
-              "ResultDuration": 0
-            }
-          ]
-        }
-      ],
-      "Requirements": {
-        "Scope": "Company",
-        "RequirementTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "ExclusionTags": {
-          "items": [],
-          "tagSetSourceFile": ""
-        },
-        "RequirementComparisons": []
-      }
-    }
-  ],
-  "PublishState": "PUBLISHED",
-  "ValidationState": "UNTESTED",
-  "EventType": "UNSELECTABLE",
-  "OneTimeEvent": false,
-  "Tags": {
-    "items": [
-      "BLACKLISTED"
     ],
-    "tagSetSourceFile": "tags/EventTags"
-  }
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "UNSELECTABLE",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [
+            "BLACKLISTED"
+        ],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
 }


### PR DESCRIPTION
…te from CRITICAL-MODS-UPDATES

Rewritten opening events to disable gaining pilot if there are not enough barracks spots on the Argo.

This event requires latest MechAffinity.dll from critical-mods-updates