### PR TITLE
Update BonusDescriptions_Painter.json

### DIFF
--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Painter.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Painter.json
@@ -64,13 +64,13 @@
       "Bonus": "Narc",
       "Short": "NARC",
       "Long": "NARC Beacon",
-      "Full": "NARC Beacons grant visibility on target. Counters ECM up to {0}"
+      "Full": "NARC Beacons grant more detailed information on a target.  {0} detailed information modifier."
     },
     {
       "Bonus": "iNarc",
       "Short": "iNarc",
       "Long": "iNarc Beacon",
-      "Full": "iNarc Beacons grant visibility on target. Counters ECM up to {0}"
+      "Full": "iNARC Beacons grant more detailed information on a target.  {0} detailed information modifier."
     },
     {
       "Bonus": "iNarcAcc",


### PR DESCRIPTION
Updated the bonus descriptions per Ticket 9782
The value called is for the detailed information modifier, not the ECM modifier.  These changes to the Narc/iNarc descriptions keep the value/call the same, but change the surrounding text to match what the value is.