### PR TITLE
Tweak Titan missions

### DIFF
--- a/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack.json
+++ b/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack.json
@@ -45,6 +45,12 @@
           "op": "Equal",
           "val": 0,
           "valueConstant": null
+        },
+        {
+          "obj": "MissionsComplete",
+          "op": "GreaterThan",
+          "val": 20,
+          "valueConstant": "20"
         }
       ]
     }
@@ -1339,6 +1345,7 @@
             },
             "unitExcludedTagSet": {
               "items": [
+                "unit_bracket_high",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack_Alt.json
+++ b/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack_Alt.json
@@ -45,6 +45,12 @@
           "op": "Equal",
           "val": 0,
           "valueConstant": null
+        },
+        {
+          "obj": "MissionsComplete",
+          "op": "GreaterThan",
+          "val": 20,
+          "valueConstant": "20"
         }
       ]
     }
@@ -1496,6 +1502,7 @@
             },
             "unitExcludedTagSet": {
               "items": [
+                "unit_bracket_high",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"
@@ -1664,6 +1671,7 @@
             },
             "unitExcludedTagSet": {
               "items": [
+                "unit_bracket_high",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ClashOfTitans.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ClashOfTitans.json
@@ -45,6 +45,12 @@
           "op": "Equal",
           "val": 0,
           "valueConstant": null
+        },
+        {
+          "obj": "MissionsComplete",
+          "op": "GreaterThan",
+          "val": 20,
+          "valueConstant": "20"
         }
       ]
     }
@@ -3913,6 +3919,7 @@
             },
             "unitExcludedTagSet": {
               "items": [
+                "unit_bracket_high",
                 "unit_advanced",
                 "unit_turret",
                 "unit_vtol",
@@ -5408,6 +5415,7 @@
             },
             "unitExcludedTagSet": {
               "items": [
+                "unit_bracket_high",
                 "unit_advanced",
                 "unit_turret",
                 "unit_vtol",


### PR DESCRIPTION
Delay their apepareance a bit, not intentional to start a new run into a guaranteed assault spawn in otherwise low weight mission. Practically only affects those who play planet diff or with very high difficulty variance.

Reduce highroll potential in their assault unit selection.