### PR TITLE
updates to DK_Mech/Pilot events

### DIFF
--- a/InstallOptions/Pilots/RtoLegends/pilot/pilot_DarkKhaos.json
+++ b/InstallOptions/Pilots/RtoLegends/pilot/pilot_DarkKhaos.json
@@ -41,7 +41,8 @@
       "pilot_NeuralImplants",
       "pilot_rtolegend",
       "MaPermAffinity_20=kodiakDK_100",
-      "BLACKLISTED"
+      "BLACKLISTED",
+      "MA_BLACKLISTED"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/RTOLegendsMechs/RogueSociety/Contracts/CaptureBase_KhaosTheory_A.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/Contracts/CaptureBase_KhaosTheory_A.json
@@ -84,14 +84,14 @@
       "ResultDuration": 0
     },
     {
-      "ForceEvents": [
+      "ForceEvents":[
         {
-          "Scope": "Company",
-          "EventID": "forcedevent_co_KhaosTheory_Search",
-          "MinDaysWait": 0,
-          "MaxDaysWait": 1,
-          "Probability": 100,
-          "RetainPilot": true
+        "Scope": "Company",
+        "EventID": "forcedevent_co_KhaosTheory_Search",
+        "MinDaysWait": 0,
+        "MaxDaysWait": 1,
+        "Probability": 100,
+        "RetainPilot": true
         }
       ]
     }
@@ -112,14 +112,14 @@
       },
       "Stats": null,
       "Actions": null,
-      "ForceEvents": [
+      "ForceEvents":[
         {
-          "Scope": "Company",
-          "EventID": "forcedevent_co_KhaosTheory_Fail",
-          "MinDaysWait": 0,
-          "MaxDaysWait": 1,
-          "Probability": 100,
-          "RetainPilot": true
+        "Scope": "Company",
+        "EventID": "forcedevent_co_KhaosTheory_Fail",
+        "MinDaysWait": 0,
+        "MaxDaysWait": 1,
+        "Probability": 100,
+        "RetainPilot": true
         }
       ],
       "TemporaryResult": false,
@@ -825,9 +825,7 @@
             },
             "pilotDefId": "pilotDef_InheritLance",
             "pilotTagSet": {
-              "items": [
-                "name_DarkKhaos"
-              ],
+              "items": [],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_co_DarkKhaos.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_co_DarkKhaos.json
@@ -26,6 +26,12 @@
                 "op" : "GreaterThan",
                 "val" : 0,
                 "valueConstant" : "0"
+            },
+            {
+                "obj" : "Travel",
+                "op" : "Equal",
+                "val" : 0,
+                "valueConstant" : "0"
             }
         ]
     },


### PR DESCRIPTION
Missing MA_BLACKLISTED tag on pilot_darkkhaos; removed extraneous tag on contract; added no travel requirement to dk pilot spawn event