### PR TITLE
Fix company diff oopsie

### DIFF
--- a/InstallOptions/GlobalDifficulty/GlobalDifficultyByCompany/settings.json
+++ b/InstallOptions/GlobalDifficulty/GlobalDifficultyByCompany/settings.json
@@ -1,4 +1,4 @@
 {
   "diffMode" : "Company",
-  "valuePerHalfSkull" : 13500000,
+  "valuePerHalfSkull" : 10000000,
 }


### PR DESCRIPTION
I could've sworn I changed both places but apparently I only did the default in dropcosts enhanced config.
Only planet diff was working as intended.
Should help people who have had trouble progressing up the ranks