### PR TITLE
ELRM adjustments

### DIFF
--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_10_Extended.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_10_Extended.json
@@ -12,6 +12,7 @@
       "RangedDmg: +100%",
       "Indirect",
       "DoesCluster",
+      "AmmoRestrictionELRM",
       "AAFactor: 8%"
     ],
     "Flags": [
@@ -24,7 +25,7 @@
   "Category": "Missile",
   "Type": "LRM",
   "WeaponSubType": "LRM10",
-  "MinRange": 210,
+  "MinRange": 300,
   "MaxRange": 1320,
   "RangeSplit": [
     360,
@@ -49,7 +50,7 @@
   "isHeatVariation": true,
   "isStabilityVariation": true,
   "isDamageVariation": true,
-  "DamageFalloffStartDistance": 210,
+  "DamageFalloffStartDistance": 300,
   "DamageFalloffEndDistance": 1140,
   "RangedDmgFalloffType": "Linear",
   "APArmorShardsMod": 0.25,
@@ -215,6 +216,30 @@
         "modType": "System.Single"
       }
     }
+  ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_Sensors",
+    "Ammunition_LRM_SolidSlug",
+    "Ammunition_LRM_Swarm",
+    "Ammunition_LRM_Swarm_I",
+    "Ammunition_LRM_Tandem",
+    "Ammunition_LRM_Thunder",
+    "Ammunition_LRM_AX",
+    "Ammunition_LRM_Banana",
+    "Ammunition_LRM_Chaff",
+    "Ammunition_LRM_Clearance",
+    "Ammunition_LRM_Deadfire",
+    "Ammunition_LRM_ER",
+    "Ammunition_LRM_FTL",
+    "Ammunition_LRM_Hydra",
+    "Ammunition_LRM_LK",
+    "Ammunition_LRM_MagPulse",
+    "Ammunition_LRM_Narc",
+    "Ammunition_LRM_SAM",
+    "Ammunition_ILRM",
+    "Ammunition_LRM_Thunder_Augmented",
+    "Ammunition_LRM_Thunder_Inferno",
+    "Ammunition_LRM_Artemis"
   ],
   "ComponentTags": {
     "items": [

--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_15_Extended.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_15_Extended.json
@@ -12,6 +12,7 @@
       "RangedDmg: +100%",
       "Indirect",
       "DoesCluster",
+      "AmmoRestrictionELRM",
       "AAFactor: 12%"
     ],
     "Flags": [
@@ -24,7 +25,7 @@
   "Category": "Missile",
   "Type": "LRM",
   "WeaponSubType": "LRM15",
-  "MinRange": 210,
+  "MinRange": 300,
   "MaxRange": 1320,
   "RangeSplit": [
     360,
@@ -49,7 +50,7 @@
   "isHeatVariation": true,
   "isStabilityVariation": true,
   "isDamageVariation": true,
-  "DamageFalloffStartDistance": 210,
+  "DamageFalloffStartDistance": 300,
   "DamageFalloffEndDistance": 1140,
   "RangedDmgFalloffType": "Linear",
   "APArmorShardsMod": 0.25,
@@ -215,6 +216,30 @@
         "modType": "System.Single"
       }
     }
+  ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_Sensors",
+    "Ammunition_LRM_SolidSlug",
+    "Ammunition_LRM_Swarm",
+    "Ammunition_LRM_Swarm_I",
+    "Ammunition_LRM_Tandem",
+    "Ammunition_LRM_Thunder",
+    "Ammunition_LRM_AX",
+    "Ammunition_LRM_Banana",
+    "Ammunition_LRM_Chaff",
+    "Ammunition_LRM_Clearance",
+    "Ammunition_LRM_Deadfire",
+    "Ammunition_LRM_ER",
+    "Ammunition_LRM_FTL",
+    "Ammunition_LRM_Hydra",
+    "Ammunition_LRM_LK",
+    "Ammunition_LRM_MagPulse",
+    "Ammunition_LRM_Narc",
+    "Ammunition_LRM_SAM",
+    "Ammunition_ILRM",
+    "Ammunition_LRM_Thunder_Augmented",
+    "Ammunition_LRM_Thunder_Inferno",
+    "Ammunition_LRM_Artemis"
   ],
   "ComponentTags": {
     "items": [

--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_20_Extended.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_20_Extended.json
@@ -12,6 +12,7 @@
       "RangedDmg: +100%",
       "Indirect",
       "DoesCluster",
+      "AmmoRestrictionELRM",
       "AAFactor: 16%"
     ],
     "Flags": [
@@ -24,7 +25,7 @@
   "Category": "Missile",
   "Type": "LRM",
   "WeaponSubType": "LRM20",
-  "MinRange": 210,
+  "MinRange": 300,
   "MaxRange": 1320,
   "RangeSplit": [
     360,
@@ -49,7 +50,7 @@
   "isHeatVariation": true,
   "isStabilityVariation": true,
   "isDamageVariation": true,
-  "DamageFalloffStartDistance": 210,
+  "DamageFalloffStartDistance": 300,
   "DamageFalloffEndDistance": 1140,
   "RangedDmgFalloffType": "Linear",
   "APArmorShardsMod": 0.25,
@@ -215,6 +216,30 @@
         "modType": "System.Single"
       }
     }
+  ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_Sensors",
+    "Ammunition_LRM_SolidSlug",
+    "Ammunition_LRM_Swarm",
+    "Ammunition_LRM_Swarm_I",
+    "Ammunition_LRM_Tandem",
+    "Ammunition_LRM_Thunder",
+    "Ammunition_LRM_AX",
+    "Ammunition_LRM_Banana",
+    "Ammunition_LRM_Chaff",
+    "Ammunition_LRM_Clearance",
+    "Ammunition_LRM_Deadfire",
+    "Ammunition_LRM_ER",
+    "Ammunition_LRM_FTL",
+    "Ammunition_LRM_Hydra",
+    "Ammunition_LRM_LK",
+    "Ammunition_LRM_MagPulse",
+    "Ammunition_LRM_Narc",
+    "Ammunition_LRM_SAM",
+    "Ammunition_ILRM",
+    "Ammunition_LRM_Thunder_Augmented",
+    "Ammunition_LRM_Thunder_Inferno",
+    "Ammunition_LRM_Artemis"
   ],
   "ComponentTags": {
     "items": [

--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_5_Extended.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_5_Extended.json
@@ -12,6 +12,7 @@
       "RangedDmg: +100%",
       "Indirect",
       "DoesCluster",
+      "AmmoRestrictionELRM",
       "AAFactor: 4%"
     ],
     "Flags": [
@@ -24,7 +25,7 @@
   "Category": "Missile",
   "Type": "LRM",
   "WeaponSubType": "LRM5",
-  "MinRange": 210,
+  "MinRange": 300,
   "MaxRange": 1320,
   "RangeSplit": [
     360,
@@ -49,7 +50,7 @@
   "isHeatVariation": true,
   "isStabilityVariation": true,
   "isDamageVariation": true,
-  "DamageFalloffStartDistance": 210,
+  "DamageFalloffStartDistance": 300,
   "DamageFalloffEndDistance": 1140,
   "RangedDmgFalloffType": "Linear",
   "APArmorShardsMod": 0.25,
@@ -215,6 +216,30 @@
         "modType": "System.Single"
       }
     }
+  ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_Sensors",
+    "Ammunition_LRM_SolidSlug",
+    "Ammunition_LRM_Swarm",
+    "Ammunition_LRM_Swarm_I",
+    "Ammunition_LRM_Tandem",
+    "Ammunition_LRM_Thunder",
+    "Ammunition_LRM_AX",
+    "Ammunition_LRM_Banana",
+    "Ammunition_LRM_Chaff",
+    "Ammunition_LRM_Clearance",
+    "Ammunition_LRM_Deadfire",
+    "Ammunition_LRM_ER",
+    "Ammunition_LRM_FTL",
+    "Ammunition_LRM_Hydra",
+    "Ammunition_LRM_LK",
+    "Ammunition_LRM_MagPulse",
+    "Ammunition_LRM_Narc",
+    "Ammunition_LRM_SAM",
+    "Ammunition_ILRM",
+    "Ammunition_LRM_Thunder_Augmented",
+    "Ammunition_LRM_Thunder_Inferno",
+    "Ammunition_LRM_Artemis"
   ],
   "ComponentTags": {
     "items": [

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_AmmoTypes.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_AmmoTypes.json
@@ -13,6 +13,12 @@
       "Full": "{0} Ammo - {1} Shots; Needs to be in same Location as the Weapon."
     },
     {
+      "Bonus": "AmmoRestrictionELRM",
+      "Short": "AmmoRestrictionELRM",
+      "Long": "Ammo Restriction ELRM",
+      "Full": "Enhanced LRM Launchers cannot fire any Specialty Ammunition types. Only basic LRM ammunition will work in missions."
+    },
+    {
       "Bonus": "MineIFF",
       "Short": "IFFMine",
       "Long": "IFF Mine",

--- a/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_Seth_ELRM.json
+++ b/Eras/CivilWar3062-3067/Base/vehicle/vehicledef_Seth_ELRM.json
@@ -12,6 +12,7 @@
       "unit_predator",
       "unit_stealth",
       "unit_noconvoy",
+			"unit_noshuffle",
       "unit_release",
       "NoBiome_lunarVacuum",
       "apply_bomb_drag_tag",
@@ -220,7 +221,7 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_FTL",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/CivilWar3062-3067/Uniques/vehicle/vehicledef_TOKUGAWA_TKG-YUMI.json
+++ b/Eras/CivilWar3062-3067/Uniques/vehicle/vehicledef_TOKUGAWA_TKG-YUMI.json
@@ -12,6 +12,7 @@
       "unit_indirectFire",
       "unit_predator",
       "unit_release",
+      "unit_noshuffle",
       "kurita"
     ],
     "tagSetSourceFile": ""

--- a/Eras/ClanInvasion3061/Base/Turrets/Command/Turret/turretdef_Assault_Command.json
+++ b/Eras/ClanInvasion3061/Base/Turrets/Command/Turret/turretdef_Assault_Command.json
@@ -13,6 +13,7 @@
     "items": [
       "unit_turret",
       "unit_assault",
+      "unit_noshuffle",
       "mr-resize-0.75",
       "davion",
       "kurita",
@@ -143,31 +144,25 @@
       "hasPrefabName": true
     },
     {
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Thunder_Half",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_InfernoThunder_Half",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Incendiary",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarm",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_AugmentedThunder",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/Turrets/Command/Turret/turretdef_Heavy_Command.json
+++ b/Eras/ClanInvasion3061/Base/Turrets/Command/Turret/turretdef_Heavy_Command.json
@@ -13,6 +13,7 @@
     "items": [
       "unit_turret",
       "unit_heavy",
+			"unit_noshuffle",
       "mr-resize-0.75",
       "davion",
       "kurita",
@@ -135,13 +136,7 @@
       "hasPrefabName": true
     },
     {
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Thunder_Half",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_AugmentedThunder_Half",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/DarkAge3131-/Base/mech/mechdef_alpha_wolf_APW-C.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_alpha_wolf_APW-C.json
@@ -17,6 +17,7 @@
       "unit_era_dark_ages",
       "unit_proxy_model",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_alphawolf",
       "unit_tonnage_90",
       "clanwolf",

--- a/Eras/DarkAge3131-/Base/mech/mechdef_awesome_AWS-11R.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_awesome_AWS-11R.json
@@ -14,6 +14,7 @@
       "unit_era_dark_ages",
       "unit_ready",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_awesome",
       "unit_tonnage_80",
       "marik",

--- a/Eras/DarkAge3131-/Base/mech/mechdef_awesome_AWS-11V.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_awesome_AWS-11V.json
@@ -12,6 +12,7 @@
       "unit_era_dark_ages",
       "unit_ready",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_awesome",
       "unit_tonnage_80",
       "marik",

--- a/Eras/DarkAge3131-/Base/mech/mechdef_hatamoto-chi_HTM-30Z.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_hatamoto-chi_HTM-30Z.json
@@ -11,6 +11,7 @@
       "unit_indirectFire",
       "unit_predator",
       "unit_command",
+      "unit_noshuffle",
       "unit_optional_era",
       "unit_era_dark_ages",
       "unit_release",

--- a/Eras/DarkAge3131-/Base/mech/mechdef_orion_C2.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_orion_C2.json
@@ -12,6 +12,7 @@
       "unit_optional_era",
       "unit_era_dark_ages",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_orion",
       "unit_tonnage_75",
       "marik",

--- a/Eras/DarkAge3131-/Base/mech/mechdef_stalker_ii_STK-9A.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_stalker_ii_STK-9A.json
@@ -11,6 +11,7 @@
       "unit_optional_era",
       "unit_era_dark_ages",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_stalkerii",
       "unit_tonnage_85",
       "liao",
@@ -291,14 +292,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Double",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/DarkAge3131-/Base/vehicle/vehicledef_PILUM_ELRM.json
+++ b/Eras/DarkAge3131-/Base/vehicle/vehicledef_PILUM_ELRM.json
@@ -9,6 +9,7 @@
       "unit_lance_support",
       "unit_wheels",
       "unit_indirectFire",
+      "unit_noshuffle",
       "unit_release",
       "davion",
       "republic",

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-C21.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-C21.json
@@ -11,6 +11,7 @@
       "unit_optional_era",
       "unit_era_jihad",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_catapult",
       "unit_tonnage_65",
       "davion",
@@ -254,7 +255,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarmi",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -268,7 +269,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarmi",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_orion_ON3-MX.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_orion_ON3-MX.json
@@ -13,6 +13,7 @@
       "unit_optional_era",
       "unit_era_jihad",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_orion",
       "unit_tonnage_75",
       "marik",

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_pandarus_LFA-1X.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_pandarus_LFA-1X.json
@@ -15,6 +15,7 @@
       "unit_era_jihad",
       "unit_proxy_model",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_pandarus",
       "unit_tonnage_75",
       "marik",

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_pendragon_PDG-1X.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_pendragon_PDG-1X.json
@@ -14,6 +14,7 @@
       "unit_totem",
       "unit_optional_era",
       "unit_era_jihad",
+			"unit_noshuffle",
       "unit_release",
       "unit_chassis_pendragon",
       "unit_tonnage_95",
@@ -244,28 +245,28 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_SAM",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Tandem",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Thunder",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_SM1_TELOS.json
+++ b/Eras/Jihad3068-3080/Uniques/vehicle/vehicledef_SM1_TELOS.json
@@ -9,6 +9,7 @@
       "unit_hover",
       "unit_indirectFire",
       "unit_release",
+      "unit_noshuffle",
       "mr-resize-1.68",
       "kurita"
     ],
@@ -93,21 +94,21 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_AugmentedThunder",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_FTL",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base Heavy Metal/mech/mechdef_archer_ARC-9R.json
+++ b/Eras/Republic3081-3130/Base Heavy Metal/mech/mechdef_archer_ARC-9R.json
@@ -13,6 +13,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_archer",
       "unit_tonnage_70",
       "republic",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_apollo_APL-4M.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_apollo_APL-4M.json
@@ -12,6 +12,7 @@
       "unit_era_republic",
       "unit_proxy_model",
       "unit_ready",
+      "unit_noshuffle",
       "unit_release",
       "unit_chassis_apollo",
       "unit_tonnage_55",
@@ -252,21 +253,21 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Thunder",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_catapult_CPLT-K6.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_catapult_CPLT-K6.json
@@ -12,6 +12,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_catapult",
       "unit_tonnage_65",
       "kurita",
@@ -225,21 +226,21 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Incendiary",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_SAM",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -253,7 +254,14 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -274,14 +282,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_orion_ON3-M.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_orion_ON3-M.json
@@ -13,6 +13,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_orion",
       "unit_tonnage_75",
       "liao",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_pandarus_LFA-1A.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_pandarus_LFA-1A.json
@@ -13,6 +13,7 @@
       "unit_era_republic",
       "unit_proxy_model",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_pandarus",
       "unit_tonnage_75",
       "marik",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_pendragon_PDG-1R.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_pendragon_PDG-1R.json
@@ -13,6 +13,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_pendragon",
       "unit_tonnage_95",
       "davion",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_pendragon_PDG-2R.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_pendragon_PDG-2R.json
@@ -15,6 +15,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_pendragon",
       "unit_tonnage_95",
       "davion",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_salamander_PPR-7T.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_salamander_PPR-7T.json
@@ -14,6 +14,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+      "unit_noshuffle",
       "unit_chassis_salamander",
       "unit_tonnage_80",
       "steiner",
@@ -213,21 +214,21 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_InfernoThunder",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_SAM",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/mech/mechdef_tenshi_TN-10-OR.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_tenshi_TN-10-OR.json
@@ -16,6 +16,7 @@
       "unit_proxy_model",
       "unit_ready",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_tenshi",
       "unit_tonnage_95",
       "kurita",
@@ -210,7 +211,7 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,
@@ -234,7 +235,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_InfernoThunder",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "IsFixed": false,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_valkyrie_VLK-QD6.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_valkyrie_VLK-QD6.json
@@ -13,6 +13,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_valkyrie",
       "unit_tonnage_30",
       "davion",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_valkyrie_VLK-QD8.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_valkyrie_VLK-QD8.json
@@ -13,6 +13,7 @@
       "unit_optional_era",
       "unit_era_republic",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_valkyrie",
       "unit_tonnage_30",
       "davion",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_CARRIER100_HAILSTORM.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_CARRIER100_HAILSTORM.json
@@ -11,6 +11,7 @@
       "unit_indirectFire",
       "unit_noconvoy",
       "unit_release",
+			"unit_noshuffle",
       "mr-resize-1.68",
       "BaumannGroup",
       "BountyHunterAssociates",
@@ -111,14 +112,14 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -139,28 +140,28 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_FTL",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_FTL",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarmi",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarmi",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_CARRIER_HEAVY_LRM_EXTENDED.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_CARRIER_HEAVY_LRM_EXTENDED.json
@@ -11,6 +11,7 @@
       "unit_indirectFire",
       "unit_noconvoy",
       "unit_release",
+      "unit_noshuffle",
       "mr-resize-1.50",
       "davion",
       "FiltveltCoalition",
@@ -97,21 +98,21 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarmi",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Left",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarmi",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -125,14 +126,14 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_FTL",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_FTL",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_CARRIER_LRM_EXTENDED.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_CARRIER_LRM_EXTENDED.json
@@ -10,6 +10,7 @@
       "unit_tracks",
       "unit_indirectFire",
       "unit_release",
+			"unit_noshuffle",
       "mr-resize-1.50",
       "davion",
       "locals"
@@ -102,28 +103,28 @@
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_MagPulse",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_SAM",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Rear",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarm_Half",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_Warrior_S9.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_Warrior_S9.json
@@ -11,6 +11,7 @@
       "unit_stealth",
       "unit_noconvoy",
       "unit_release",
+			"unit_noshuffle",
       "NoBiome_lunarVacuum",
       "apply_bomb_drag_tag",
       "mr-resize-1.50",

--- a/Optionals/ExperimentalWeapons/Superheavys/mech/mechdef_flawless_FLW-4E.json
+++ b/Optionals/ExperimentalWeapons/Superheavys/mech/mechdef_flawless_FLW-4E.json
@@ -11,6 +11,7 @@
       "unit_proxy_model",
       "unit_ready",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_flawless",
       "unit_tonnage_130",
       "unit_superheavy_tier1",
@@ -219,7 +220,7 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_MagPulse",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/RogueElites/Base/mech/mechdef_longbow_LGB-0F.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_longbow_LGB-0F.json
@@ -13,6 +13,7 @@
       "unit_stealth",
       "unit_optional_rogue_elites",
       "unit_ready",
+			"unit_noshuffle",
       "unit_release",
       "unit_chassis_longbow",
       "unit_tonnage_100",
@@ -340,7 +341,7 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Deadfire",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -361,14 +362,14 @@
     },
     {
       "MountedLocation": "LeftLeg",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Swarm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "RightLeg",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_AugmentedThunder",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/Superheavys/Base/mech/mechdef_narayana_NRY-OE.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_narayana_NRY-OE.json
@@ -11,6 +11,7 @@
       "unit_optional_superheavys",
       "unit_proxy_model",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_narayana",
       "unit_tonnage_140",
       "unit_superheavy_tier3",

--- a/Optionals/Superheavys/Base/mech/mechdef_sobek_SBK-7K.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_sobek_SBK-7K.json
@@ -8,6 +8,7 @@
       "unit_optional_superheavys",
       "unit_proxy_model",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_sobek",
       "unit_tonnage_170",
       "unit_superheavy_tier2",

--- a/Optionals/Superheavys/Base/mech/mechdef_wannu_WNU-O.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_wannu_WNU-O.json
@@ -9,6 +9,7 @@
       "unit_optional_superheavys",
       "unit_proxy_model",
       "unit_release",
+			"unit_noshuffle",
       "unit_chassis_wannu",
       "unit_tonnage_165",
       "unit_superheavy_tier2",
@@ -246,7 +247,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/Superheavys/RISCtech/mech/mechdef_stalker_iv_STK-11G.json
+++ b/Optionals/Superheavys/RISCtech/mech/mechdef_stalker_iv_STK-11G.json
@@ -10,6 +10,7 @@
       "unit_proxy_icon",
       "unit_proxy_model",
       "unit_release",
+      "unit_noshuffle",
       "unit_rt_custom",
       "unit_chassis_stalkeriv",
       "unit_tonnage_170",
@@ -251,7 +252,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Ammo_AmmunitionBox_LRM_ListenKill_Half",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Half",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanlord_UBL-77.json
+++ b/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanlord_UBL-77.json
@@ -15,6 +15,7 @@
       "unit_proxy_icon",
       "unit_proxy_model",
       "unit_release",
+			"unit_noshuffle",
       "unit_unofficial",
       "unit_chassis_urbanlord",
       "unit_tonnage_70",


### PR DESCRIPTION
Make ELRMs more canon by restricting to standard ammunition. 
Made units with ELRM launchers no shuffle.
Note: These changes ONLY work IN MISSION. Players can still put ammo in the units if they have mixed launchers, but ELRMs will ONLY work with standard LRM ammo.