### PR TITLE
Revert "Release prep" to re-enable raycast physics

### DIFF
--- a/Core/CustomAmmoCategories/CustomAmmoCategoriesSettings.json
+++ b/Core/CustomAmmoCategories/CustomAmmoCategoriesSettings.json
@@ -355,10 +355,10 @@
 	"AIPathingOptimization": true,
 	"AIPathingSamplesLimit": 120,
 	"AIPathingMultithread": false,
-	"PhysicsAoE_Weapons": false,
-	"PhysicsAoE_Deffered": false,
-	"PhysicsAoE_Minefield": false,
-	"PhysicsAoE_API": false,
+	"PhysicsAoE_Weapons": true,
+	"PhysicsAoE_Deffered": true,
+	"PhysicsAoE_Minefield": true,
+	"PhysicsAoE_API": true,
 	"RemoveToHitModifiers": [
 		"DAMAGED"
 	],


### PR DESCRIPTION
This reverts commit 32444c5279d7ef041a881f207a2ccaed920c853e.