### PR TITLE
Fix error in PilotingClasses

### DIFF
--- a/Core/CustomUnits/piloting_classes/LAMClass.json
+++ b/Core/CustomUnits/piloting_classes/LAMClass.json
@@ -9,14 +9,14 @@
   ],
   "PilotTags": [
     "can_pilot_landairmech",
-    "can_pilot_generic_vehicle"
+    "can_pilot_generic_mech"
   ],
   "ExcludeClasses": [],
   "expertiseGenerationChance": 0.1,
   "expertiseGenerationMinCount": 0,
   "additionalExpertisesCount": 1,
   "AdditionalClasses": [
-    "GenericMechClass",
+    "BAClass",
     "GenericVehicleClass",
     "VTOLClass"
   ]

--- a/Core/CustomUnits/piloting_classes/VTOLClass.json
+++ b/Core/CustomUnits/piloting_classes/VTOLClass.json
@@ -17,7 +17,7 @@
   "additionalExpertisesCount": 1,
   "AdditionalClasses": [
     "GenericMechClass",
-    "GenericVehicleClass",
+    "BAClass",
     "LAMClass"
   ]
 }


### PR DESCRIPTION
Fixed error which didn't correctly assign supporting pilot class for LAM (Mech) and VTOL (Vehicle) classes.