### PR TITLE
Tagged Rhinos as carriers

### DIFF
--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_RHINO_EC.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_RHINO_EC.json
@@ -10,6 +10,7 @@
       "unit_indirectFire",
       "unit_early_clan",
       "unit_vehicle_clan",
+      "unit_carrier",
       "unit_release",
       "mr-resize-1.73",
       "clancoyote",

--- a/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_RHINO_ROYAL_CLAN.json
+++ b/Eras/ClanInvasion3061/Base/CLANK/vehicle/vehicledef_RHINO_ROYAL_CLAN.json
@@ -10,6 +10,7 @@
       "unit_tracks",
       "unit_indirectFire",
       "unit_vehicle_clan",
+      "unit_carrier",
       "unit_release",
       "skip_heatcheck",
       "mr-resize-1.73",

--- a/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO.json
@@ -8,6 +8,7 @@
       "unit_lance_support",
       "unit_tracks",
       "unit_indirectFire",
+      "unit_carrier",
       "unit_solaris",
       "unit_release",
       "mr-resize-1.73",

--- a/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_3052.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_3052.json
@@ -8,6 +8,7 @@
       "unit_lance_support",
       "unit_tracks",
       "unit_indirectFire",
+      "unit_carrier",
       "unit_solaris",
       "unit_release",
       "unit_rt_custom",

--- a/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_FLAMER.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_FLAMER.json
@@ -11,6 +11,7 @@
       "unit_indirectFire",
       "unit_solaris",
       "unit_release",
+      "unit_carrier",
       "mr-resize-1.73",
       "Faction_Employer",
       "Faction_Neutral",

--- a/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_MG.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_MG.json
@@ -9,6 +9,7 @@
       "unit_tracks",
       "unit_indirectFire",
       "unit_solaris",
+      "unit_carrier",
       "unit_release",
       "mr-resize-1.73",
       "Faction_Employer",

--- a/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_ROYAL.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_ROYAL.json
@@ -10,6 +10,7 @@
       "unit_tracks",
       "unit_indirectFire",
       "unit_sldf",
+      "unit_carrier",
       "unit_release",
       "mr-resize-1.73",
       "ClanStoneLion",

--- a/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_SL.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/assault/vehicledef_RHINO_SL.json
@@ -7,6 +7,7 @@
       "unit_bracket_high",
       "unit_lance_tank",
       "unit_tracks",
+      "unit_carrier",
       "unit_indirectFire",
       "unit_solaris",
       "unit_release",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_RHINO_ML.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_RHINO_ML.json
@@ -7,6 +7,7 @@
       "unit_bracket_high",
       "unit_lance_support",
       "unit_lance_tank",
+      "unit_carrier",
       "unit_tracks",
       "unit_indirectFire",
       "unit_release",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_RHINO_WOB.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_RHINO_WOB.json
@@ -8,6 +8,7 @@
       "unit_lance_support",
       "unit_tracks",
       "unit_indirectFire",
+      "unit_carrier",
       "unit_predator",
       "unit_command",
       "unit_release",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_RHINO_ROS.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_RHINO_ROS.json
@@ -11,6 +11,7 @@
       "unit_predator",
       "unit_release",
       "mr-resize-1.73",
+      "unit_carrier",
       "republic"
     ],
     "tagSetSourceFile": ""


### PR DESCRIPTION
Fix for an annoyingly persistent rep-me. Tagged all Rhinos as carriers on the basis they all have support lance tags, a crap ton of LRM's and are the needed class/threat bracket