### PR TITLE
add bracket tag to normal units missing one & role_scout to CUS

### DIFF
--- a/Core/CustomUnitSpawn/mod.json
+++ b/Core/CustomUnitSpawn/mod.json
@@ -38,6 +38,7 @@
       "unit_lance_support": { "weight": 20, "replace": [ "unit_lance_assassin", "unit_lance_vanguard" ] },
       "unit_lance_vanguard": { "weight": 20, "replace": [ "unit_lance_tank" ,"unit_lance_assassin", "unit_lance_support" ] },
       "unit_lance_tank": { "weight": 20, "replace": [ "unit_lance_vanguard" ] },
+      "unit_role_scout": { "weight": 20, "replace": [ "unit_predator" ] },
       "unit_superheavy_tier5": { "weight": 15, "replace": [ "unit_superheavy_tier4" ] },
       "unit_superheavy_tier4": { "weight": 15, "replace": [ "unit_superheavy_tier3" ] },
       "unit_superheavy_tier3": { "weight": 15, "replace": [ "unit_superheavy_tier2" ] },

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_gui_guisui_lam_GGI-A1.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_gui_guisui_lam_GGI-A1.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
+      "unit_bracket_low",
       "unit_role_scout",
       "unit_lance_vanguard",
       "unit_LAM",

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_gui_guisui_lam_GGI-A2.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_gui_guisui_lam_GGI-A2.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
+      "unit_bracket_low",
       "unit_role_scout",
       "unit_lance_vanguard",
       "unit_LAM",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_Marksman_MBT_M1.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_Marksman_MBT_M1.json
@@ -3,6 +3,7 @@
     "items": [
       "unit_vehicle",
       "unit_assault",
+      "unit_bracket_med",
       "unit_advanced",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_Marksman_MBT_M1A.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_Marksman_MBT_M1A.json
@@ -3,6 +3,7 @@
     "items": [
       "unit_vehicle",
       "unit_assault",
+      "unit_bracket_med",
       "unit_advanced",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_Marksman_MBT_M1J.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_Marksman_MBT_M1J.json
@@ -3,6 +3,7 @@
     "items": [
       "unit_vehicle",
       "unit_assault",
+      "unit_bracket_med",
       "unit_advanced",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/OperationRevival/vehicle/vehicledef_TEZCATLIPOCA.json
+++ b/Optionals/OperationRevival/vehicle/vehicledef_TEZCATLIPOCA.json
@@ -3,6 +3,7 @@
     "items": [
       "unit_vehicle",
       "unit_heavy",
+      "unit_bracket_med",
       "unit_advanced",
       "unit_generic",
       "unit_lance_assassin",

--- a/Optionals/PirateTech/Base/mech/mechdef_warthog_WTG-A10.json
+++ b/Optionals/PirateTech/Base/mech/mechdef_warthog_WTG-A10.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_role_sniper",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/PirateTech/Flashpoint/vehicle/vehicledef_Kirov.json
+++ b/Optionals/PirateTech/Flashpoint/vehicle/vehicledef_Kirov.json
@@ -2,7 +2,9 @@
   "VehicleTags": {
     "items": [
       "unit_legendary",
+      "unit_vehicle",
       "unit_airship",
+      "unit_bracket_high",
       "unit_indirectFire",
       "unit_noconvoy",
       "unit_singleton",

--- a/Optionals/QuicksellCustoms/Mech/mechdef_queenbee_lam_QNB-A.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_queenbee_lam_QNB-A.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
+      "unit_bracket_low",
       "unit_role_scout",
       "unit_lance_vanguard",
       "unit_LAM",

--- a/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-O.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-O.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_role_sniper",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OA.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OA.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_role_sniper",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OB.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OB.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_role_sniper",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OC.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OC.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_role_sniper",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OD.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OD.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_role_sniper",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OE.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_berkut_SHX-OE.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_role_sniper",
       "unit_lance_assassin",
       "unit_lance_vanguard",

--- a/Optionals/RogueOmnis/RISCtech/mech/mechdef_berkut_SHX-OF.json
+++ b/Optionals/RogueOmnis/RISCtech/mech/mechdef_berkut_SHX-OF.json
@@ -4,6 +4,7 @@
       "unit_mech",
       "unit_medium",
       "unit_advanced",
+      "unit_bracket_high",
       "unit_elite",
       "unit_legendary",
       "unit_role_sniper",


### PR DESCRIPTION
added suitable bracket tags to combat units missing one as that is required (barring very few exceptions) for one to spawn.
added the scout role tag to CUS fallback list as it was missing there
still leaves a convoy exclusive units and some specials without:
![image](https://github.com/BattletechModders/RogueTech/assets/59488828/957e569c-e1cb-4a62-8e64-1837046de529)
