### PR TITLE
Startlists 2765 update

### DIFF
--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_A.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_A.csv
@@ -1,0 +1,11 @@
+itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_A,,,
+mechdef_ostscout_OTT-7J,Mech,1,1
+mechdef_stinger_STG-3R,Mech,1,2
+mechdef_locust_LCT-1V,Mech,1,3
+mechdef_firestarter_FS9-H,Mech,1,4
+mechdef_falcon_FLC-4N,Mech,1,5
+mechdef_mongoose_MON-66,Mech,1,6
+mechdef_talon_TLN-5V,Mech,1,4
+mechdef_hussar_HSR-200-D,Mech,1,3
+mechdef_firefly_FFL-3A,Mech,1,2
+mechdef_nighthawk_NTK-2Q,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_B.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_B.csv
@@ -1,0 +1,12 @@
+itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_B,,,
+mechdef_hornet_HNT-151,Mech,1,1
+mechdef_wasp_WSP-1A,Mech,1,2
+mechdef_hussar_HSR-200-D,Mech,1,3
+mechdef_locust_LCT-1M,Mech,1,4
+mechdef_ostscout_OTT-7J,Mech,1,5
+mechdef_stinger_STG-3R,Mech,1,6
+mechdef_locust_LCT-1V,Mech,1,5
+mechdef_firestarter_FS9-H,Mech,1,4
+mechdef_falcon_FLC-4N,Mech,1,3
+mechdef_mongoose_MON-66,Mech,1,2
+mechdef_javelin_JVN-10N,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_A.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_A.csv
@@ -1,0 +1,11 @@
+itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_A,,,
+mechdef_clint_CLNT-2-3T,Mech,1,1
+mechdef_wolverine_WVR-6R,Mech,1,2
+mechdef_dervish_DV-6M,Mech,1,3
+mechdef_griffin_GRF-1N,Mech,1,5
+mechdef_shadowhawk_SHD-2H,Mech,1,6
+mechdef_dervish_DV-6Md,Mech,1,5
+mechdef_kintaro_KTO-19,Mech,1,4
+mechdef_galahad_GLH-1D,Mech,1,3
+mechdef_kyudo_KY2-D-02,Mech,1,2
+mechdef_griffin_GRF-2N,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_B.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_B.csv
@@ -1,0 +1,9 @@
+itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_B,,,
+mechdef_blackjack_BJ-1,Mech,1,2
+mechdef_hoplite_HOP-4C,Mech,1,3
+mechdef_clint_CLNT-2-3T,Mech,1,5
+mechdef_wolverine_WVR-6R,Mech,1,6
+mechdef_dervish_DV-6M,Mech,1,5
+mechdef_griffin_GRF-1N,Mech,1,3
+mechdef_shadowhawk_SHD-2H,Mech,1,2
+mechdef_dervish_DV-6Md,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Light.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Light.csv
@@ -1,0 +1,12 @@
+itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Light,,,
+mechdef_wasp_WSP-1A,Mech,1,1
+mechdef_stinger_STG-3R,Mech,1,2
+mechdef_panther_PNT-8Z,Mech,1,3
+mechdef_panther_PNT-9R,Mech,1,4
+mechdef_stinger_STG-3G,Mech,1,5
+mechdef_locust_LCT-1V,Mech,1,6
+mechdef_panther_PNT-9R,Mech,1,5
+mechdef_mongoose_MON-66,Mech,1,4
+mechdef_ostscout_OTT-7J,Mech,1,3
+mechdef_hussar_HSR-200-D,Mech,1,2
+mechdef_thorn_THE-N,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium.csv
@@ -1,0 +1,8 @@
+itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium,,,
+mechdef_hunchback_HBK-4G,Mech,1,1
+mechdef_whitworth_WTH-1,Mech,1,2
+mechdef_wolverine_WVR-6K,Mech,1,4
+mechdef_shadowhawk_SHD-2H,Mech,1,5
+mechdef_griffin_GRF-1N,Mech,1,6
+mechdef_wolverine_WVR-6K,Mech,1,4
+mechdef_kintaro_KTO-19,Mech,1,2

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Light.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Light.csv
@@ -1,0 +1,12 @@
+itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Light,,,
+mechdef_urbanmech_UM-R60,Mech,1,1
+mechdef_locust_LCT-1V,Mech,1,2
+mechdef_firebee_FRB-2E,Mech,1,3
+mechdef_stinger_STG-3G,Mech,1,4
+mechdef_firestarter_FS9-K,Mech,1,5
+mechdef_mercury_MCY-99,Mech,1,6
+mechdef_spider_SDR-5V,Mech,1,5
+mechdef_hermes_HER-1S,Mech,1,4
+mechdef_falcon_FLC-4N,Mech,1,3
+mechdef_panther_PNT-8Z,Mech,1,2
+mechdef_firefly_FFL-3A,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium.csv
@@ -1,0 +1,10 @@
+itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium,,,
+mechdef_clint_CLNT-2-3T,Mech,1,2
+mechdef_griffin_GRF-1N,Mech,1,3
+mechdef_wolverine_WVR-6R,Mech,1,4
+mechdef_hunchback_HBK-4G,Mech,1,5
+mechdef_wyvern_WVE-5N,Mech,1,6
+mechdef_hoplite_HOP-4B,Mech,1,4
+mechdef_griffin_GRF-2N,Mech,1,3
+mechdef_galahad_GLH-1D,Mech,1,2
+mechdef_osprey_OSP-15,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Light.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Light.csv
@@ -1,0 +1,12 @@
+itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Light,,,
+mechdef_falcon_FLC-4N,Mech,1,1
+mechdef_thorn_THE-N,Mech,1,2
+mechdef_talon_TLN-5V,Mech,1,3
+mechdef_nighthawk_NTK-2Q,Mech,1,4
+mechdef_mongoose_MON-66,Mech,1,5
+mechdef_spider_SDR-5V,Mech,1,6
+mechdef_firestarter_FS9-H,Mech,1,5
+mechdef_ostscout_OTT-7J,Mech,1,4
+mechdef_firefly_FFL-4C,Mech,1,3
+mechdef_mercury_MCY-99,Mech,1,2
+mechdef_hussar_HSR-200-D,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium.csv
@@ -1,0 +1,9 @@
+itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium,,,
+mechdef_icarus_II_ICR-1S,Mech,1,1
+mechdef_shadowhawk_SHD-2H,Mech,1,3
+mechdef_griffin_GRF-1N,Mech,1,4
+mechdef_wolverine_WVR-6R,Mech,1,5
+mechdef_kintaro_KTO-19,Mech,1,5
+mechdef_kyudo_KY2-D-02,Mech,1,4
+mechdef_lynx_LNX-9Q,Mech,1,2
+mechdef_griffin_GRF-2N,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Light.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Light.csv
@@ -1,0 +1,12 @@
+itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Light,,,
+mechdef_firestarter_FS9-H,Mech,1,1
+mechdef_commando_COM-1D,Mech,1,2
+mechdef_ostscout_OTT-7J,Mech,1,3
+mechdef_wasp_WSP-1A,Mech,1,4
+mechdef_stinger_STG-3R,Mech,1,5
+mechdef_commando_COM-2D,Mech,1,6
+mechdef_locust_LCT-1S,Mech,1,5
+mechdef_firestarter_FS9-H,Mech,1,4
+mechdef_falcon_FLC-4N,Mech,1,3
+mechdef_thorn_THE-N,Mech,1,2
+mechdef_panther_PNT-8Z,Mech,1,1

--- a/Core/IRTweaks/data/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium.csv
+++ b/Core/IRTweaks/data/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium.csv
@@ -1,0 +1,10 @@
+itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium,,,
+mechdef_scorpion_SCP-1N,Mech,1,1
+mechdef_alfar_AL-A1,Mech,1,2
+mechdef_cicada_CDA-2A,Mech,1,3
+mechdef_dervish_DV-6M,Mech,1,4
+mechdef_sentinel_STN-3L,Mech,1,6
+mechdef_griffin_GRF-1N,Mech,1,5
+mechdef_hunchback_HBK-4G,Mech,1,4
+mechdef_griffin_GRF-1N,Mech,1,3
+mechdef_shadowhawk_SHD-2H,Mech,1,2

--- a/Documents/Starts checklist.txt
+++ b/Documents/Starts checklist.txt
@@ -55,25 +55,25 @@ WOB                                      No
 Amaris Empire                            Yes (RW Line unit list)
 Rimworlds Republic                       Yes (RW republican guard list)
 SLDF                                     Yes
-Terran Hegemony                          Yes (First Succession War - Terran Hegemony)
+Terran Hegemony                          Yes (First Succession War/Terran Hegemony)[2xMm,2xLm]
 
-Axumite                                  Yes (Primitive 2765-2785 Lists)
-Castile                                  Yes ("Lore Compliant" Tank Start - Custom List)
-Davion                                   No
-Delphi                                   Yes (Primitive 2765-2785 Lists)
+Axumite                                  Yes (Custom Primitive 2765-2785)[1xMm,2xHv,3xLv]
+Castile                                  Yes (Custom Tank/Carrier 2765-85)[3xHv,1xMv,2xLv]
+Davion                                   Yes (FR 2765/AvalonHussars)[2xMm,2xLm]
+Delphi                                   Yes (Custom Primitive 2765-2785)[1xMm,2xHv,3xLv]
 Illyrian                                 Yes (1 Steiner/FWL B-list per category)
-Jarnfolk                                 Yes (Primitive 2765-2785 Lists)
-Kurita                                   No
+Jarnfolk                                 Yes (Custom Primitive 2765-2785)[1xMm,2xHv,3xLv]
+Kurita                                   Yes (FR 2765/GaledonRegulars)[2xMm,2xLm]
 LAM                                      N/A
-Liao                                     No
-Magistracy                               Yes (First Succession War - MajorPeriphery Shared Lists)
-Marik                                    No
+Liao                                     Yes (FR 2765/CapellanHuassars)[2xMm,2xLm]
+Magistracy                               Yes (First Succession War/MajorPeriphery)[2xMm,2xLm]
+Marik                                    Yes (FR 2765/FusiliersOriente)[2xMm,2xLm]
 Mercenary                                No
-Outworld                                 Yes (First Succession War - MajorPeriphery Shared Lists)
+Outworld                                 Yes (First Succession War/MajorPeriphery)[2xMm,2xLm]
 Solaris                                  No (Probably not a time appropriate start)
-Steiner                                  No
+Steiner                                  Yes (FR 2765/LyranRegulars)[2xMm,2xLm]
 Tanks                                    N/A
-Taurian                                  Yes (First Succession War - MajorPeriphery Shared Lists)
+Taurian                                  Yes (First Succession War/MajorPeriphery)[2xMm,2xLm]
 Tortuga                                  No (Need to work out what pirate stuff fits the era)
 Urbie                                    N/A
 VTOL                                     N/A
@@ -83,47 +83,47 @@ Finmark Free Republic                    Yes (using RWR guard list)
 SLDF in Exile                            Yes (using Pentagon Powers lists)
 Umayyad Caliphate                        Yes (same as above)
 
-Axumite                                  Yes (Primitive 2765-2785 Lists)
-Castile                                  Yes (Tank/Carrier Only - As lore dictates)
-Davion                                   Yes
-Delphi                                   Yes (Primitive 2765-2785 Lists)
-Illyrian                                 Yes (1 Steiner/FWL B-list per category)
-Jarnfolk                                 Yes (Primitive 2765-2785 Lists)
-Kurita                                   Yes
+Axumite                                  Yes (Custom Primitive 2765-2785)[1xMm,2xHv,3xLv]
+Castile                                  Yes (Custom Tank/Carrier 2765-85)[3xHv,1xMv,2xLv]
+Davion                                   Yes (First Succession War)[2xMm,2xLm]
+Delphi                                   Yes (Custom Primitive 2765-2785 Lists)[1xMm,2xHv,3xLv]
+Illyrian                                 Yes (1 Steiner/FWL B-list per category)[2xMm,2xLm]
+Jarnfolk                                 Yes (Custom Primitive 2765-2785 Lists)[1xMm,2xHv,3xLv]
+Kurita                                   Yes (First Succession War)[2xMm,2xLm]
 LAM                                      N/A
-Liao                                     Yes
-Magistracy                               Yes (First Succession War - MajorPeriphery Shared Lists)
-Marik                                    Yes
+Liao                                     Yes (First Succession War)[2xMm,2xLm]
+Magistracy                               Yes (First Succession War/MajorPeriphery)[2xMm,2xLm]
+Marik                                    Yes (First Succession War)[2xMm,2xLm]
 Mercenary                                No (On hold for now)
-Outworld                                 Yes (First Succession War - MajorPeriphery Shared Lists)
+Outworld                                 Yes (First Succession War/MajorPeriphery)[2xMm,2xLm]
 Solaris                                  No (Probably not a time appropriate start)
-Steiner                                  Yes
+Steiner                                  Yes (First Succession War)[2xMm,2xLm]
 Tanks                                    N/A
-Taurian                                  Yes (First Succession War - MajorPeriphery Shared Lists)
+Taurian                                  Yes (First Succession War/MajorPeriphery)[2xMm,2xLm]
 Tortuga                                  No (Need to work out what pirate stuff fits the era)
 Urbie                                    N/A
 VTOL                                     N/A
 
-3075 ISM
+3075 ISM     (PATCHDEF NOT UPDATED FOR BELOW, CSV's CREATED FOR APPLICABLE)
 Kittery Prefecture                       No - No applicable RAT that pairs with spawn pool/MUL
 
-Auxmite                                  No
+Auxmite                                  Yes - (Custom Primitive 2765-2785 Lists)[1xMm,2xHv,3xLv]
 BA Platoon                               No
 Bradfords and Bulldogs                   N/A
-Chainelaine                              No
-Clans                                    No
+Chainelaine                              Yes - (3075-85: A Time of War/MinorPerihery3075)[2xMm,2xLm]
+Clans                                    Yes - (3075-85: A Time of War/Clans3075)[1xMm,4xLm]
 Clan BA                                  No
-Davion                                   No
-Delphi                                   No
+Davion                                   Yes - (3075-85: A Time of War)[2xMm,2xLm]
+Delphi                                   Yes - (Custom Primitive 2765-2785 Lists)[1xMm,2xHv,3xLv]
 Farmers Uprising                         N/A
-Hanse                                    No
+Hanse                                    Yes - (3075-85: A Time of War/MinorPerihery3075)
 Hells Horses                             No
-Jarnfolk                                 No
-Kurita                                   No
-Liao                                     No
-Magistracy                               No
-Marian                                   No
-Marik                                    No
+Jarnfolk                                 Yes - (Custom Primitive 2765-2785 Lists)[1xMm,2xHv,3xLv]
+Kurita                                   Yes - (3075-85: A Time of War)[2xMm,2xLm]
+Liao                                     Yes - (3075-85: A Time of War)[2xMm,2xLm]
+Magistracy                               Yes - (3075-85: A Time of War/MajorPerihery3075)[2xMm,2xLm]
+Marian                                   Yes - (3075-85: A Time of War/MinorPerihery3075)[2xMm,2xLm]
+Marik                                    Yes - (3075-85: A Time of War)[2xMm,2xLm]
 Mercenary                                No
 Militia                                  N/A
 Primitive Mechs                          N/A
@@ -133,9 +133,9 @@ Royal Mechs                              N/A
 Recon Lance                              N/A
 Rusty Dan                                N/A
 Solaris                                  No
-Steiner                                  No
+Steiner                                  Yes - (3075-85: A Time of War)[2xMm,2xLm]
 Tanks (IS)                               N/A
-Taurian                                  No
+Taurian                                  Yes - (3075-85: A Time of War/MajorPerihery3075)[2xMm,2xLm]
 The Dumps                                N/A
 Tortuga                                  No
 Urbie                                    N/A

--- a/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium.csv
@@ -1,0 +1,2 @@
+
+mechdef_crab_CRB-27,Mech,1,1

--- a/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium.csv
@@ -1,0 +1,2 @@
+
+mechdef_crab_CRB-27,Mech,1,5

--- a/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium.csv
@@ -1,0 +1,2 @@
+
+mechdef_crab_CRB-27,Mech,1,3

--- a/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base FlashPoint/Starter/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium.csv
@@ -1,0 +1,2 @@
+
+mechdef_crab_CRB-27,Mech,1,1

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_A.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_A.csv
@@ -1,0 +1,2 @@
+
+mechdef_phoenixhawk_PXH-1D,Mech,1,4

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_B.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_B.csv
@@ -1,0 +1,4 @@
+
+mechdef_assassin_ASN-21,Mech,1,1
+mechdef_phoenixhawk_PXH-1,Mech,1,4
+mechdef_phoenixhawk_PXH-1D,Mech,1,4

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium.csv
@@ -1,0 +1,4 @@
+
+mechdef_phoenixhawk_PXH-1,Mech,1,3
+mechdef_phoenixhawk_PXH-1K,Mech,1,5
+mechdef_phoenixhawk_PXH-1Kk,Mech,1,3

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium.csv
@@ -1,0 +1,2 @@
+
+mechdef_phoenixhawk_PXH-2,Mech,1,1

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium.csv
@@ -1,0 +1,3 @@
+
+mechdef_phoenixhawk_PXH-1,Mech,1,2
+mechdef_phoenixhawk_PXH-2,Mech,1,6

--- a/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium.csv
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/Starter/itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium.csv
@@ -1,0 +1,2 @@
+
+mechdef_phoenixhawk_PXH-1,Mech,1,5

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_A.csv
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_A.csv
@@ -1,0 +1,2 @@
+
+mechdef_javelin_JVN-10N,Mech,1,5

--- a/Eras/ClanInvasion3061/Base UrbanWarfare/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_B.csv
+++ b/Eras/ClanInvasion3061/Base UrbanWarfare/Starter/itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_B.csv
@@ -1,0 +1,2 @@
+
+mechdef_javelin_JVN-10N,Mech,1,1

--- a/InstallOptions/ISM2765/patchdef.json
+++ b/InstallOptions/ISM2765/patchdef.json
@@ -13025,7 +13025,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Davion_2765_Medium,itemCollection_Mechs_Starting_Davion_2765_Medium,itemCollection_Mechs_Starting_Davion_2765_Light,itemCollection_Mechs_Starting_Davion_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_A,itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Medium_B,itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_A,itemCollection_Mechs_Starting_Davion_AvalonHussars_2765_Light_B"
                     }
                 },
                 {
@@ -13043,7 +13043,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Steiner_2785_Medium_B,itemCollection_Mechs_Starting_Marik_2785_Medium_B,itemCollection_Mechs_Starting_Steiner_2785_Light_B,itemCollection_Mechs_Starting_Marik_2785_Light_B"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium,itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Light,itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium,itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Light"
                     }
                 },
                 {
@@ -13061,7 +13061,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Kurita_2765_Medium,itemCollection_Mechs_Starting_Kurita_2765_Medium,itemCollection_Mechs_Starting_Kurita_2765_Light,itemCollection_Mechs_Starting_Kurita_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium,itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Medium,itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Light,itemCollection_Mechs_Starting_Kurita_GaledonRegulars_2765_Light"
                     }
                 },
                 {
@@ -13079,7 +13079,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Liao_2765_Medium,itemCollection_Mechs_Starting_Liao_2765_Medium,itemCollection_Mechs_Starting_Liao_2765_Light,itemCollection_Mechs_Starting_Liao_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium,itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Medium,itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Light,itemCollection_Mechs_Starting_Liao_CapellanHussars_2765_Light"
                     }
                 },
                 {
@@ -13097,7 +13097,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Marik_2765_Medium,itemCollection_Mechs_Starting_Marik_2765_Medium,itemCollection_Mechs_Starting_Marik_2765_Light,itemCollection_Mechs_Starting_Marik_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium,itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Medium,itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Light,itemCollection_Mechs_Starting_Marik_FusiliersOriente_2765_Light"
                     }
                 },
                 {
@@ -13133,7 +13133,7 @@
                         "ConstantName": "StartingRandomMechLists"
                     },
                     "patch": {
-                        "ConstantValue": "itemCollection_Mechs_Starting_Steiner_2765_Medium,itemCollection_Mechs_Starting_Steiner_2765_Medium,itemCollection_Mechs_Starting_Steiner_2765_Light,itemCollection_Mechs_Starting_Steiner_2765_Light,itemCollection_Mechs_Starting_Tanks_Medium_2765,itemCollection_Mechs_Starting_Tanks_Medium_2765"
+                        "ConstantValue": "itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium,itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Medium,itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Light,itemCollection_Mechs_Starting_Steiner_LyranRegulars_2765_Light"
                     }
                 },
                 {


### PR DESCRIPTION
Changes
- Major houses 2765 updated
- Illyria 2765 updated with 2765 steiner+marik.
- Patchdef 2765 updated reflecting above.


Notes
- Checklist updated with more details.
- 2765/2785 mostly complete, missing "tortuga" and "mercenary" starts. 
- 3075 partially finished on local, waiting for info about patchdef before pushing

Extra note, remove old 2765 start csv's after new ones confirmed working.