### PR TITLE
Random start rosters, 2785 Mostly finished, Partial 2765 Update

### DIFF
--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_H-Carriers.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_H-Carriers.csv
@@ -1,0 +1,6 @@
+itemCollection_Mechs_Starting_Castile_2765-2785_H-Carriers,,,
+vehicledef_CARRIER_SRM,Vehicle,1,4
+vehicledef_CARRIER_LRM,Vehicle,1,6
+vehicledef_CARRIER_AC10,Vehicle,1,2
+vehicledef_CARRIER_AC5,Vehicle,1,2
+vehicledef_CARRIER_AC2,Vehicle,1,3

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_Light.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_Light.csv
@@ -1,0 +1,6 @@
+itemCollection_Mechs_Starting_Castile_2765-2785_Light,,,
+vehicledef_JEdgar,Vehicle,1,3
+vehicledef_JEdgar_MG,Vehicle,1,2
+vehicledef_JEdgar_TAG,Vehicle,1,1
+vehicledef_JEdgar_Flamer,Vehicle,1,1
+vehicledef_GALLEON,Vehicle,1,4

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_M-Carriers.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_M-Carriers.csv
@@ -1,0 +1,5 @@
+itemCollection_Mechs_Starting_Castile_2765-2785_M-Carriers,,,
+vehicledef_CARRIER_LIGHT_SRM,Vehicle,1,3
+vehicledef_CARRIER_LIGHT_LRM,Vehicle,1,4
+vehicledef_CARRIER_LIGHT_FLAMER,Vehicle,1,1
+vehicledef_PZH2000,Vehicle,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_MBT.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Castile_2765-2785_MBT.csv
@@ -1,0 +1,8 @@
+itemCollection_Mechs_Starting_Castile_2765-2785_MBT,,,
+vehicledef_MANTICORE,Vehicle,1,1
+vehicledef_MANTICORE_LASER,Vehicle,1,4
+vehicledef_MANTICORE_AC10,Vehicle,1,3
+vehicledef_BULLDOG,Vehicle,1,5
+vehicledef_BULLDOG_AC,Vehicle,1,2
+vehicledef_BULLDOG_PERIPHERY,Vehicle,1,1
+vehicledef_LTV-4,Vehicle,1,4

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers.csv
@@ -1,0 +1,5 @@
+itemCollection_Mechs_Starting_Primitive_2765-2785_Carriers,,,
+vehicledef_CARRIER_AC2_Primitive,Vehicle,1,1
+vehicledef_CARRIER_RIFLE_PRIMITIVE,Vehicle,1,2
+vehicledef_CARRIER_SRM,Vehicle,1,2
+vehicledef_CARRIER_LRM,Vehicle,1,3

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums.csv
@@ -1,0 +1,7 @@
+itemCollection_Mechs_Starting_Primitive_2765-2785_Mediums,,,
+mechdef_griffin_GRF-1A,Mech,1,3
+mechdef_hunchback_HBK-1G,Mech,1,4
+mechdef_rifleman_RFL-1N,Mech,1,5
+mechdef_swordsman_SWD-1,Mech,1,2
+mechdef_icarus_ii_ICR-1X,Mech,1,1
+mechdef_kyudo_KY2-D-01,Mech,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks.csv
@@ -1,0 +1,7 @@
+itemCollection_Mechs_Starting_Primitive_2765-2785_RelicTanks,,,
+vehicledef_ESTEVEZ,Vehicle,1,4
+vehicledef_AUGUSTUS_A3,Vehicle,1,2
+vehicledef_MARSDENII_Primitive,Vehicle,1,2
+vehicledef_STURMBLITZ,Vehicle,1,3
+vehicledef_TunguskaAA,Vehicle,1,1
+vehicledef_BULLDOG_PERIPHERY,Vehicle,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals.csv
@@ -1,0 +1,9 @@
+itemCollection_Mechs_Starting_Primitive_2765-2785_Carriers,,,
+vehicledef_FIRETRUCK_ACID,Vehicles,1,2
+vehicledef_FIRETRUCK_FIRE,Vehicles,1,2
+vehicledef_FIRETRUCK_OIL,Vehicles,1,1
+vehicledef_TECHNICAL_LARGE_RIFLE,Vehicles,1,4
+vehicledef_TECHNICAL_LARGE_HOWITZER,Vehicles,1,2
+vehicledef_TECHNICAL_LARGE_RR,Vehicles,1,1
+vehicledef_TECHNICAL_MEDIUM_MG,Vehicles,1,5
+vehicledef_TECHNICAL_MEDIUM_RIFLE,Vehicles,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Lights_A.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Lights_A.csv
@@ -1,0 +1,12 @@
+itemCollection_Mechs_Starting_Terran_2765_Lights_A,,,
+mechdef_falcon_FLC-4Nb,Mech,1,2
+mechdef_hermes_HER-1Sb,Mech,1,3
+mechdef_mongoose_MON-66B,Mech,1,4
+mechdef_locust_LCT-1Vb,Mech,1,5
+mechdef_ostscout_OTT-7Jb,Mech,1,6
+mechdef_hermes_HER-1Sb,Mech,1,7
+mechdef_thorn_THE-Nb,Mech,1,6
+mechdef_sling_SL-1G,Mech,1,5
+mechdef_stinger_STG-3Gb,Mech,1,4
+mechdef_spector_SPR-4F,Mech,1,3
+mechdef_hussar_HSR-200-Db,Mech,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Lights_B.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Lights_B.csv
@@ -1,0 +1,12 @@
+itemCollection_Mechs_Starting_Terran_2765_Lights_B,,,
+mechdef_talon_TLN-5W,Mech,1,2
+mechdef_hussar_HSR-200-D,Mech,1,3
+mechdef_panther_PNT-9R,Mech,1,4
+mechdef_firestarter_FS9-H,Mech,1,5
+mechdef_firefly_FFL-4A,Mech,1,6
+mechdef_mongoose_MON-66,Mech,1,7
+mechdef_spider_SDR-5V,Mech,1,6
+mechdef_mercury_MCY-99,Mech,1,5
+mechdef_spector_SPR-4F,Mech,1,4
+mechdef_talon_TLN-5V,Mech,1,3
+mechdef_nighthawk_NTK-2Q,Mech,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Medium_A.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Medium_A.csv
@@ -1,0 +1,9 @@
+itemCollection_Mechs_Starting_Terran_2765_Medium_A,,,
+mechdef_wyvern_WVE-5Nb,Mech,1,2
+mechdef_wolverine_ii_WVR-7H,Mech,1,3
+mechdef_kintaro_KTO-19b,Mech,1,4
+mechdef_shadowhawk_SHD-2Hb,Mech,1,5
+mechdef_griffin_GRF-2N,Mech,1,6
+mechdef_hunchback_HBK-4G,Mech,1,6
+mechdef_sentinel_STN-3Lb,Mech,1,4
+mechdef_lynx_LNX-9Q,Mech,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Medium_B.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Terran_2765_Medium_B.csv
@@ -1,0 +1,10 @@
+itemCollection_Mechs_Starting_Terran_2765_Medium_B,,,
+mechdef_shadowhawk_SHD-2H,Mech,1,2
+mechdef_sentinel_STN-3L,Mech,1,3
+mechdef_whitworth_WTH-1,Mech,1,4
+mechdef_kintaro_KTO-19,Mech,1,6
+mechdef_cicada_CDA-2A,Mech,1,6
+mechdef_assassin_ASN-21,Mech,1,5
+mechdef_griffin_GRF-2N,Mech,1,4
+mechdef_kyudo_KY2-D-02,Mech,1,3
+mechdef_starslayer_STY-2C,Mech,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Terran_Lights.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Terran_Lights.csv
@@ -1,9 +1,0 @@
-itemCollection_Mechs_Terran_Lights,,,
-mechdef_hornet_HNT-151,Mech,1,5
-mechdef_wasp_WSP-1A,Mech,1,5
-mechdef_thorn_THE-N,Mech,1,5
-mechdef_mongoose_MON-66,Mech,1,4
-mechdef_hussar_HSR-200-D,Mech,1,4
-mechdef_hermes_HER-1S,Mech,1,4
-mechdef_panther_PNT-8Z,Mech,1,4
-mechdef_talon_TLN-5V,Mech,1,4

--- a/Core/IRTweaks/data/itemCollection_Mechs_Terran_Medium.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Terran_Medium.csv
@@ -1,9 +1,0 @@
-itemCollection_Mechs_Terran_Medium,,,
-mechdef_sentinel_STN-3L,Mech,1,4
-mechdef_swordsman_SWD-2,Mech,1,4
-mechdef_blackjack_BJ-1,Mech,1,4
-mechdef_wyvern_WVE-5N,Mech,1,3
-mechdef_chameleon_TRC-4B,Mech,1,3
-mechdef_galahad_GLH-1D,Mech,1,3
-mechdef_hoplite_HOP-4B,Mech,1,3
-mechdef_kintaro_KTO-19,Mech,1,3

--- a/Documents/Starts checklist.txt
+++ b/Documents/Starts checklist.txt
@@ -52,29 +52,29 @@ VTOL                                     N/A
 WOB                                      No
 
 2765 ISM: 
-Amaris Empire                            Yes  (RW Line unit list)
+Amaris Empire                            Yes (RW Line unit list)
 Rimworlds Republic                       Yes (RW republican guard list)
 SLDF                                     Yes
-Terran Hegemony                          No
+Terran Hegemony                          Yes (First Succession War - Terran Hegemony)
 
-Axumite                                  No
-Castile                                  No
+Axumite                                  Yes (Primitive 2765-2785 Lists)
+Castile                                  Yes ("Lore Compliant" Tank Start - Custom List)
 Davion                                   No
-Delphi                                   No
-Illyrian                                 No
-Jarnfolk                                 No
+Delphi                                   Yes (Primitive 2765-2785 Lists)
+Illyrian                                 Yes (1 Steiner/FWL B-list per category)
+Jarnfolk                                 Yes (Primitive 2765-2785 Lists)
 Kurita                                   No
 LAM                                      N/A
 Liao                                     No
-Magistracy                               No
+Magistracy                               Yes (First Succession War - MajorPeriphery Shared Lists)
 Marik                                    No
 Mercenary                                No
-Outworld                                 No
-Solaris                                  No
+Outworld                                 Yes (First Succession War - MajorPeriphery Shared Lists)
+Solaris                                  No (Probably not a time appropriate start)
 Steiner                                  No
 Tanks                                    N/A
-Taurian                                  No
-Tortuga                                  No
+Taurian                                  Yes (First Succession War - MajorPeriphery Shared Lists)
+Tortuga                                  No (Need to work out what pirate stuff fits the era)
 Urbie                                    N/A
 VTOL                                     N/A
 
@@ -83,24 +83,24 @@ Finmark Free Republic                    Yes (using RWR guard list)
 SLDF in Exile                            Yes (using Pentagon Powers lists)
 Umayyad Caliphate                        Yes (same as above)
 
-Axumite                                  No
-Castile                                  No
+Axumite                                  Yes (Primitive 2765-2785 Lists)
+Castile                                  Yes (Tank/Carrier Only - As lore dictates)
 Davion                                   Yes
-Delphi                                   No
-Illyrian                                 No
-Jarnfolk                                 No
+Delphi                                   Yes (Primitive 2765-2785 Lists)
+Illyrian                                 Yes (1 Steiner/FWL B-list per category)
+Jarnfolk                                 Yes (Primitive 2765-2785 Lists)
 Kurita                                   Yes
 LAM                                      N/A
 Liao                                     Yes
 Magistracy                               Yes (First Succession War - MajorPeriphery Shared Lists)
 Marik                                    Yes
-Mercenary                                No
+Mercenary                                No (On hold for now)
 Outworld                                 Yes (First Succession War - MajorPeriphery Shared Lists)
-Solaris                                  No
+Solaris                                  No (Probably not a time appropriate start)
 Steiner                                  Yes
 Tanks                                    N/A
 Taurian                                  Yes (First Succession War - MajorPeriphery Shared Lists)
-Tortuga                                  No
+Tortuga                                  No (Need to work out what pirate stuff fits the era)
 Urbie                                    N/A
 VTOL                                     N/A
 

--- a/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_A.csv
+++ b/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_A.csv
@@ -1,0 +1,2 @@
+
+mechdef_crab_CRB-27b,Mech,1,7

--- a/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_B.csv
+++ b/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_B.csv
@@ -1,0 +1,2 @@
+
+mechdef_crab_CRB-27,Mech,1,5

--- a/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Terran_Medium.csv
+++ b/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Terran_Medium.csv
@@ -1,2 +1,0 @@
-
-mechdef_crab_CRB-27,Mech,1,3

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_A.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_A.csv
@@ -1,0 +1,2 @@
+
+mechdef_phoenixhawk_PXH-1b,Mech,1,5

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_B.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Terran_2765_Medium_B.csv
@@ -1,0 +1,2 @@
+
+mechdef_phoenixhawk_PXH-2,Mech,1,7

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/Starter/itemCollection_Mechs_Starting_Castile_2765-2785_Light.csv
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/Starter/itemCollection_Mechs_Starting_Castile_2765-2785_Light.csv
@@ -1,0 +1,4 @@
+
+vehicledef_PACKRAT,Vehicle,1,3
+vehicledef_PACKRAT_SRM2,Vehicle,1,2
+vehicledef_PACKRAT_ML,Vehicle,1,2

--- a/InstallOptions/ISM2765/patchdef.json
+++ b/InstallOptions/ISM2765/patchdef.json
@@ -13007,7 +13007,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks,itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums,itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,Collection_Mechs_Starting_Periphery_2765-2785_Technicals"
                     }
                 },
                 {
@@ -13016,7 +13016,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Castile_2765-2785_MBT,itemCollection_Mechs_Starting_Castile_2765-2785_MBT,itemCollection_Mechs_Starting_Castile_2765-2785_H-Carriers,itemCollection_Mechs_Starting_Castile_2765-2785_M-Carriers,itemCollection_Mechs_Starting_Castile_2765-2785_Light,itemCollection_Mechs_Starting_Castile_2765-2785_Light"
                     }
                 },
                 {
@@ -13034,7 +13034,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks,itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums,itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,Collection_Mechs_Starting_Periphery_2765-2785_Technicals"
                     }
                 },
                 {
@@ -13043,7 +13043,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Steiner_2785_Medium_B,itemCollection_Mechs_Starting_Marik_2785_Medium_B,itemCollection_Mechs_Starting_Steiner_2785_Light_B,itemCollection_Mechs_Starting_Marik_2785_Light_B"
                     }
                 },
                 {
@@ -13052,7 +13052,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_Medium,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_DeepPeriphery_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks,itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums,itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,Collection_Mechs_Starting_Periphery_2765-2785_Technicals"
                     }
                 },
                 {
@@ -13088,7 +13088,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Magistracy_2765_Light,itemCollection_Mechs_Starting_Magistracy_2765_Light,itemCollection_Mechs_Starting_Magistracy_2765_Medium,itemCollection_Mechs_Starting_Magistracy_2765_Medium,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_B,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_B"
                     }
                 },
                 {
@@ -13115,7 +13115,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Outworlds_2765_Medium,itemCollection_Mechs_Starting_Outworlds_2765_Medium,itemCollection_Mechs_Starting_Outworlds_2765_Light,itemCollection_Mechs_Starting_Outworlds_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_B,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_B"
                     }
                 },
                 {
@@ -13151,7 +13151,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Taurian_2765_Medium,itemCollection_Mechs_Starting_Taurian_2765_Light,itemCollection_Mechs_Starting_Taurian_2765_Medium,itemCollection_Mechs_Starting_Taurian_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_B,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_B"
                     }
                 },
                 {
@@ -13291,7 +13291,7 @@
                             {
                                 "ConstantType": "CareerMode",
                                 "ConstantName": "StartingRandomMechLists",
-                                "ConstantValue": "itemCollection_Mechs_Terran_Medium,itemCollection_Mechs_Terran_Medium,itemCollection_Mechs_Terran_Lights,itemCollection_Mechs_Terran_Lights"
+                                "ConstantValue": "itemCollection_Mechs_Starting_Terran_2765_Medium_A,itemCollection_Mechs_Starting_Terran_2765_Medium_B,itemCollection_Mechs_Starting_Terran_2765_Lights_A,itemCollection_Mechs_Starting_Terran_2765_Lights_B"
                             },
                             {
                                 "ConstantType": "CareerMode",

--- a/InstallOptions/PersistentMapClient/patchdef.json
+++ b/InstallOptions/PersistentMapClient/patchdef.json
@@ -1237,12 +1237,57 @@
                     }
                 },
                 {
+                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Castile\"}::DifficultyConstants",
+                    "indexIdentifier": {
+                        "ConstantName": "StartingRandomMechLists"
+                    },
+                    "patch": {
+                        "ConstantValue": "itemCollection_Mechs_Starting_Castile_2765-2785_MBT,itemCollection_Mechs_Starting_Castile_2765-2785_MBT,itemCollection_Mechs_Starting_Castile_2765-2785_H-Carriers,itemCollection_Mechs_Starting_Castile_2765-2785_M-Carriers,itemCollection_Mechs_Starting_Castile_2765-2785_Light,itemCollection_Mechs_Starting_Castile_2765-2785_Light"
+                    }
+                },
+                {
                     "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Outworld\"}::DifficultyConstants",
                     "indexIdentifier": {
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
                         "ConstantValue": "itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Medium_B,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_A,itemCollection_Mechs_Starting_MajorPeriphery_2785_Light_B"
+                    }
+                },
+                {
+                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Jarnfolk\"}::DifficultyConstants",
+                    "indexIdentifier": {
+                        "ConstantName": "StartingRandomMechLists"
+                    },
+                    "patch": {
+                        "ConstantValue": "itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks,itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums,itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,Collection_Mechs_Starting_Periphery_2765-2785_Technicals"
+                    }
+                },
+                {
+                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Delphi\"}::DifficultyConstants",
+                    "indexIdentifier": {
+                        "ConstantName": "StartingRandomMechLists"
+                    },
+                    "patch": {
+                        "ConstantValue": "itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks,itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums,itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,Collection_Mechs_Starting_Periphery_2765-2785_Technicals"
+                    }
+                },
+                {
+                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Axumite\"}::DifficultyConstants",
+                    "indexIdentifier": {
+                        "ConstantName": "StartingRandomMechLists"
+                    },
+                    "patch": {
+                        "ConstantValue": "itemCollection_Mechs_Starting_Periphery_2765-2785_RelicTanks,itemCollection_Mechs_Starting_Periphery_2765-2785_Mediums,itemCollection_Mechs_Starting_Periphery_2765-2785_Carriers,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,itemCollection_Mechs_Starting_Periphery_2765-2785_Technicals,item,Collection_Mechs_Starting_Periphery_2765-2785_Technicals"
+                    }
+                },
+                {
+                    "arrayEntryPoint": "difficultyList;;{\"ID\": \"diff_startingplanet\"}::Options;;{\"ID\": \"diff_Illyrian\"}::DifficultyConstants",
+                    "indexIdentifier": {
+                        "ConstantName": "StartingRandomMechLists"
+                    },
+                    "patch": {
+                        "ConstantValue": "itemCollection_Mechs_Starting_Steiner_2785_Medium_B,itemCollection_Mechs_Starting_Marik_2785_Medium_B,itemCollection_Mechs_Starting_Steiner_2785_Light_B,itemCollection_Mechs_Starting_Marik_2785_Light_B"
                     }
                 }
             ]


### PR DESCRIPTION
Delphi, Jarnfolk, Axumite 2765/85 - Custom lists: 1 primitive medium mech, 1 "old" heavy tank, 1 primitive carrier and 2-3 technicals. Might need sanity checking.

Illyria 2765/85 - 4 Mechs using Marik/Steiner "B" roster-lists from 2785

Castille 2765/85 - Specifically called out as having no mechs pre 2900's, given generous (maybe too generous) tank/vehicle start for 2765/85

Majorperiphery2785 lists also used for Taurian/Canopus/Outworlds in 2765