### PR TITLE
Fix Loaner Squads

### DIFF
--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Hardened_Plates.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Hardened_Plates.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Hardened Plates",
-        "decription": "-3% Damage Taken, TAC Immune",
+        "decription": "-3% Damage Taken, +25% TAD Resist",
         "affinities": [],
         "effectData": [
           {
@@ -30,7 +30,7 @@
             "Description": {
               "Id": "Affinity-Quirk-HardenedPlates-DamageReduction",
               "Name": "Quirk Affinity Hardened Plates: Decreased Damage Taken",
-              "Details": "All incoming damage reduced by 20%.",
+              "Details": "All incoming damage reduced by 3%.",
               "Icon": "uixSvgIcon_action_end"
             },
             "statisticData": {
@@ -38,31 +38,6 @@
               "operation": "Float_Multiply",
               "modValue": "0.97",
               "modType": "System.Single"
-            }
-          },
-          {
-            "durationData": {
-              "duration": -1,
-              "stackLimit": -1
-            },
-            "targetingData": {
-              "effectTriggerType": "Passive",
-              "effectTargetType": "Creator",
-              "showInStatusPanel": false
-            },
-            "effectType": "StatisticEffect",
-            "nature": "Buff",
-            "Description": {
-              "Id": "Affinity-Quirk-HardenedPlates-TACImmune",
-              "Name": "Quirk Affinity Hardened Plates: TAC Immune",
-              "Details": "MORE SPEED.",
-              "Icon": "uixSvgIcon_run_n_gun"
-            },
-            "statisticData": {
-              "statName": "CACAPProtection",
-              "operation": "Set",
-              "modValue": "true",
-              "modType": "System.Boolean"
             }
           },
           {
@@ -82,13 +57,38 @@
             "Description": {
               "Id": "Affinity-Quirk-HardenedPlates-AoEDamageTaken",
               "Name": "Quirk Affinity Hardened Plates: Decreased AoE Damage Taken",
-              "Details": "All incoming damage reduced by 20%.",
+              "Details": "All incoming damage reduced by 3%.",
               "Icon": "uixSvgIcon_action_end"
             },
             "statisticData": {
               "statName": "CACAoEDamageMult",
               "operation": "Float_Multiply",
               "modValue": "0.97",
+              "modType": "System.Single"
+            }
+          },
+          {
+            "durationData": {
+              "duration": -1,
+              "stackLimit": -1
+            },
+            "targetingData": {
+              "effectTriggerType": "Passive",
+              "effectTargetType": "Creator",
+              "showInStatusPanel": false
+            },
+            "effectType": "StatisticEffect",
+            "nature": "Buff",
+            "Description": {
+              "Id": "Affinity-Quirk-HardenedPlates-APDamageTaken",
+              "Name": "Quirk Affinity Hardened Plates: Decreased AP Damage",
+              "Details": "Incoming AP damage reduced by 25%",
+              "Icon": "uixSvgIcon_action_end"
+            },
+            "statisticData": {
+              "statName": "CACAPDamageMult",
+              "operation": "Float_Multiply",
+              "modValue": "0.75",
               "modType": "System.Single"
             }
           }

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Resilience.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Resilience.json
@@ -35,7 +35,7 @@
             "statisticData": {
               "statName": "CriticalHitChanceReceivedMultiplier",
               "operation": "Float_Multiply",
-              "modValue": "0.4",
+              "modValue": "0.6",
               "modType": "System.Single"
             }
           }

--- a/Core/RogueModuleTech/AddOn/JumpJet/Special_AddOn_JumpBooster_1.json
+++ b/Core/RogueModuleTech/AddOn/JumpJet/Special_AddOn_JumpBooster_1.json
@@ -12,11 +12,11 @@
       }
     ],
     "BonusDescriptions": [
-      "Special: 10%",
+      "Special: 20%",
       "JumpCapacity: 1",
       "JumpHeat: 4",
-      "Visibility: +4%",
-      "Signature: +4%"
+      "Visibility: +8%",
+      "Signature: +8%"
     ],
     "Flags": [
       "not_broken"
@@ -24,7 +24,7 @@
     "IBLS": {
       "StorageSize": 1
     },
-    "CarryLeftOverUsageLeftOverTopOffFactor": 0.1
+    "CarryLeftOverUsageLeftOverTopOffFactor": 0.2
   },
   "Description": {
     "Cost": 110000,
@@ -35,7 +35,7 @@
     "UIName": "Jump Booster Pack 1",
     "Id": "Special_AddOn_JumpBooster_1",
     "Name": "Jump Booster",
-    "Details": "A Jump Booster can be added externally to Any Mech weight and jump capacity Permitting.",
+    "Details": "Essentially an externally-carried rocket pack, Jump Boosters are a bulky but effective way to enhance a 'Mech's jump capabilities.",
     "Icon": "jetpack"
   },
   "JumpCapacity": 1,
@@ -101,7 +101,7 @@
       "statisticData": {
         "statName": "SensorSignatureModifier",
         "operation": "Float_Multiply",
-        "modValue": "1.04",
+        "modValue": "1.08",
         "modType": "System.Single"
       }
     },
@@ -127,7 +127,7 @@
       "statisticData": {
         "statName": "SpottingVisibilityMultiplier",
         "operation": "Float_Multiply",
-        "modValue": "1.04",
+        "modValue": "1.08",
         "modType": "System.Single"
       }
     }

--- a/Core/RogueModuleTech/AddOn/JumpJet/Special_AddOn_JumpBooster_2.json
+++ b/Core/RogueModuleTech/AddOn/JumpJet/Special_AddOn_JumpBooster_2.json
@@ -12,11 +12,11 @@
       }
     ],
     "BonusDescriptions": [
-      "Special: 20%",
+      "Special: 40%",
       "JumpCapacity: 2",
       "JumpHeat: 5",
-      "Visibility: +8%",
-      "Signature: +8%"
+      "Visibility: +16%",
+      "Signature: +16%"
     ],
     "Flags": [
       "not_broken"
@@ -24,10 +24,10 @@
     "IBLS": {
       "StorageSize": 1
     },
-    "CarryLeftOverUsageLeftOverTopOffFactor": 0.2
+    "CarryLeftOverUsageLeftOverTopOffFactor": 0.4
   },
   "Description": {
-    "Cost": 220000,
+    "Cost": 330000,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "Generic",
@@ -35,7 +35,7 @@
     "UIName": "Jump Booster Pack 2",
     "Id": "Special_AddOn_JumpBooster_2",
     "Name": "Jump Booster",
-    "Details": "A Jump Booster can be added externally to Any Mech weight and jump capacity Permitting.",
+    "Details": "Essentially an externally-carried rocket pack, Jump Boosters are a bulky but effective way to enhance a 'Mech's jump capabilities.",
     "Icon": "jetpack"
   },
   "JumpCapacity": 2,
@@ -101,7 +101,7 @@
       "statisticData": {
         "statName": "SensorSignatureModifier",
         "operation": "Float_Multiply",
-        "modValue": "1.08",
+        "modValue": "1.16",
         "modType": "System.Single"
       }
     },
@@ -127,7 +127,7 @@
       "statisticData": {
         "statName": "SpottingVisibilityMultiplier",
         "operation": "Float_Multiply",
-        "modValue": "1.08",
+        "modValue": "1.16",
         "modType": "System.Single"
       }
     }

--- a/Core/RogueModuleTech/AddOn/JumpJet/Special_AddOn_JumpBooster_3.json
+++ b/Core/RogueModuleTech/AddOn/JumpJet/Special_AddOn_JumpBooster_3.json
@@ -12,11 +12,11 @@
       }
     ],
     "BonusDescriptions": [
-      "Special: 30%",
+      "Special: 60%",
       "JumpCapacity: 3",
       "JumpHeat: 6",
-      "Visibility: +12%",
-      "Signature: +12%"
+      "Visibility: +24%",
+      "Signature: +24%"
     ],
     "Flags": [
       "not_broken"
@@ -24,10 +24,10 @@
     "IBLS": {
       "StorageSize": 1
     },
-    "CarryLeftOverUsageLeftOverTopOffFactor": 0.3
+    "CarryLeftOverUsageLeftOverTopOffFactor": 0.6
   },
   "Description": {
-    "Cost": 550000,
+    "Cost": 660000,
     "Rarity": 0,
     "Purchasable": true,
     "Manufacturer": "Generic",
@@ -35,7 +35,7 @@
     "UIName": "Jump Booster Pack 3",
     "Id": "Special_AddOn_JumpBooster_3",
     "Name": "Jump Booster",
-    "Details": "A Jump Booster can be added externally to Any Mech weight and jump capacity Permitting.",
+    "Details": "Essentially an externally-carried rocket pack, Jump Boosters are a bulky but effective way to enhance a 'Mech's jump capabilities.",
     "Icon": "jetpack"
   },
   "JumpCapacity": 3,
@@ -101,7 +101,7 @@
       "statisticData": {
         "statName": "SensorSignatureModifier",
         "operation": "Float_Multiply",
-        "modValue": "1.12",
+        "modValue": "1.24",
         "modType": "System.Single"
       }
     },
@@ -127,7 +127,7 @@
       "statisticData": {
         "statName": "SpottingVisibilityMultiplier",
         "operation": "Float_Multiply",
-        "modValue": "1.12",
+        "modValue": "1.24",
         "modType": "System.Single"
       }
     }

--- a/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam.json
+++ b/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam.json
@@ -811,6 +811,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -853,6 +855,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -895,6 +899,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"

--- a/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam.json
+++ b/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam.json
@@ -812,7 +812,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -856,7 +855,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -900,7 +898,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"

--- a/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam_Alt.json
+++ b/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam_Alt.json
@@ -875,6 +875,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -917,6 +919,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -959,6 +963,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"

--- a/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam_Alt.json
+++ b/Core/RogueTechCore/Contracts/capturebase/2/CaptureBase_TheBTeam_Alt.json
@@ -876,7 +876,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -920,7 +919,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"
@@ -964,7 +962,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_legendary",
                 "unit_killteam"

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_ALT_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_ALT_NEW.json
@@ -3506,7 +3506,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_light",
                 "unit_medium",
                 "unit_skycrane",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_ALT_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_ALT_NEW.json
@@ -3505,6 +3505,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_light",
                 "unit_medium",
                 "unit_skycrane",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_NEW.json
@@ -3506,7 +3506,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_light",
                 "unit_medium",
                 "unit_skycrane",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_VTOL_2_NEW.json
@@ -3505,6 +3505,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_light",
                 "unit_medium",
                 "unit_skycrane",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_2_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_2_NEW.json
@@ -3642,7 +3642,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_assault",
                 "unit_heavy",
                 "unit_primitive",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_2_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_2_NEW.json
@@ -3641,6 +3641,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_assault",
                 "unit_heavy",
                 "unit_primitive",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_5_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_5_NEW.json
@@ -3642,7 +3642,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_assault",
                 "unit_light",
                 "unit_primitive",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_5_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_5_NEW.json
@@ -3641,6 +3641,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_assault",
                 "unit_light",
                 "unit_primitive",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_8_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_8_NEW.json
@@ -3641,6 +3641,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_medium",
                 "unit_light",
                 "unit_primitive",

--- a/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_8_NEW.json
+++ b/Core/RogueTechCore/Contracts/testdrive/ThreeWayBattle_TestDrive_Wildcard_8_NEW.json
@@ -3642,7 +3642,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_medium",
                 "unit_light",
                 "unit_primitive",

--- a/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay.json
@@ -3584,7 +3584,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_heavy",
                 "unit_assault",
@@ -3631,7 +3630,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_heavy",
                 "unit_assault",
@@ -3678,7 +3676,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_heavy",
                 "unit_assault",

--- a/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay.json
@@ -3582,8 +3582,9 @@
             },
             "unitExcludedTagSet": {
               "items": [
-                "unit_battlearmor",
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_heavy",
                 "unit_assault",
@@ -3628,8 +3629,9 @@
             },
             "unitExcludedTagSet": {
               "items": [
-                "unit_battlearmor",
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_heavy",
                 "unit_assault",
@@ -3674,8 +3676,9 @@
             },
             "unitExcludedTagSet": {
               "items": [
-                "unit_battlearmor",
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_heavy",
                 "unit_assault",

--- a/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt.json
@@ -3647,8 +3647,9 @@
             },
             "unitExcludedTagSet": {
               "items": [
-                "unit_battlearmor",
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_assault",
                 "unit_elite",
@@ -3693,8 +3694,9 @@
             },
             "unitExcludedTagSet": {
               "items": [
-                "unit_battlearmor",
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_assault",
                 "unit_elite",
@@ -3739,8 +3741,9 @@
             },
             "unitExcludedTagSet": {
               "items": [
-                "unit_battlearmor",
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_assault",
                 "unit_elite",

--- a/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt.json
@@ -3649,7 +3649,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_assault",
                 "unit_elite",
@@ -3696,7 +3695,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_assault",
                 "unit_elite",
@@ -3743,7 +3741,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_bracket_high",
                 "unit_assault",
                 "unit_elite",

--- a/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt_2.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt_2.json
@@ -3621,7 +3621,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"
@@ -3661,7 +3660,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"
@@ -3701,7 +3699,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt_2.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/2/ThreeWayBattle_TrainingDay_Alt_2.json
@@ -3620,6 +3620,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"
@@ -3658,6 +3660,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"
@@ -3696,6 +3700,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_killteam"
               ],
               "tagSetSourceFile": "tags/UnitTags"

--- a/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ShowTheFlag_Alt.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ShowTheFlag_Alt.json
@@ -3694,6 +3694,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_light",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_assault",
                 "unit_killteam"
               ],

--- a/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ShowTheFlag_Alt.json
+++ b/Core/RogueTechCore/Contracts/threewaybattle/5/ThreeWayBattle_ShowTheFlag_Alt.json
@@ -3695,7 +3695,6 @@
               "items": [
                 "unit_light",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_assault",
                 "unit_killteam"
               ],

--- a/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_assassinate.json
+++ b/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_assassinate.json
@@ -597,7 +597,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_quadvee",
@@ -641,7 +640,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_unique",
                 "unit_elite",
                 "unit_quadvee",
@@ -685,7 +683,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_unique",
                 "unit_elite",
                 "unit_quadvee",
@@ -729,7 +726,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_quadvee",

--- a/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_assassinate.json
+++ b/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_assassinate.json
@@ -596,6 +596,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_quadvee",
@@ -638,6 +640,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_unique",
                 "unit_elite",
                 "unit_quadvee",
@@ -680,6 +684,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_unique",
                 "unit_elite",
                 "unit_quadvee",
@@ -722,6 +728,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_quadvee",

--- a/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_defendBase.json
+++ b/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_defendBase.json
@@ -776,7 +776,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_killteam"
@@ -818,7 +817,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_light",
                 "unit_elite",
@@ -863,7 +861,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_killteam"
@@ -905,7 +902,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_light",
                 "unit_assault",

--- a/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_defendBase.json
+++ b/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_defendBase.json
@@ -775,6 +775,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_killteam"
@@ -815,6 +817,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_light",
                 "unit_elite",
@@ -858,6 +862,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_killteam"
@@ -898,6 +904,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_light",
                 "unit_assault",

--- a/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_simpleBattle1.json
+++ b/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_simpleBattle1.json
@@ -314,7 +314,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_killteam"
@@ -357,7 +356,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_elite",
                 "unit_unique",
@@ -400,7 +398,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_heavy",
                 "unit_elite",
@@ -444,7 +441,6 @@
               "items": [
                 "unit_reqni",
                 "unit_squad",
-                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_assault",
                 "unit_light",

--- a/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_simpleBattle1.json
+++ b/DLC/RogueFlashPointModule/contract/TestDrive/c_fp_testdrive_simpleBattle1.json
@@ -313,6 +313,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_elite",
                 "unit_unique",
                 "unit_killteam"
@@ -354,6 +356,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_elite",
                 "unit_unique",
@@ -395,6 +399,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_heavy",
                 "unit_elite",
@@ -437,6 +443,8 @@
             "unitExcludedTagSet": {
               "items": [
                 "unit_reqni",
+                "unit_squad",
+                "unit_battlearmor",
                 "unit_superheavy_mech",
                 "unit_assault",
                 "unit_light",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_vindicator_VND-5L.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_vindicator_VND-5L.json
@@ -7,34 +7,7 @@
       "PrefabID": "vindicator",
       "Exclude": false,
       "Include": true
-    },
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialMelee",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "LeftArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "LeftArm",
-        "DefID": "Default_HandHeld_Melee_Sword_4tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialMelee",
-          "HandHeld"
-        ]
-      }
-    ]
+    }
   },
   "CustomParts": {
     "CustomParts": []

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_crosscut_ED-X2M.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_crosscut_ED-X2M.json
@@ -7,7 +7,6 @@
       "unit_bracket_low",
       "unit_industrial",
       "unit_lance_vanguard",
-      "unit_jumpOK",
       "unit_melee",
       "unit_core",
       "unit_era_clan_invasion",
@@ -145,8 +144,8 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Special_AddOn_JumpBooster_3",
-      "ComponentDefType": "JumpJet",
+      "ComponentDefID": "Special_AddOn_ThermalVision_Mk1",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_vindicator_VND-5L.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_vindicator_VND-5L.json
@@ -155,6 +155,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_Sword_4tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_Actuator_Arm_Lower_Melee",
       "ComponentDefType": "Upgrade",

--- a/Optionals/PirateTech/Base/mech/mechdef_annihilator_ANH-GZ.json
+++ b/Optionals/PirateTech/Base/mech/mechdef_annihilator_ANH-GZ.json
@@ -11,7 +11,6 @@
       "unit_lance_assassin",
       "unit_reqni",
       "unit_pirate",
-      "unit_jumpOK",
       "unit_optional_pirate_tech",
       "unit_release",
       "unit_chassis_anni-gojira",
@@ -208,8 +207,8 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Special_AddOn_JumpBooster_2",
-      "ComponentDefType": "JumpJet",
+      "ComponentDefID": "Special_AddOn_NightVision",
+      "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
@@ -228,6 +227,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "HandHeld_Weapon_PlasmaTorch",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Weapon_Gauss_Heavy_Snubnose",
       "ComponentDefType": "Weapon",
@@ -237,6 +243,13 @@
     {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "Weapon_Gauss_Heavy_Snubnose",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "HandHeld_Weapon_PlasmaTorch",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"

--- a/Optionals/PirateTech/Base/mech/mechdef_mackie_MSK-L10-J0N.json
+++ b/Optionals/PirateTech/Base/mech/mechdef_mackie_MSK-L10-J0N.json
@@ -208,7 +208,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Special_AddOn_JumpBooster_3",
+      "ComponentDefID": "Special_AddOn_JumpBooster_1",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/PirateTech/HeavyMetal/mech/mechdef_phoenixhawk_PXH-SHIV.json
+++ b/Optionals/PirateTech/HeavyMetal/mech/mechdef_phoenixhawk_PXH-SHIV.json
@@ -131,10 +131,10 @@
   "Locations": [
     {
       "Location": "Head",
-      "CurrentArmor": 45,
+      "CurrentArmor": 44,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 16,
-      "AssignedArmor": 45,
+      "AssignedArmor": 44,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
@@ -149,29 +149,29 @@
     },
     {
       "Location": "LeftTorso",
-      "CurrentArmor": 110,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 110,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 140,
+      "CurrentArmor": 120,
       "CurrentRearArmor": 45,
       "CurrentInternalStructure": 70,
-      "AssignedArmor": 140,
+      "AssignedArmor": 120,
       "AssignedRearArmor": 45,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightTorso",
-      "CurrentArmor": 110,
-      "CurrentRearArmor": 45,
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 40,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 110,
-      "AssignedRearArmor": 45,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 40,
       "DamageLevel": "Functional"
     },
     {
@@ -185,19 +185,19 @@
     },
     {
       "Location": "LeftLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 90,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 110,
+      "AssignedArmor": 90,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     },
     {
       "Location": "RightLeg",
-      "CurrentArmor": 110,
+      "CurrentArmor": 90,
       "CurrentRearArmor": 0,
       "CurrentInternalStructure": 55,
-      "AssignedArmor": 110,
+      "AssignedArmor": 90,
       "AssignedRearArmor": 0,
       "DamageLevel": "Functional"
     }
@@ -324,7 +324,7 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Special_AddOn_JumpBooster_3",
+      "ComponentDefID": "Special_AddOn_JumpBooster_1",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -387,7 +387,21 @@
     },
     {
       "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_JumpJet_Standard_LegUpper",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
       "ComponentDefID": "Gear_JumpJet_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_JumpJet_Standard_LegUpper",
       "ComponentDefType": "JumpJet",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/QuicksellCustoms/Mech/mechdef_corgi_CRG-CB.json
+++ b/Optionals/QuicksellCustoms/Mech/mechdef_corgi_CRG-CB.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_rare",
       "unit_squad",
       "unit_mech_squad",

--- a/Optionals/Quicsell/Mech/mechdef_clint_CLNT-QS3.json
+++ b/Optionals/Quicsell/Mech/mechdef_clint_CLNT-QS3.json
@@ -190,7 +190,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "BoltOn_Weapon_Rocket_10_x3",
+      "ComponentDefID": "BoltOn_Weapon_Rocket_10_x2",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"

--- a/Optionals/RogueElites/Base/chassis/chassisdef_super_griffin_GRF-3-X.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_super_griffin_GRF-3-X.json
@@ -7,34 +7,7 @@
       "PrefabID": "SuperGriffin",
       "Exclude": false,
       "Include": true
-    },
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialMelee",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Melee_VibroSword_9tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialMelee",
-          "HandHeld"
-        ]
-      }
-    ]
+    }
   },
   "CustomParts": {
     "CustomParts": []

--- a/Optionals/RogueElites/Base/mech/mechdef_hollander_ii_BZK-S7.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_hollander_ii_BZK-S7.json
@@ -310,7 +310,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "BoltOn_Weapon_AMS",
+      "ComponentDefID": "BoltOn_Weapon_AMS_Flare",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"

--- a/Optionals/RogueElites/Base/mech/mechdef_kingcrab_KGC-B.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_kingcrab_KGC-B.json
@@ -228,7 +228,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "BoltOn_Weapon_Rocket_20_Tandem_x3",
+      "ComponentDefID": "BoltOn_Weapon_Rocket_20_Tandem_x2",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"

--- a/Optionals/RogueElites/Base/mech/mechdef_super_griffin_GRF-3-X.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_super_griffin_GRF-3-X.json
@@ -253,6 +253,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_VibroSword_9tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Ammo_AmmunitionBox_SRM_MagPulse",
       "ComponentDefType": "AmmunitionBox",

--- a/Optionals/RogueElites/Base/mech/mechdef_super_griffin_GRF-3-X.json
+++ b/Optionals/RogueElites/Base/mech/mechdef_super_griffin_GRF-3-X.json
@@ -81,10 +81,10 @@
     },
     {
       "Location": "CenterTorso",
-      "CurrentArmor": 200,
+      "CurrentArmor": 180,
       "CurrentRearArmor": 85,
       "CurrentInternalStructure": 100,
-      "AssignedArmor": 200,
+      "AssignedArmor": 180,
       "AssignedRearArmor": 85,
       "DamageLevel": "Functional"
     },
@@ -254,6 +254,20 @@
     },
     {
       "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Actuator_Arm_Lower_Melee_Weapon",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Actuator_GrippyHand",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "Lootable_HandHeld_Melee_VibroSword_9tons",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -305,13 +319,6 @@
       "MountedLocation": "RightLeg",
       "ComponentDefID": "Gear_JumpJet_Heavy_Improved",
       "ComponentDefType": "JumpJet",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_HeatSink_Prototype",
-      "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },

--- a/Optionals/RogueElites/Flashpoint/chassis/chassisdef_crab_CRB-27-H.json
+++ b/Optionals/RogueElites/Flashpoint/chassis/chassisdef_crab_CRB-27-H.json
@@ -19,56 +19,6 @@
           }
         ]
       }
-    ],
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "LeftArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      },
-      {
-        "CategoryID": "SpecialMelee",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "LeftArm",
-        "DefID": "Default_HandHeld_Shield_5tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      },
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Melee_Sword_5tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialMelee",
-          "HandHeld"
-        ]
-      }
     ]
   },
   "CustomParts": {

--- a/Optionals/RogueElites/Flashpoint/mech/mechdef_crab_CRB-27-H.json
+++ b/Optionals/RogueElites/Flashpoint/mech/mechdef_crab_CRB-27-H.json
@@ -160,6 +160,14 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_5tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_AdvancedMaterials2",
       "ComponentDefType": "Upgrade",
@@ -218,6 +226,14 @@
     {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_HarJel",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_Sword_5tons",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,

--- a/Optionals/RogueElites/RISC/mech/mechdef_assassin_ii_ASNII-KU.json
+++ b/Optionals/RogueElites/RISC/mech/mechdef_assassin_ii_ASNII-KU.json
@@ -269,7 +269,7 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Special_AddOn_AdvancedOptics_Mk3",
+      "ComponentDefID": "Special_AddOn_AdvancedOptics_Mk1",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": false,


### PR DESCRIPTION
- Remove squads from loaner mech selections
- Replace default handhelds with lootable versions on VND-5L, GRF-3-X, CRB-27-H
- Rugged/Easy To Maintain Quirk Affinities: Replace TAD-immunity 25% TAD resist
- Increase jump booster pack weight +100% (sorry)
- Fix Resilience affinity to work as stated