### PR TITLE
Engine Locking

### DIFF
--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_blue_flame_BLF-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_blue_flame_BLF-QSK.json
@@ -41,6 +41,34 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_225",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_Light",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Gear_Actuator_Leg_Speedy_Quicsell",
       "ComponentDefType": "Upgrade",

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_bushwacker_BSW-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_bushwacker_BSW-QSK.json
@@ -43,6 +43,34 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_275",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_Light",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Weapon_Laser_MediumLaserREX_Quicsell",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_catapult_CPLT-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_catapult_CPLT-QSK.json
@@ -23,6 +23,37 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_260",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Gyro_Omnimech_Quicsell",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_fafnir_FNR-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_fafnir_FNR-QSK.json
@@ -22,6 +22,34 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Gyro_Omnimech_Quicsell",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_incorgnito_ICO-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_incorgnito_ICO-QSK.json
@@ -20,6 +20,34 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_250",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_longbow_LGB-TQ.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_longbow_LGB-TQ.json
@@ -29,6 +29,38 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_325",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_ICE_XL_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_6",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_6",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Special_AddOn_ThermalMass_Large_Quicsell",
       "ComponentDefType": "HeatSink",

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_nightstar_NSR-QSXL.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_nightstar_NSR-QSXL.json
@@ -62,6 +62,13 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_QSX",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_queenbee_lam_QNB-A.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_queenbee_lam_QNB-A.json
@@ -66,6 +66,14 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Gyro_LAM_QS",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_rifleman_RFL-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_rifleman_RFL-QSK.json
@@ -29,6 +29,38 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_240",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Special_AddOn_ThermalMass_Medium_Quicsell",
       "ComponentDefType": "HeatSink",

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_stalker_STK-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_stalker_STK-QSK.json
@@ -41,6 +41,36 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_255",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_Quicsell",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Special_AddOn_ThermalMass_Large_Quicsell",
       "ComponentDefType": "HeatSink",

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_stinger_lam_STG-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_stinger_lam_STG-QSK.json
@@ -52,6 +52,36 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_180",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_LAM_QS",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Quirk_LandAirMech_Active",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_talos_TLS-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_talos_TLS-QSK.json
@@ -38,6 +38,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_200",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Gear_Actuator_Arm_Compact_x4_Quicsell",
       "ComponentDefType": "Upgrade",

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_vapor_eagle_VGL-QSXL.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_vapor_eagle_VGL-QSXL.json
@@ -22,6 +22,13 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_330",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Gyro_Omnimech_Quicsell",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_warhammer_lam_WHM-LAM-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_warhammer_lam_WHM-LAM-QSK.json
@@ -59,6 +59,35 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_270",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_LAM_QS",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_4",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_LAM_QS",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Chassis/chassisdef_wasp_lam_WSP-QSK.json
+++ b/Optionals/QuicksellCustoms/Chassis/chassisdef_wasp_lam_WSP-QSK.json
@@ -59,6 +59,13 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_150",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_LAM_QS",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_blue_flame_BLF-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_blue_flame_BLF-QSK.json
@@ -149,34 +149,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_225",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_Light",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_2",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_2",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_bushwacker_BSW-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_bushwacker_BSW-QSK.json
@@ -209,34 +209,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_275",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_Light",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_2",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_2",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCooling_Heatsinks_1_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_catapult_CPLT-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_catapult_CPLT-QSK.json
@@ -140,37 +140,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_260",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_XL_Quicsell",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_fafnir_FNR-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_fafnir_FNR-QSK.json
@@ -194,34 +194,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_300",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_XL_Quicsell",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCooling_Heatsinks_2_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_incorgnito_ICO-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_incorgnito_ICO-QSK.json
@@ -209,34 +209,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_250",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_XL_Quicsell",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_longbow_LGB-TQ.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_longbow_LGB-TQ.json
@@ -151,38 +151,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_325",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_ICE_XL_Quicsell",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_6",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_6",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCooling_Heatsinks_2_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_nightstar_NSR-QSXL.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_nightstar_NSR-QSXL.json
@@ -207,13 +207,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_285",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "Head",
       "ComponentDefID": "Weapon_Laser_MediumLaserREX_Quicsell",
       "ComponentDefType": "Weapon",

--- a/Optionals/QuicksellCustoms/Mech/mechdef_queenbee_lam_QNB-A.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_queenbee_lam_QNB-A.json
@@ -137,14 +137,7 @@
     }
   ],
   "inventory": [
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_200",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
+    
     {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "Weapon_Laser_Chemical_Small",

--- a/Optionals/QuicksellCustoms/Mech/mechdef_rifleman_RFL-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_rifleman_RFL-QSK.json
@@ -221,38 +221,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_240",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_XL_Quicsell",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_stalker_STK-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_stalker_STK-QSK.json
@@ -211,36 +211,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_255",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_XL_Quicsell",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_stinger_lam_STG-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_stinger_lam_STG-QSK.json
@@ -136,36 +136,6 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_180",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_XL_LAM_QS",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_Booster_LAM_SuperBurner_3",
       "ComponentDefType": "JumpJet",

--- a/Optionals/QuicksellCustoms/Mech/mechdef_talos_TLS-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_talos_TLS-QSK.json
@@ -129,14 +129,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_200",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_vapor_eagle_VGL-QSXL.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_vapor_eagle_VGL-QSXL.json
@@ -219,13 +219,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_330",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCooling_Heatsinks_2_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_warhammer_lam_WHM-LAM-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_warhammer_lam_WHM-LAM-QSK.json
@@ -154,35 +154,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_270",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_Engine_XL_LAM_QS",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Linked_Engine_Size_4",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Quicsell",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Optionals/QuicksellCustoms/Mech/mechdef_wasp_lam_WSP-QSK.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_wasp_lam_WSP-QSK.json
@@ -136,14 +136,6 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_EngineCore_150",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "IsFixed": false,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_Booster_LAM_SuperBurner_5",
       "ComponentDefType": "JumpJet",


### PR DESCRIPTION
Was discussed last savebreak (after it happened) and was pointed out all engines should be locked on QS mechs.