### PR TITLE
Tweaks to custom tank fluff + new model

### DIFF
--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER.json
@@ -114,10 +114,10 @@
     "Cost": 1623275,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-A5",
+    "UIName": "Cloud Buster CB-AA-A5",
     "Id": "vehicledef_CLOUDBUSTER",
-    "Name": "Cloud Buster CB-A5",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>Fuel Cell: Improved vehicle engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         120     25\n<b>Right</b>       120     25\n<b>Rear</b>         90     25\n<b>Turret</b>      140     25\n\n<b>Total</b>      650    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Name": "Cloud Buster CB-AA-A5",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated Fuel Cell and incorporates a pair of AC/5's in the tanks turret.\n\n<b><color=#ffcc00>Fuel Cell: Improved vehicle engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         120     25\n<b>Right</b>       120     25\n<b>Rear</b>         90     25\n<b>Turret</b>      140     25\n\n<b>Total</b>      650    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "Locations": [

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER_LASER.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER_LASER.json
@@ -115,10 +115,10 @@
     "Cost": 1714987,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-LL",
+    "UIName": "Cloud Buster CB-AA-LL",
     "Id": "vehicledef_CLOUDBUSTER_LASER",
-    "Name": "Cloud Buster CB-LL",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Name": "Cloud Buster CB-AA-LL",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated Fusion engine that allows SDI engineers to mount paired Large Lasers and Machine Guns in the tanks turret.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "Locations": [
@@ -161,14 +161,14 @@
   "inventory": [
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_Laser_Primitive_Large",
+      "ComponentDefID": "Weapon_Laser_Large",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_Laser_Primitive_Large",
+      "ComponentDefID": "Weapon_Laser_Large",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER_PERIPHERY.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER_PERIPHERY.json
@@ -40,10 +40,10 @@
     "Cost": 1098737,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-MR",
+    "UIName": "Cloud Buster CB-AA-MR",
     "Id": "vehicledef_CLOUDBUSTER_PERIPHERY",
-    "Name": "Cloud Buster CB-MR",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Name": "Cloud Buster CB-AA-MR",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated ICE engine and incorporates a pair of Medium Rifles in the tanks turret.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "Locations": [

--- a/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER_PERIPHERY_2.json
+++ b/Eras/ClanInvasion3061/Base/vehicle/medium/vehicledef_CLOUDBUSTER_PERIPHERY_2.json
@@ -40,10 +40,10 @@
     "Cost": 1213287,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-CL",
+    "UIName": "Cloud Buster CB-AA-CL",
     "Id": "vehicledef_CLOUDBUSTER_PERIPHERY_2",
-    "Name": "Cloud Buster CB-CL",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       175     25\n<b>Left</b>         130     25\n<b>Right</b>       130     25\n<b>Rear</b>         80     25\n<b>Turret</b>      155     25\n\n<b>Total</b>      670    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Name": "Cloud Buster CB-AA-CL",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated ICE engine and incorporates a trio of primitive Chemical Lasers in the tanks turret.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       175     25\n<b>Left</b>         130     25\n<b>Right</b>       130     25\n<b>Rear</b>         80     25\n<b>Turret</b>      155     25\n\n<b>Total</b>      670    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "Locations": [

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER.json
@@ -14,10 +14,10 @@
     "Cost": 1623275,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-A5",
+    "UIName": "Cloud Buster CB-AA-A5",
     "Id": "vehiclechassisdef_CLOUDBUSTER",
     "Name": "Cloud Buster AA",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>Fuel Cell: Improved vehicle engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         120     25\n<b>Right</b>       120     25\n<b>Rear</b>         90     25\n<b>Turret</b>      140     25\n\n<b>Total</b>      650    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated Fuel Cell and incorporates a pair of AC/5's in the tanks turret.\n\n<b><color=#ffcc00>Fuel Cell: Improved vehicle engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         120     25\n<b>Right</b>       120     25\n<b>Rear</b>         90     25\n<b>Turret</b>      140     25\n\n<b>Total</b>      650    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "YangsThoughts": "It's a tank, Boss, they all look the same to me.",

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_LASER.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_LASER.json
@@ -14,10 +14,10 @@
     "Cost": 1714987,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-LL",
+    "UIName": "Cloud Buster CB-AA-LL",
     "Id": "vehiclechassisdef_CLOUDBUSTER_LASER",
     "Name": "Cloud Buster AA",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated Fusion engine that allows SDI engineers to mount paired Large Lasers and Machine Guns in the tanks turret.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "YangsThoughts": "It's a tank, Boss, they all look the same to me.",

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_PERIPHERY.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_PERIPHERY.json
@@ -14,10 +14,10 @@
     "Cost": 1098737,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-MR",
+    "UIName": "Cloud Buster CB-AA-MR",
     "Id": "vehiclechassisdef_CLOUDBUSTER_PERIPHERY",
     "Name": "Cloud Buster AA",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated ICE engine and incorporates a pair of Medium Rifles in the tanks turret.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "YangsThoughts": "It's a tank, Boss, they all look the same to me.",

--- a/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_PERIPHERY_2.json
+++ b/Eras/ClanInvasion3061/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_PERIPHERY_2.json
@@ -14,10 +14,10 @@
     "Cost": 1213287,
     "Rarity": 0,
     "Purchasable": false,
-    "UIName": "Cloud Buster CB-CL",
+    "UIName": "Cloud Buster CB-AA-CL",
     "Id": "vehiclechassisdef_CLOUDBUSTER_PERIPHERY_2",
     "Name": "Cloud Buster AA",
-    "Details": "Introduced during the early years of the Star League, the 45 ton ‘‘Cloud Buster’’ is a hugely popular medium weight AA Tank. Originally produced by Shepard Defense Industries, the Cloud Buster has spawned such a wide variety of variants and identical clones that nearly every planet in the Inner Sphere has at least one in it’s defence force. Usually armed with either paired AC/5’s or Large Laser’s; lower tech models in the Periphery sometimes use Rifles or Chemical Lasers in place of the more advanced weapons.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       175     25\n<b>Left</b>         130     25\n<b>Right</b>       130     25\n<b>Rear</b>         80     25\n<b>Turret</b>      155     25\n\n<b>Total</b>      670    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+    "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated ICE engine and incorporates a trio of primitive Chemical Lasers in the tanks turret.\n\n<b><color=#ffcc00>ICE: Air breathing Combustion Engine. This unit can not deploy in thin atmosphere.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       175     25\n<b>Left</b>         130     25\n<b>Right</b>       130     25\n<b>Rear</b>         80     25\n<b>Turret</b>      155     25\n\n<b>Total</b>      670    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
     "Icon": "Partisan"
   },
   "YangsThoughts": "It's a tank, Boss, they all look the same to me.",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_CLOUDBUSTER_CHEM-LASER.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_CLOUDBUSTER_CHEM-LASER.json
@@ -1,0 +1,254 @@
+{
+    "VehicleTags": {
+        "items": [
+            "unit_vehicle",
+            "unit_medium",
+            "unit_advanced",
+            "unit_bracket_low",
+            "unit_lance_support",
+            "unit_lance_vanguard",
+            "unit_tracks",
+            "unit_proxy_icon",
+            "unit_proxy_model",
+            "unit_release",
+            "unit_rt_custom",
+            "unit_rarity_equipment_level_0",
+            "skip_heatcheck",
+            "mr-resize-0.6",
+            "GhostBearDominion",
+            "ClanWolfInExile",
+            "RavenAlliance",
+            "clandiamondshark",
+            "clanhellshorses",
+            "clanjadefalcon",
+            "clannovacat",
+            "clanwolf",
+            "davion",
+            "kurita",
+            "liao",
+            "marik",
+            "republic",
+            "steiner",
+            "locals"
+        ],
+        "tagSetSourceFile": ""
+    },
+    "ChassisID": "vehiclechassisdef_CLOUDBUSTER_CHEM-LASER",
+    "Description": {
+        "Cost": 1714987,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Cloud Buster CB-AA-CL2",
+        "Id": "vehicledef_CLOUDBUSTER_CHEM-LASER",
+        "Name": "Cloud Buster CB-AA-CL2",
+        "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated Fusion engine that allows SDI engineers to mount paired Large Lasers and Machine Guns in the tanks turret.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+        "Icon": "Partisan"
+    },
+    "Locations": [
+        {
+            "Location": "Front",
+            "CurrentArmor": 180,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 180,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Left",
+            "CurrentArmor": 140,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 140,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Right",
+            "CurrentArmor": 140,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 140,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Rear",
+            "CurrentArmor": 100,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 100,
+            "DamageLevel": "Functional"
+        },
+        {
+            "Location": "Turret",
+            "CurrentArmor": 170,
+            "CurrentInternalStructure": 25,
+            "AssignedArmor": 170,
+            "DamageLevel": "Functional"
+        }
+    ],
+    "inventory": [
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_Chemical_Large_Clan",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_Laser_Chemical_Large_Clan",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_MachineGun",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Weapon_MachineGun",
+            "ComponentDefType": "Weapon",
+            "HardpointSlot": 0,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_MachineGun",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Laser_Chemical_Large_Double",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Ammo_AmmunitionBox_Laser_Chemical_Large_Double",
+            "ComponentDefType": "AmmunitionBox",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_CASE",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Crew_Compartment",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Default_Vehicle_Sensors",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_FCS_AdvancedTC",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_AA",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Front",
+            "ComponentDefID": "Gear_TargetingTrackingSystem_Energy",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Left",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Left",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Right",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Right",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Armor_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Structure_Standard",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Default_Vehicle_Motive_Tracked_Defaultbox",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Quirk_AntiAirTargeting",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Turret",
+            "ComponentDefID": "Default_Vehicle_Turret",
+            "ComponentDefType": "Upgrade",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_EngineCore_180",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Engine_FuelCell",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        },
+        {
+            "MountedLocation": "Rear",
+            "ComponentDefID": "Gear_Vehicle_EngineCooling_CoolantSystem",
+            "ComponentDefType": "HeatSink",
+            "HardpointSlot": -1,
+            "DamageLevel": "Functional"
+        }
+    ]
+}

--- a/Eras/Republic3081-3130/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_CHEM-LASER.json
+++ b/Eras/Republic3081-3130/Base/vehicleChassis/vehiclechassisdef_CLOUDBUSTER_CHEM-LASER.json
@@ -1,0 +1,138 @@
+{
+    "Custom": {
+        "VAssemblyVariant": {
+            "PrefabID": "Cloud",
+            "Exclude": false,
+            "Include": true
+        }
+    },
+    "CustomParts": {
+        "CustomParts": [],
+        "CrewLocation": "None"
+    },
+    "Description": {
+        "Cost": 1714987,
+        "Rarity": 0,
+        "Purchasable": false,
+        "UIName": "Cloud Buster CB-AA-CL2",
+        "Id": "vehiclechassisdef_CLOUDBUSTER_CHEM-LASER",
+        "Name": "Cloud Buster AA",
+        "Details": "Produced by Shepard Defence Industries since the early years of the Star League, the Cloud Buster AA tank has become a mainstay of second line units and mercenary units everywhere. This version of the CB-AA tank is built around a 180 rated Fusion engine that allows SDI engineers to mount paired Large Lasers and Machine Guns in the tanks turret.\n\n<b><color=#ffcc00>Fusion: Expensive engine that works in a Vacuum.</color></b>\n\n<b><color=#ffcc00>Movement: 4/6 hexes / 120/180 meters.</color></b>\n\n<color=#ffcc00><b>Armor:</b> Armor\n<b>Structure:</b> Structure\n<b>Values       A        S  </b>\n<b>Front</b>       180     25\n<b>Left</b>         140     25\n<b>Right</b>       140     25\n<b>Rear</b>        100     25\n<b>Turret</b>      170     25\n\n<b>Total</b>      730    125</color>\n\n<color=#ff0000>Quirk: Anti-Air Targeting</color>",
+        "Icon": "Partisan"
+    },
+    "YangsThoughts": "It's a tank, Boss, they all look the same to me.",
+    "MovementCapDefID": "movedef_4-6cv",
+    "movementType": "Tracked",
+    "PathingCapDefID": "pathingdef_medium_tracked",
+    "HardpointDataDefID": "hardpointdatadef_paladin",
+    "PrefabIdentifier": "chrprfvhcl_paladin",
+    "PrefabBase": "paladin",
+    "Tonnage": 45,
+    "weightClass": "MEDIUM",
+    "BattleValue": 993,
+    "TopSpeed": 85,
+    "TurnRadius": 90,
+    "SpotterDistanceMultiplier": 1,
+    "VisibilityMultiplier": 1,
+    "SensorRangeMultiplier": 1,
+    "Signature": 1,
+    "Radius": 4,
+    "Locations": [
+        {
+            "Location": "Front",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 180,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Left",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 140,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Right",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 140,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Rear",
+            "Hardpoints": [],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 100,
+            "InternalStructure": 25
+        },
+        {
+            "Location": "Turret",
+            "Hardpoints": [
+                {
+                    "WeaponMountID": "Ballistic",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Ballistic",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                },
+                {
+                    "WeaponMountID": "Energy",
+                    "Omni": false
+                }
+            ],
+            "Tonnage": 0,
+            "InventorySlots": 0,
+            "MaxArmor": 170,
+            "InternalStructure": 25
+        }
+    ],
+    "LOSSourcePositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        }
+    ],
+    "LOSTargetPositions": [
+        {
+            "x": 0,
+            "y": 3.5,
+            "z": -0.5
+        },
+        {
+            "x": 0,
+            "y": 2,
+            "z": 3
+        },
+        {
+            "x": -3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 3,
+            "y": 1.5,
+            "z": 0
+        },
+        {
+            "x": 0,
+            "y": 3,
+            "z": -4
+        }
+    ]
+}


### PR DESCRIPTION
Added a new Cloud Buster variant for the Republic/DA. Cut word count down on CB-AA descriptions (by between 10 and 20 words) on all existing models