### PR TITLE
Added new lam/vtol events to shops

### DIFF
--- a/Core/Aircademy/data/RT_Respec_A.csv
+++ b/Core/Aircademy/data/RT_Respec_A.csv
@@ -1,0 +1,3 @@
+RT_Respec_A,,,
+RT_Respec_A_TEAM,Reference,1,7
+RT_Respec_A_CO,Reference,1,7

--- a/Core/Aircademy/data/RT_Respec_A_CO.csv
+++ b/Core/Aircademy/data/RT_Respec_A_CO.csv
@@ -1,0 +1,2 @@
+RT_Respec_A_CO,,,
+Gear_Aircademy_VTOL_Appointment_Commander,Upgrade,1,7

--- a/Core/Aircademy/data/RT_Respec_A_TEAM.csv
+++ b/Core/Aircademy/data/RT_Respec_A_TEAM.csv
@@ -1,0 +1,2 @@
+RT_Respec_A_TEAM,,,
+Gear_Aircademy_VTOL_Appointment,Upgrade,1,7

--- a/Core/DynamicShops/data/RT_List_Clan_Major.csv
+++ b/Core/DynamicShops/data/RT_List_Clan_Major.csv
@@ -1,4 +1,5 @@
 RT_List_Clan_Major,,,
+RT_Respec,Reference,1,10
 RT_EIDNI,Reference,1,10
 RT_Beacons_Drones,Reference,1,10
 RT_Proto_Parts_Clan,Reference,2,10

--- a/Core/DynamicShops/data/RT_List_Clan_Minor.csv
+++ b/Core/DynamicShops/data/RT_List_Clan_Minor.csv
@@ -1,4 +1,5 @@
 RT_List_Clan_Minor,,,
+RT_Respec,Reference,1,10
 RT_Proto_Parts_Clan,Reference,1,10
 RT_Clan_Gear_Common,Reference,3,10
 RT_Ammo_Clan,Reference,4,10

--- a/Core/DynamicShops/data/RT_List_InnerSphere_Major.csv
+++ b/Core/DynamicShops/data/RT_List_InnerSphere_Major.csv
@@ -1,4 +1,5 @@
 RT_List_InnerSphere_Major,,,
+RT_Respec,Reference,1,10
 RT_Beacons_Drones,Reference,1,10
 RT_IntroTech,Reference,4,10
 RT_BA_Generic,Reference,2,10

--- a/Core/DynamicShops/data/RT_List_InnerSphere_Minor.csv
+++ b/Core/DynamicShops/data/RT_List_InnerSphere_Minor.csv
@@ -1,4 +1,5 @@
 RT_List_InnerSphere_Minor,,,
+RT_Respec,Reference,1,10
 RT_IntroTech,Reference,4,10
 RT_BA_Generic,Reference,1,10
 RT_BA_Parts_Generic,Reference,4,10

--- a/Core/DynamicShops/data/RT_List_Periphery_Major.csv
+++ b/Core/DynamicShops/data/RT_List_Periphery_Major.csv
@@ -1,4 +1,5 @@
 RT_List_Periphery_Major,,,
+RT_Respec,Reference,1,10
 RT_Beacons_Drones,Reference,1,10
 RT_IntroTech,Reference,4,10
 RT_BA_Generic,Reference,2,10

--- a/Core/DynamicShops/data/RT_List_Periphery_Minor.csv
+++ b/Core/DynamicShops/data/RT_List_Periphery_Minor.csv
@@ -1,4 +1,5 @@
 RT_List_Periphery_Minor,,,
+RT_Respec,Reference,1,10
 RT_IntroTech,Reference,4,10
 RT_BA_Generic,Reference,1,10
 RT_BA_Parts_Generic,Reference,2,10

--- a/Core/DynamicShops/data/RT_List_Pirates_Major.csv
+++ b/Core/DynamicShops/data/RT_List_Pirates_Major.csv
@@ -1,4 +1,5 @@
 RT_List_Pirates_Major,,,
+RT_Respec,Reference,1,10
 RT_IntroTech_Pirate,Reference,4,10
 RT_Ammo_Common_1,Reference,4,10
 RT_Basics_Common,Reference,3,10

--- a/Core/DynamicShops/data/RT_List_Pirates_Minor.csv
+++ b/Core/DynamicShops/data/RT_List_Pirates_Minor.csv
@@ -1,4 +1,5 @@
 RT_List_Pirates_Minor,,,
+RT_Respec,Reference,1,10
 RT_IntroTech_Pirate,Reference,4,10
 RT_Ammo_Common_1,Reference,4,10
 RT_Basics_Common,Reference,2,10

--- a/Core/DynamicShops/data/RT_Respec.csv
+++ b/Core/DynamicShops/data/RT_Respec.csv
@@ -1,0 +1,3 @@
+RT_Respec,,,
+RT_Respec_A,Reference,2,10
+RT_Respec_B,Reference,2,10

--- a/Core/WhamBaLAM/data/RT_Respec_B.csv
+++ b/Core/WhamBaLAM/data/RT_Respec_B.csv
@@ -1,0 +1,3 @@
+RT_Respec_B,,,
+RT_Respec_B_TEAM,Reference,1,7
+RT_Respec_B_CO,Reference,1,7

--- a/Core/WhamBaLAM/data/RT_Respec_B_CO.csv
+++ b/Core/WhamBaLAM/data/RT_Respec_B_CO.csv
@@ -1,0 +1,2 @@
+RT_Respec_B_CO,,,
+Gear_LAMcademy_LAM_Appointment_Commander,Upgrade,1,7

--- a/Core/WhamBaLAM/data/RT_Respec_B_TEAM.csv
+++ b/Core/WhamBaLAM/data/RT_Respec_B_TEAM.csv
@@ -1,0 +1,2 @@
+RT_Respec_B_TEAM,,,
+Gear_LAMcademy_LAM_Appointment,Upgrade,1,7


### PR DESCRIPTION
Added a master list (RT_Respec) to all shops. List then sub divides into A (Air Academy) and B (LAM) branches (each living in their respective core folder) which should enable 2 events to be rolled so the player gets the choice of both commander and mechwarrior events (for maximum player choice) in either aero or LAM training 