### PR TITLE
Update event_solarisSeasonStart4.json

### DIFF
--- a/Core/Solaris7/events/event_solarisSeasonStart4.json
+++ b/Core/Solaris7/events/event_solarisSeasonStart4.json
@@ -18,12 +18,7 @@
     },
     "ExclusionTags": {
       "tagSetSourceFile": "Tags/CompanyTags",
-      "items": [
-        "company_solaris_BANNED",
-        "company_solaris_recent",
-        "company_solaris_championship",
-        "company_solaris_DECLINED"
-      ]
+      "items": []
     },
     "RequirementComparisons": []
   },
@@ -53,9 +48,7 @@
               "Requirements": null,
               "AddedTags": {
                 "tagSetSourceFile": "Tags/CompanyTags",
-                "items": [
-                  "company_solaris_DECLINED"
-                ]
+                "items": []
               },
               "RemovedTags": {
                 "tagSetSourceFile": "",
@@ -121,9 +114,9 @@
             "items": []
           },
           "ExclusionTags": {
-             "tagSetSourceFile": "Tags/CompanyTags",
+            "tagSetSourceFile": "Tags/CompanyTags",
             "items": [
-             "company_solaris_championship_ticket"
+              "company_solaris_championship_ticket"
             ]
           },
           "RequirementComparisons": []
@@ -175,9 +168,7 @@
               "Requirements": null,
               "AddedTags": {
                 "tagSetSourceFile": "Tags/CompanyTags",
-                "items": [
-                  "company_solaris_championship_ticket"
-                ]
+                "items": []
               },
               "RemovedTags": {
                 "tagSetSourceFile": "",


### PR DESCRIPTION
Stripped out unneeded exclusion tags and fixed an oversight. Event added   "company_solaris_championship_ticket" when fp dialogue was started but if player declines then the tag stays. The conversation preceding this had the tag as an exclusion so if the player launched and then declined it would block any further attempts at progress