### PR TITLE
Update AMS quirk affinity levels on Raptor III

### DIFF
--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
@@ -27,7 +27,7 @@
             "effectType": "StatisticEffect",
             "Description": {
               "Id": "AMSDamage",
-              "Name": "Quirk Affinity Missile Defender: Increased AMS Damage",
+              "Name": "Quirk Affinity Missile Defender: Increased AMS Accuracy",
               "Details": "Provides a penalty to all attacks against this unit.",
               "Icon": "uixSvgIcon_equipment_Gyro"
             },

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Missile Defender",
-        "decription": "Increased AMS Accuracy, -10% Missile Damage Taken",
+        "decription": "+25% AMS Accuracy, -10% Missile Damage Taken",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Missile Defender",
-        "decription": "+1 AMS Damage, -10% Missile Damage Taken",
+        "decription": "Increased AMS Accuracy, -10% Missile Damage Taken",
         "affinities": [],
         "effectData": [
           {
@@ -33,9 +33,9 @@
             },
             "nature": "Buff",
             "statisticData": {
-              "statName": "CAC_AMSDamage",
-              "operation": "Float_Add",
-              "modValue": "1.0",
+              "statName": "CAC_AMSHitChanceMult_Mod",
+              "operation": "Float_Multiply",
+              "modValue": "0.25",
               "modType": "System.Single",
               "targetCollection": "Weapon"
             }
@@ -64,6 +64,41 @@
               "operation": "Float_Multiply",
               "modValue": "0.9",
               "modType": "System.Single"
+            }
+          }
+        ]
+      },
+      {
+        "missionsRequired": 110,
+        "levelName": "Missile Defender II",
+        "decription": "+1 AMS Damage",
+        "affinities": [],
+        "effectData": [
+          {
+            "durationData": {
+              "duration": -1,
+              "stackLimit": -1
+            },
+            "targetingData": {
+              "effectTriggerType": "Passive",
+              "effectTargetType": "Creator",
+              "showInTargetPreview": false,
+              "showInStatusPanel": false
+            },
+            "effectType": "StatisticEffect",
+            "Description": {
+              "Id": "AMSDamage",
+              "Name": "Quirk Affinity Missile Defender II: Increased AMS Damage",
+              "Details": "Provides a penalty to all attacks against this unit.",
+              "Icon": "uixSvgIcon_equipment_Gyro"
+            },
+            "nature": "Buff",
+            "statisticData": {
+              "statName": "CAC_AMSDamage",
+              "operation": "Float_Add",
+              "modValue": "1.0",
+              "modType": "System.Single",
+              "targetCollection": "Weapon"
             }
           }
         ]


### PR DESCRIPTION
As above. Direct nerf to Raptor III, especially early game as an AMS boat.