### PR TITLE
Swap Assassin for Reckless in Loner Youth Background

### DIFF
--- a/Core/RogueBackgrounds/BackgroundYouth/background_youth_loner.json
+++ b/Core/RogueBackgrounds/BackgroundYouth/background_youth_loner.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "background_youth_loner",
     "Name": "Loner",
-    "Details": "Hobbies were a luxury you could not afford to have.\nQuirks: [[DM.BaseDescriptionDefs[QuirkAssassin],Assassin]], [[DM.BaseDescriptionDefs[QuirkBrave],Brave]]",
+    "Details": "You blazed a trail through life, sticking to the only guns you could trust — your own.\nQuirks: [[DM.BaseDescriptionDefs[QuirkReckless],Reckless]], [[DM.BaseDescriptionDefs[QuirkBrave],Brave]]",
     "Icon": "uixTxrLogo_backgroundLoner",
     "Cost": 0,
     "Rarity": 0,
@@ -15,7 +15,7 @@
       "items": [
         "commander_youth_loner",
         "pilot_brave",
-        "pilot_assassin"
+        "pilot_reckless"
       ],
       "tagSetSourceFile": ""
     },


### PR DESCRIPTION
Making good on a desire to curb some of the headcapping meta I had a year and change ago.

This makes Ex-Military and Assassin mutually exclusive Commander quirks to prevent players stacking all called shot modifiers possible on the Commander.