### PR TITLE
Fix #2 Jelly VA

### DIFF
--- a/Core/CustomVoices/voicepacks/JellyRoll.json
+++ b/Core/CustomVoices/voicepacks/JellyRoll.json
@@ -1,5 +1,5 @@
 {
-  "name": "JellyRoll",
+  "name": "Jelly",
   "vobank": "",
   "uiname": "JellyRoll",
   "baseVoice": "m_bear01",

--- a/InstallOptions/Pilots/RtoLegends/pilot/pilot_JellyRoll.json
+++ b/InstallOptions/Pilots/RtoLegends/pilot/pilot_JellyRoll.json
@@ -26,7 +26,7 @@
   "LethalInjury": false,
   "Incapacitated": false,
   "Morale": 0,
-  "Voice": "JellyRoll",
+  "Voice": "Jelly",
   "abilityDefNames": [],
   "AIPersonality": "Undefined",
   "PilotTags": {


### PR DESCRIPTION
Reverts previous fix as this will not apply to pilots hired before the fix.

In order to make this work for all Jelly pilots, the voicepack JSON needs to match the original incorrect pilot JSON.

Future options are either to:

- Leave this fix as is and live with the fuck-up, or
- Create a duplicate voicepack JSON with the correct `name` field and update the pilot JSON to use that one, while still leaving the old, incorrect version intact for legacy support.