### PR TITLE
Fix the new Titan requirements

### DIFF
--- a/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack.json
+++ b/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack.json
@@ -45,6 +45,16 @@
           "op": "Equal",
           "val": 0,
           "valueConstant": null
+        }
+      ]
+    },
+    {
+      "Scope": "Company",
+      "RequirementComparisons": [
+        {
+          "obj": "DCE-CurrentDifficulty",
+          "op": "GreaterThanOrEqual",
+          "val": 8
         },
         {
           "obj": "MissionsComplete",

--- a/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack_Alt.json
+++ b/Core/RogueTechCore/Contracts/defendbase/5/DefendBase_TitanAttack_Alt.json
@@ -45,6 +45,16 @@
           "op": "Equal",
           "val": 0,
           "valueConstant": null
+        }
+      ]
+    },
+    {
+      "Scope": "Company",
+      "RequirementComparisons": [
+        {
+          "obj": "DCE-CurrentDifficulty",
+          "op": "GreaterThanOrEqual",
+          "val": 8
         },
         {
           "obj": "MissionsComplete",

--- a/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ClashOfTitans.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ClashOfTitans.json
@@ -45,6 +45,16 @@
           "op": "Equal",
           "val": 0,
           "valueConstant": null
+        }
+      ]
+    },
+    {
+      "Scope": "Company",
+      "RequirementComparisons": [
+        {
+          "obj": "DCE-CurrentDifficulty",
+          "op": "GreaterThanOrEqual",
+          "val": 8
         },
         {
           "obj": "MissionsComplete",


### PR DESCRIPTION
`MissionsComplete` is not a star system requirement, fixed that.
Added requirement for reasonably high current difficulty so that you can't get a very low difficulty version of it when playing with diff variance.

Contract is valid at d5 -> company/planet at d3, +-2 variance (default) -> contract is valid for spawning -> variance can roll it to d1 (3 base - 2 variance), no good.

Also limits them to top end difficulties of medium contracts which is still quite a bit earlier than when you would see assaults otherwise