### PR TITLE
Reorganisation of Loading Tips

### DIFF
--- a/Core/RogueTechCore/GameTips/general.txt
+++ b/Core/RogueTechCore/GameTips/general.txt
@@ -1,170 +1,24 @@
 Look for ways to make your units and company cheaper without losing much effectiveness.
 Sometimes fancy tech is a lot of money for a small improvement.
-If your 'Mech is invalid, you can hit the "Confirm" button to see what issues it has.
-Switch between your equipped ammunition types by clicking on the name of your current ammunition in the 'Mech's weapon panel.
-Vehicles take each point of heat damage as two points of normal damage.
-Most AFVs have heavily armored fronts, but weaker sides and rear.
-Tanks and VTOLs are more vulnerable to Through Armor Criticals than 'Mechs.
-Every Important Information on item is either in the Traits or Brightly Coloured.
-PPC Weapon hits clear nearby landmines.
-Many high explosive weapons with AOE clear nearby landmines.
-Fire may damage or destroy landmines. Inferno mines are immune.
-Machine Guns, Flamers and Small Pulse lasers get bonuses vs Power Armor Squads.
-Through Armor Criticals are defined by Weapons; a Gauss slug can punch through the thickest of hides but a Laser only melts the surface.
-Putting your cursor over your weapons will show you exactly why you can't hit the flanking stealthed light hiding on a forest hill.
-Can't Headshot a moving target with Offensive Push? Try to find a Headshot Capable FCS or BC Headshot.
-You cannot Multi-Target Stealthed Units.
-You cannot Offensive Push a unit if you have No Visual.
-Evasion pips don't go away when you shoot at a target. 
-TAB can be used to toggle between Targets.
-Press V to cycle between available melee Targets.
-Mouseover the Cybereye in your 'Mech's status panel to see your sensor rolls.
-The colored dots on the ground show different types of terrain.
-Movement - Holding Left Alt: This lets you see the movement nodes around your cursor.
-Combat - Ctrl + T: Enable/Disable attack direction indicators.
-Combat - With Attack Ground selected, hold Left Alt: Allows you to friendly fire allied units. Note: you do not receive salvage for allied units.
-Combat - Hold Ctrl while dismounting a building with Battle Armor: When you click dismount, the BA will now dismount to the roof.
-Weapon Panel - Left Ctrl + Click Ammo Column: Ejects ammo and/or Drops Hand Held and Wing Mounted Weapons
-Weapon Panel - Left Shift + Click Weapon Name: Enable/Disable all weapons with the same name.
-Weapon Panel - Left Shift + Click Ammo Type: Sync ammo for all weapons with the same name.
-Weapon Panel - Left Shift + Click Fire Mode: Sync mode for all weapons with the same name.
-Ctrl + Brace Button: Will open dialogue to enable/disable individual heat sinks.
-In Combat: Ctrl + A toggles visibility of ECM and other Auras.
-Mechlab - Ctrl + Strip Equip: Will only strip weapons and ammo.
-Drop Screen - Click on a unit in a drop slot, the pilot list will reorganize to show characters with the highest affinity for that unit.
-Press Ctrl-Shift-U to toggle the game UI for better views of your units in the mechbay, or for screenshots.
-Putting your units in AA Stance can stop an Airstrike strafing run happening. They don't have to be inside the smoke marking the area to be strafed.
-Tracked, Wheeled and Hover vehicles all handle terrain differently.
-VTOL, Hover, Wheeled and Tracked vehicle have different bonuses. Check the Motive System item in their Inventory.
-High mobility units makes it easier to play objectives rather than slugging it out with every last enemy on the field.
-Shooting makes you twice as easy to detect. If you want to hide a unit move it out of sight and don't fire.
-Take light fast units off the field whenever you get the chance even if they are lightly armed. It will pay off later. They won't flee, flank or charge.
 READ THE WIKI!
-Some VTOL carry powerful bombs, watch out for the big ones!
-Hover tanks have trouble going up and down steep hills.
-Hover tanks treat water as roads!
-Tracked vehicles can go up steeper hills than any other ground unit except infantry.
-Wheeled vehicles move best on roads and in cities.
-If one of your pilots is panicking try to keep them from getting hit for a couple turns until they calm down.
-A unit carrying a Command Console, Communications Gear, or C3 equipment can buff all your units on the field.
-If your MechWarrior got a bad sensor roll; consider cooling down, using a Sensor ping, or guarding this turn rather than taking bad shots.
-It's hard to aim on the move! Your pilots may have trouble hitting a target while moving, especially when sprinting!
-While jump jets increase the chance of evading enemy fire, they also reduce your weapon accuracy.
-If you have trouble moving around and laying traps, try jump jets and enjoy a whole new dimension of freedom.
-Be careful about hugging enemies, or you just might end up shooting your own units in the back. Or your allies might do it for you.
-Positioning is key. Take the high ground or dig in deep.
-Upgrade the Argo! Don't scoff at morale upgrades or ignore your Mechtechs.
-Choose MechWarriors who work well as a team and complement each other's skills.
-Equipment is key. A well-equipped Light can kill a poorly equipped Assault.
-Instability removes Evasion AND Guarded! Perfect for a follow up volley.
-You can have up to three repair bays working simultaneously with Argo upgrades, and at 100% efficiency to boot!
-Ammo explodes. Don't have too much of it. Also, don't run out of ammo. But you do you, chief.
-Untrained MechWarriors are more likely to panic. Punch through their armor to make them reach for that Eject button. 
-Scare your enemy into bailing out! Destroying their allies, flanking, and reducing their offensive capability all lead to panic.
-The danger zones in a DropShip landing area are no joke, no matter what your fellow MechWarriors told you.
-Plan your lance according to the range & strategy you intend to use.
-A 'Mech needs an engine core to function.
-Clan XL engines and Light engines can survive the loss of one torso.
-An IS XL engine will save a lot of weight, but if you lose a Torso Side, you lose the 'Mech.
-Bring some Streaks or pulse lasers to deal with those pesky Lights!
-Watch your heat. Riding the redline will slow you down or blow you sky high.
-Riding the redline is dangerous... but oh so fun.
-If you ever want to progress, you may need to punch above your lance's weight!
-Choose your contracts carefully and you can get yourself some great salvage!
-Hitting an already overheated enemy with flamers or heat-generating weapons gives bonus damage!
-Buildings burn well. Buildings burn very well.
-It's harder for your pilots to see when it's dark or foggy.
-Trees are decent ablative armor, until they get set on fire.
-Double Heat Sinks (DHS) require a DHS Kit, which can be installed in the cooling slot.
-Repair costs of armor varies depending on type and Mechtech level.
-Primitive Armour is cheap and easy to maintain. Hardened plates, not so much.
-Read your ECM's Traits to see how it protects you and / or your Lancemates and Allies
-Active Probes boost your sensor check, improving the information you see about enemies at longer ranges.
-Stealth makes you harder to detect. It also provides a range based defense as well as extra defense the less you move!
-Narcs attach to a unit, providing visibility beyond sensor range and increased accuracy! This is opposed by enemy ECM, and lasts for a short duration.
-Tags increase your sensor check for tagged units, but this bonus degrades as they move from the position they were originally tagged.
-IFF jammers add a penalty to enemy sensor check's against a unit, making it harder to detect.
-Melee combat in RogueTech is dramatically more difficult to start with, but a specialized melee 'Mech is a nightmare.
-Railguns and Gauss rifles deal tremendous damage at equally tremendous ranges. Reach out and touch someone.
-Killing Rocket Launcher units before they blow their load is tactically advisable.
-Attacks against the side and rear of a target have an increased chance to hit.
-Overheating 'Mechs in RogueTech do not suffer structure damage, but do suffer penalties and their ammunition bins have a chance to explode.
-"How do you pronounce HHR? HHHHHuuuhhhhrrrrr." - Unknown (not really, it was Dan)
-Anti-Missile Systems (AMS) will intercept missiles fired at the 'Mech using them. Advanced models even intercept enemy missiles in a radius around the 'Mech.
-C.A.S.E. PROTECTS! C.A.S.E. IS LIFE!
-C.A.S.E. greatly reduces damage from ammunition explosions. Like a condom or fire extinguisher, it is often better to have and not need, than need and not have.
-A Gausszilla is only as dangerous as the local geography is flat. Careful positioning defeats mad courage every time.
-After a forest tile has been burned, it offers no cover and negatively affects the stability of BattleMechs standing on it.
-90% to hit is still 10% to miss. Dice don't follow your expectations.
-Friendly Fire isn't very friendly. Don't put your 'Mechs in the line of fire.
-Pyrrhic victories are for idealists.  You're a Merc: if the repairs are going to cost more than you're getting paid you should have left already.
-Talk to Sumire to arrange Aerospace Fighter cover for the Leopard while you withdraw.
-Use Shift + Click on Armor adjustment for single point changes to your armor.
-Big weapons are scary, but if you can't land shots, they won't do any good! Try using many smaller weapons instead to increase your effectiveness with more inexperienced pilots.
-Quantity over quality! Being able to fire multiple medium lasers with proper heat management will be worth more than that single large laser that might not even hit.
-ER Lasers have much longer range than their standard siblings, but build up significantly more heat!
-The Argo's Mechbay upgrades let you work on more than one unit at a time.
+Mouse Over All The Things! - Roguetech has many tooltips and pop-up info panels.
+Never half ass two things, whole ass one thing.
+Loading Tip: Did you know these loading screens contain tips?
 If this keeps spinning freely, it may have soft-locked. Please visit our Discord to submit a ticket before restarting.
 If the loading wheel isn't spinning, it probably hasn't crashed.
 RogueTech is the story of your little company surviving the harsh life of a Merc.
-Basic components that come with a 'Mech like the default cockpit and gyro are easy to come by and replace. Don't worry if they blow up! They'll be replaced when the 'Mech is repaired.
+Losing is fun!
 Beware of the S.H.I.T.S. : Severe Hazardous Irritable Taco Syndrome
-If it's stupid and it works, it's still stupid but you got lucky.
-If brute force isn't working, you aren't using enough of it.
-The key to negotiating with Mercs is convincing them that the compromise they agreed on is no compromise at all.
+You will stop procrastinating. Later.
+The key to negotiating with mercenaries is convincing them that the compromise they agreed on is no compromise at all.
 SPEED IS LIFE, GO SLOW? YOU DIE.
-Stack the odds in your favor! Take precision or Artemis ammo, equip targeting computers, and fire TAGs to drastically increase your chance to hit!
-Being a warrior means killing your enemies, but equally important is knowing which of your enemies to kill first.
-Those without the resources or money for proper BattleMechs may field Agro or IndustrialMechs! Even these unassuming 'Mechs can be dangerous in the right hands!
-"Murderer? Well, that's a harsh word. I prefer to think of myself as a 'mortality technician.'" - Pete DiBiasio, Tri-M Graduate
-"Of course I'm taking it in for the recall! I don't want to get rear-ended and burst into flames." - Jason "Bunny" Berkhoff, rookie MechWarrior
-"If you're using a Heavy Gauss Rifle, you only need to hit the target once. If the target's still standing, you oughta be somewhere else anyway." - Defiance Industries
-"Entrust your House bills to our blessed accounts." - Ad for ComStar Financial Affairs Branch
-"For some, the paycheck is more important than who's paying. Profit before patriotism." - Well-known adage on Solaris VII
-"If it moves, shoot it. If it doesn't, get behind it." - Light 'Mech Pilot's Handbook
-"Up is easy. Down is sort of unsettling." - Shujin Marius Lawler, Atlas pilot
-"All she needs is a little paint, a little wiring, and duct tape - lots of duct tape'." - Joseph MacDonald, AsTech Rhonda's Irregulars
-"The Mercenary Review and Bonding Commission settled differences between employers and Merc units in an equal and fair way - unless you knew someone on the Commission, that is." - Sr. Colonel Elliot Knight, Capellan Armed Services
-"You can't always get what you want, but if you know the right people, you just might get what you need." - Tai-sa Naramasa Asano, 1st Genyosha
-"Make it a priority to locate your enemy's ammo bin. Once you figure out where the ammunition is stored, the rest is easy." - Light 'Mech Pilot's Handbook, Chapter 12, Section 3 
-"Armor doesn't make you invincible. Use cover at every opportunity." - Light 'Mech Pilot's Handbook, Chapter 4, Section 3
-"Single combat? You spent too much time on Solaris! Coordinate your attack or you'll die alone." - Captain Joan Silverburg, Devnon Company, Denizli
-"The most lucrative clause of a mercenary contract is the allowed percentage of salvage rights." - Colonel Wolfgang Hansen, Hansen's Roughriders
-"It's not so much the jumping that's risky. It's coming down in a hot LZ that can give you fits." - Leftenant Kirsten Parks, 10th Lyran Guards, Twycross
-"What do you mean, "the Atlas jumped"?!?" - Last words of Lieutenant Percy Jones
-"The proper business of the warrior is death. His only concern must be to destroy the enemy, or else to die fighting." - Dictum Honorium Volume II, On Proper Behavior of the Warrior
-"We know they're coming. They know they're coming. But they don't know that we know they're coming." - Lieutenant Peer Kröger, House Kurita
-"When we bring VIPs on the field they ride in a Demolisher. That way they've got a decent chance of not coming off the field in a body bag." - Sergeant Delkon Meers, 20th Avalon Hussars
-"Kings of the battlefield? Hah! From where I sit, 'Mechs are nothing but targets." - Pilot Carew, Clan Wolf
-"I know a guy in the Yakuza who knows someone in the Confederation who can get you a field upgrade kit... for a price." - Cy Armstrong, owner of Cy's 'Mech City, Solaris VII
-"Our lawyers have informed us that it's not legally decapitation unless the head comes completely off." - Spencer and Son Insurance Claims Adjustor
-"A warrior putting on his sword for battle should not boast like a warrior who has already won." - Ahab's Proverb
-"Before you seek Revenge with someone be sure and dig two graves." - Ancient Japanese Proverb
-"Sometimes reasonable men must do unreasonable things." - Marvin Hemeyer
-"When you're wounded and left on Afghanistan's plains; And the women come out to cut up what remains; Jest roll to your rifle and blow out your brains; An' go to your Gawd like a soldier." - Rudyard Kipling
-Failure is always a possibility! RNGesus giveth, and it taketh away.
-Failure is not an option - it is mandatory. The option is whether or not to let failure be the last thing you do.
+Failure is always a possibility! RNGesus giveth, and RNGesus taketh away.
+Pyrrhic victories are for idealists. You're a mercenary — if the repairs are going to cost more than you're getting paid, you should have left already.
 The most important mantra you can learn: 'Guns off the field.' If you can remove a target do so. Ignore salvage. Ignore target priority. Make it gone.
-Get eyes on the blips as quickly as possible. You NEED to know if that 100-ton blip is a Gausszilla or a Mackie.
-Restoring a salvaged 'Mech is a significant undertaking. Make sure your company is economically stable before you commit to expanding your roster.
-Only you can prevent friendly fire.
-Never turn your back on an enemy, unless your front armor is already gone.
 It's not the chassis, but the components that separate a Light 'Mech from a walking coffin.
-Money is the key enabler. Without money, there is no company or a chance to rebuild and experiment on 'Mechs.
-Mechjockeys have a tough life. Empathize and build them a lounge to relax and blow off steam. They will love you for it.
-Manage your resources. Keeping your company in the black AND your 'Mechs functioning are equally important.
 Just because you rolled out to the battlefield with your new shiny heavy 'Mech, don't get too cocky. A few light 'Mechs can still kick your ass.
-Always keep an eye on the weaponry the enemy has. Just because an Urbie looks small and cute, doesn't mean that it can't wreck your face.
 Competent commanders give the humble Urbanmech the respect it deserves.
-If you install an ECM, NSS or Stealth armor you might feel like a ninja dodging every shot, but remember: one good hit and you are dead meat
-If you need some quick C-Bills, scrap some of the 'Mech chassis parts you have. Drop them into the trash compactor and milk some money out of them. You can sell extra weaponry as well.
-Always keep an eye on your expenses. If you overspend, don't be surprised if you can't afford the next electricity bill.
-Sometimes a bigger or smaller core is better for your 'Mech. Don't be afraid to experiment and see what you need. If you have a fire support 'Mech, it won't need a big-ass core for melee anyway.
-If you are in a tight spot you can try to wrap up the mission by completing only the main objective then escaping. If it isn't possible, sometimes withdrawing in bad faith is better than losing your lance completely.
-Upgrading the training module will help your MechWarriors get experience even if they are out of combat. Who thought playing video games can actually help you in the long run?
-Negotiating from a position of strength does not mean you shouldn't also negotiate from a position near the exits.
-Sometimes rank is a function of firepower.
-THE PRIME AXIOM: In any field of scientific endeavour, anything that can go wrong, will.
+In any field of scientific endeavour, anything that can go wrong, will.
 If the possibility exists of several things going wrong, the one that will go wrong is the one that will do the most damage.
 Everything will go wrong at one time. That time is always when you least expect it.
 If nothing can go wrong, something will.
@@ -179,21 +33,8 @@ If you ever feel like you are doing far too much work take a moment to inspect t
 If it doesn't fit, use a bigger hammer.
 In an instrument or device characterized by a number of plus-or-minus errors, the total error will be the sum of all the errors adding in the same direction.
 All warranty and guarantee clauses become invalid upon payment of the final invoice.
-"The man who can smile when things go wrong has thought of someone he can blame it on." - Jones's Law
-A trained sniper not only has deadly weapons, but keen eyesight. Same applies to 'Mechs. Have a scout to see where to shoot.
-Any shot not taken is a miss. Just ask if it's worth the heat.
-Generous use of Thunder LRMs or other mine-laying ammunition can destroy lighter 'Mechs before they get close by removing their legs.
-Vehicles designated as weapon carriers, such as LRM Carriers normally have low durability, but high firepower. Prioritize and destroy.
-There are rumours that worlds emphasizing 'research' are developing advanced BattleMechs. It would be a shame if a prototype fell into the wrong hands.
-"Infantry win firefights. Tanks win battles. Artillery win wars." - Traditional Saying
 When opportunity comes knocking, don't complain about the noise.
-There is no 'overkill'. Only open fire and reload.
-The flesh is weak.
-Iron within, iron without.
 Some days you're the pigeon. Other days you're the statue. Today is more of a statue day.
-Some mistakes are too fun to make only once.
-Live each day like it's your last. Or at least today, because... Oh I don't want to spoil it.
-You will stop procrastinating. Later.
 Some humans would do anything to see if it was possible to do it. If you put a large switch in some cave somewhere, with a sign on it saying 'End-of-the-World Switch. PLEASE DO NOT TOUCH', the paint wouldn't even have time to dry.
 It's not worth doing something unless someone, somewhere, would much rather you weren't doing it.
 Real stupidity beats artificial intelligence every time.
@@ -220,8 +61,6 @@ Death waits for the slightest lapse in concentration.
 Carelessness will find no clemency in this place!
 There is no such thing as luck; there is only adequate or inadequate preparation to cope with a statistical universe.
 Do not underestimate light targets in large groups.
-"Are you a Capellan spy? You have to tell me if you're a Capellan spy." - Brandon Fosdok, NAIS Junior Researcher
-"If I had a C-Bill for every time the mission briefing was accurate; I might have one C-Bill." - Sumire
 If all goes according to plan, you are almost certainly walking into an ambush.
 The funny thing about routine missions, is that those are the ones where everything goes south.
 Expectations are what get you killed faster than anything else. Plan for things to not go according to plan.
@@ -230,37 +69,8 @@ To be wise is to realize that you know almost nothing, and that what you do know
 Complex does not mean competent, and the most damning fool of all is an educated fool.
 Never make anything simple and efficient when a way can be found to make it complex and wonderful.
 The totally convinced and the totally stupid have too much in common for the resemblance to be accidental.
-"If things seem under control, you are just not going fast enough." - Mario Andretti
-"Politicians are the same all over. They promise to build a bridge even where there is no river." - Nikita Khrushchev
-"Half the lies our opponents tell about us are not true." - Sir Boyle Roche
-"Why should we put ourselves out of our way to do anything for posterity? For what has posterity ever done for us?" - Sir Boyle Roche
-"Prediction is very difficult, especially about the future." - Niels Bohr
-"If you find yourself in a fair fight, your tactics suck." - John Steinbeck
-"The phrase 'Someone ought to do something' was not, by itself, a helpful one. People who used it never added the rider 'and that someone is me'." - Terry Pratchet
-"If an injury has to be done to a man it should be so severe that his vengeance need not be feared." - Niccolo Machiavelli, The Prince
-"All courses of action are risky, so prudence is not in avoiding danger, but calculating risk and acting decisively. Make mistakes of ambition and not mistakes of sloth. Develop the strength to do bold things, not the strength to suffer." - Niccolo Machiavelli 
-"Let it work, For 'tis the sport to have the engineer hoist with his own petard" - Hamlet, Act 3, Scene 4
-"That the impact of your army may be like a grindstone dashed against an egg, this is effected by the science of weak points and strong." - Sun Tzu
-"In all fighting, the direct method may be used for joining battle, but indirect methods will be needed in order to secure victory." - Sun Tzu
-"Military tactics are like unto water; for water in its natural course runs away from high places and hastens downwards. So in war, the way is to avoid what is strong and to strike at what is weak. " - Sun Tzu
-"In battle, there are not more than two methods of attack: the direct and the indirect; yet these two in combination give rise to an endless series of manoeuvres." - Sun Tzu
-"It is a military axiom not to advance uphill against the enemy, nor to oppose him when he comes downhill." - Sun Tzu
-"If you know the enemy and know yourself, you need not fear the result of a hundred battles. If you know yourself but not the enemy, for every victory gained you will also suffer a defeat." - Sun Tzu
-"A general of great merit should be said to be a man who has met with at least one great defeat." - Asakura Soteki
-"Victorious warriors win first and then go to war, while defeated warriors go to war first and then seek to win." - Sun Tzu
-"Valour is superior to numbers." - Vegetius
-"So ends the bloody business of the day." - Homer
-"Ah, yes, mere infantry - poor beggars..." - Plautus
-"Generally, management of many is the same as management of few. It is a matter of organization. And to control many is the same as to control few. This is a matter of formations and signals." - Sun Tzu
-"You should not have a favorite weapon. To become over-familiar with one weapon is as much a fault as not knowing it sufficiently well." - Miyamoto Musashi
-"They have an abundance of gold and silver, and these make war, like other things, go smoothly." - Hermocrates of Syracuse
-"A little piece of gold may be highly valued, but if it gets in one's eye, the result will be darkness." - Unknown
-"There's only two things in this galaxy I hate. People who are intolerant of other people's cultures and the Lyrans." - Old Marik Proverb
 Superior training and superior weaponry have, when taken together, a geometric effect on overall military strength.
 Well-trained, well-equipped troops can stand up to many more times their lesser brethren than linear arithmetic would seem to indicate.
-"Man has killed man from the beginning of time, and each new frontier has brought new ways and new places to die. Why should the future be different?" - Col. Corazon Santiago
-"He held his arm too stiffly, and so was thrown back repeatedly, until at last I seized his forearm and snapped it back against itself. His training suffered while the arm healed, of course, but I felt this was a lesson he must learn early, and well." - Spartan Kel, "Honing the Ki"
-"The first thing you have to understand about any knife fight is that you WILL get cut. Trade a cut for a kill." - Sgt Timothy Drake, Concord Army Special Operations
 Our commander is a military historian, his knowledge of the Star League is not due to 'being old enough to remember it'.
 Should you prefer a more direct approach to combat, try autocannons. Nothing says, "BEGONE!" louder than a roaring AC/20.
 Laser shows have been occasionally known to blind the eyes, 'Mechs, vehicles, buildings, and your neighbours.
@@ -272,76 +82,19 @@ Magistracy of Canopus Battle Lance composition: there are no ‘Mechs. Just the 
 Free Rasalhague Republic Air Lance composition: 4 Cattlemasters (ground combat element) and the flies that surround them (air support).
 Wolf's Dragoons Battle Lance composition: 1 Flea, 1 Archer, an Annihilator, and an ongoing argument about why Kell left.
 In any given calculation, the fault will never be placed if more than one person is involved. In any given discovery, the credit will never be properly placed if more than one person is involved.
-"If there are two or more ways to do something, and one of those ways can result in a catastrophe, then someone will do it." - Murphy's Law
-"As soon as you make something idiot-proof, along comes another idiot." - Grave's Law
 A common mistake that people make when trying to design something completely foolproof is to underestimate the ingenuity of complete fools.
 Million-to-one chances... crop up nine times out of ten.
 Professionals are predictable, it's the amateurs that are dangerous.
 The only time suppressive fire works is when it is used on abandoned positions.
-"They'll never expect this" really means: "I want to try something stupid."
-The size of the combat bonus is inversely proportional to the likelihood of surviving to collect it.
-Don't try to save money by conserving ammunition. Bullets cost less than ‘Mechs.
-Don't expect the enemy to cooperate in the creation of your dream engagement.
-If it ain't broke, it hasn't been issued to the infantry.
-Every client is one missed payment away from becoming a target and every target is one bribe away from becoming a client.
-If it only works in exactly the way the manufacturer intended, it is defective.
-Let them see you sharpen the sword before you fall on it.
-The army you've got is never the army you want.
-The Intel you've got is never the Intel you want. 
-The best way to win a one-on-one fight is to be the third to arrive. 
-It's only too many troops if you can't pay them.
-It's only too many weapons if they're pointing in the wrong direction.
-Infantry exists to paint targets for people with real guns.
-Artillery exists to launch large chunks of budget at an enemy it cannot actually see.
-The pen is mightiest when it writes orders for more swords.
-Two wrongs is probably not going to be enough.
-Any weapon's rate of fire is inversely proportional to the number of available targets.
-Don't bring big grenades into small rooms.
-Anything labelled "This end toward enemy" is dangerous at both ends.
-The brass knows "how" to do it by knowing "who" can do it.
-An ounce of sniper is worth a pound of suppressing fire.
-Necessity is the mother of deception.
+The best way to win a one-on-one fight is to be the third to arrive.
 Incoming fire has the right of way.
 If the enemy is within range, so are you.
 The only thing more accurate than incoming enemy fire is incoming friendly fire.
 Whenever you lose contact with the enemy, look behind you.
 To every rule there is an exception, and an idiot ready to demonstrate it.
-Maxim 16: Your name is in the mouth of others: be sure it has teeth.
-The longer everything goes according to plan, the bigger the impending disaster.
-If the officers are leading from in front, watch out for an attack from the rear.
-The world is richer when you turn enemies into friends, but that's not the same as you being richer.
-If you're not willing to shell your own position, you're not willing to win.
-Give a man a fish, feed him for a day. Take his fish away and tell him he's lucky just to be alive, and he'll figure out how to catch another one for you to take tomorrow.
 Give a man a fire and he's warm for a day, but set fire to him and he's warm for the rest of his life.
-If you can see the whites of their eyes, somebody's done something wrong.
-The company mess and friendly fire should be easier to tell apart.
-Any sufficiently advanced technology is indistinguishable from a big gun.
-If the damage you do is covered by a manufacturer’s warranty, you didn't do enough damage.
-"Fire and Forget" is fine, provided you never actually forget.
-Don't be afraid to be the first to resort to violence.
-If the price of collateral damage is high enough, you might be able to get paid for bringing ammunition home with you.
-The enemy of my enemy is my enemy's enemy. No more. No less.
-A little trust goes a long way. The less you use, the further you'll go.
-Anything is amphibious if you can get it back out of the water.
-If you're leaving tracks, you're being followed.
-That which does not kill you has made a tactical error.
-When the going gets tough, the tough call for close air support.
-Just because it's easy for you doesn't mean it can't be hard on your clients.
-Pillage, then burn. Make sure you get it in the right order.
-A Sergeant in motion outranks a Lieutenant who doesn't know what's going on.
-An ordnance technician at a dead run outranks everybody.
-Close air support covereth a multitude of sins.
-Close air support and friendly fire should be easier to tell apart.
-If violence wasn't your last resort, you failed to resort to enough of it.
-If the food is good enough, the grunts will stop complaining about the incoming fire.
-Mockery and derision have their place. Usually, it's on the far side of the airlock.
-Sometimes the only way out is through... the hull.
-Everything is air-droppable at least once.
-A soft answer turneth away wrath. Once wrath is looking the other way, shoot it in the head.
-Do unto others.
-"Mad Science" means never stopping to ask "what's the worst thing that could happen?"
 There is a light at the end of the tunnel, and it's a flamethrower.
-It's all fun and games on patrol, until the trees start speaking Clan. 
+It's all fun and games on patrol, until the trees start speaking Clan.
 I once was a mercenary like you, but then I took a Thunderbolt to the lower leg actuator...
 I love the sound of RAC in the morning.
 To be sure of hitting your target... shoot first, then call whatever you hit your target.
@@ -370,32 +123,14 @@ What on God's Green Flat Earth is going on here?
 Help! I've been kidnapped and forced to write loading screen tips!
 Help! I've been kidnapped and forced to test everyone's work!
 Help! I've been kidnapped and forced to make trashcans for your amusement!
+Help! I've been kidnapped and forced to work in a Crab factory!
 Never diss a Trashcan, you never know what people left in there.
 It is bad form to shout, "Stop exploding, you cowards!" at the foe, but who are we to tell you how to have fun?
-"HURHUR AC GOES BRRRT" - Pvt. Morphyum
 Reloading your save because you lost a mech? Pansy.
-"A handsome young cyborg named Ace; wooed women at every base; but once ladies glanced at his special enhancement; they vanished with nary a trace." - Barracks Graffiti, Sparta Command
 It is always morally correct to use nuclear weapons on The Professional.
 It is grueling to beat the pride out of a Davion.
-"Are ya winnin', son?" - Dad
-"Roguetech is about family." - Dom
 Apes together strong!
 Acronym of the day - Strategic Transfer of Equipment to Alternate Locations
-"So we keep asking, over and over, until a handful of earth stops our mouths- But is that an answer?" - Heinrich Heine, 1854
-"That is not dead which can eternal lie; and with strange aeons even death may die." - H.P. Lovecraft
-"We live on a placid island of ignorance in the midst of black seas of infinity, and it was not meant that we should voyage far." - H.P. Lovecraft
-“Ph’nglui mglw’nafh Cthulhu R’lyeh wgah’nagl fhtagn.”
-"For the last time, there is no procedure "110-Montauk", so stop telling the newbies to ask for an instructions printout." - Darius Oliveira, Argo XO
-"Anyone who sends a green tech to requisition a "Fallopian Tube" from Supply will scrubbing mechwarrior sweat from inside cockpits for a week." - Yang
-"Obviously, procedure 110-Montauk is putting pineapples on pizza." - Anonymous Pilot
-"If trouble comes when you least expect it, then maybe the thing to do is to always expect it." - Cormac McCarthy
-"There's a difference between quittin' and knowin' when you're beat." - Cormac McCarthy
-"Nobody wants to be here and nobody wants to leave." - Cormac McCarthy
-"War was always here. Before man was, war waited for him. The ultimate trade awaiting its ultimate practitioner." - Cormac McCarthy
-"In every trade save war men of talent and vigor prosper. In war they die." - Cormac McCarthy
-"The way below winds deeper. Longer. Unspeakable it's patterns laid. The lost forever damned to wander this thing a quiet madness made."
-"I'm only truly dead once I've been forgotten" - Anonymous
-"Pain don't hurt" - Dalton
 Infantry: "This Sucks"
 Elementals: "I wish it would suck more"
 Tankers: "I like how this sucks"
@@ -405,50 +140,341 @@ Mechwarriors: "Cable is out? This sucks"
 Have you tried turning the Mech off and on?
 Y O U  D O  N O T  R E C O G N I Z E  T H E  B O D I E S  I N  T H E  W A T E R
 Y o U d O n O t R e C o G n I z E t H e B o D i E s I n T h E w A t E r
-"I'm not superstitious, but I am a little stitious" - Glitch
-"I`ve never won anything in my life but people say I'm eligible for a Darwin Award!" - Decker
-When a mech's stability bar gets filled up to the marked threshold it becomes unstable and loses Evasion and Guarded.
-You can try to shake Battle Armor off your mechs and vehicles by activating the Erratic Maneuvers ability then moving as far as possible.
-Battle Armor inside the bay of a vehicle have a 33% chance of being destroyed outright if the vehicle is destroyed.
-Vehicles can't be optimized like 'Mechs. But they often have good firepower relative to their tiny effect on your lance rating and costs.
-Purchase alternate UAV deploayables in Shops! Hold Shift when placing a UAV to open the selection menu.
-First Aid not only delays bleed-out for a turn, it gives the pilot a bonus to their next Panic check.
-Handheld weapons block other weapons in that arm from firing until they are dropped. See weapon for details.
-"For these wounded wings; I've never left this barren soil; Where all my wishes slowly fade away" - Insomnium, Heart Like a Grave
-"Do you still remember?; Would you still believe?; That this blackened soul of mine; Was once untarnished?" - Insomnium, Heart Like a Grave
-The weapons panel can scroll up and down to display a large number of items and activatable equipment.
-High ground is good ground, as long as it doesn't leave you too exposed.
-Weather and Environmental effect details can be viewed by mousing over the status effect icon in the lower left panel.
-"Fortunately, I have my stethoscope. We undertakers cannot be too careful. If we bury people before they are dead, they get very cross." - Monsieur Alfonse
-Double check before you fire. There might be something in front or behind your target that you really do not want to hit.
-Reinforcement lances and support lances are two different things, read the wiki.
-Do not discredit jump jets. The added mobility could save your life.
-Vehicles have more concentrated armor, but loosing any part of hull is death. Mechs can lose bodyparts.
-Most important rule of combat: Have fun.
-Every gun pointing at an allied lance is a gun not pointing at you.
-Don't have too many weapons, else your mobility may suffer.  However, dont have too few weapons either, but you do you, Boss.
-Losing your ranged weapons does not mean the battle is lost. It just means that the battle is about to get less civilized.
-Usually, you jump farther in the water than you can walk.
-Gunnery Skill reduces Jam/Misfire chance by a flat 1 percentage point per point. Other methods are multipliers.
-Clan equipment is generally lighter, or more powerful than it's Inner Sphere equivilents, but it runs hotter too.
-AA Multiplier on weapons provides more efficiency for AA stance. It has no effect against against VTOLs and LAM.
-Clan armor has built-in CASE in every location, but it's less effective than a dedicated CASE item.
-In the Mechbay click the little spanner icon to set weapon order for a unit. Double-click a weapon to select its default fire more and ammo.
-Primitive engines have serious chance of core meltdown, don't stay close to mechs with them.
-Vehicle pilots are most likely to die if the Front is destroyed. In a dire situation show your tank's side or rear if you value the pilot.
-A C3 network requires a C3 Master to work, or a command module with C3 Master capabilities. C3i networks do not.
-Parts of Omnimechs are generally more valuable than Battlemechs due to in-built engines and gear.
-Monthly expenses are halved when you accept a Priority Contract that requires travel.
-In Combat: Clicking on an objective in the list focuses the camera on related units or locations.
-Explosive equipment and weapons can be protected with CASE just like ammo.
-You can drop up to 4 Units, +2 tanks and +2 Battle Armor from the start. If you have fewer than 6 mechs/vehicles than that get more by any means nessasary.
-There are multiple ways to improve Battle Armor mobility - From APCs, transport helicopters, and riding Omni units, to LAM BA compartments.
-Stray shots are just as deadly as well aimed ones, don't bunch up. Look for groups of enemies were on miss at one might hit another.
-Dismounting is a free action for Battle Armor. It does not start their turn. You can dismount them, then reserve or select another unit.
+The most important rule of combat - "have fun!"
+Career Tip #1: Upgrade the Argo! Upgrades can raise your MedTech and MechTech ratings, as well as unlock new paths for events.
+Career Tip #2: A fully upgraded Argo can support up to three Mech Bays working simultaneously.
+Career Tip #3: Without upgrades, the Leopard can drop up to 4 Units, +2 tanks and +2 Battle Armor. Argo upgrades can increase both drop capacity and the maximum drop tonnage.
+Career Tip #4: Mechjocks have a tough life. Argo upgrades can raise the Morale of your pilots, increasing their Resolve generation in combat, and unlocking new paths for events.
+Career Tip #5: Upgrading the training module will help your MechWarriors get experience even if they are out of combat. Who thought playing video games can actually help you in the long run?
+Career Tip #6: Money is the enabler. Without money, there is no company or a chance to rebuild and experiment on 'Mechs.
+Career Tip #7: Always keep an eye on your expenses. If you overspend, don't be surprised if you can't afford the next electricity bill.
+Career Tip #8: Manage your resources. Keeping your company in the black AND your 'Mechs functioning are equally important.
+Career Tip #9: Restoring a salvaged 'Mech is a significant undertaking. Make sure your company is economically stable before you commit to expanding your roster.
+Career Tip #10: Keep on top of your parts storage. 'Mech parts cost c-bills to store based on the tonnage of the 'Mech they're a part of. Selling 'Mech parts is a great way to cut costs AND generate extra cash quick.
+Career Tip #11: Equipment costs c-bills to store based on how many critical slots it takes up. Keep on top of your storage costs by selling excess gear you don't need for spares.
+Career Tip #12: Monthly expenses are halved when you accept a Priority Contract that requires travel.
+Career Tip #13: Choose your contracts carefully, and you can get yourself some great salvage!
+Career Tip #14: If you ever want to progress, you may need to punch above your lance's weight!
+Career Tip #15: Talk to Sumire in Navigation to arrange Aerospace Fighter cover for the Leopard. Fighters can cover the Leopard during withdrawals and reduce the time it takes for extraction to arrive.
+Career Tip #16: There are rumours that worlds emphasizing 'research' are developing advanced BattleMechs. It would be a shame if a prototype fell into the wrong hands.
+Career Tip #17: Multiple types of deployable UAV can be purchased in some planet stores. Some of these variants come with powerful Electronic Warfare (EWAR) systems.
+Combat Tip #1: Positioning is key. High elevation gives bonus accuracy against enemy units, but be careful of exposing your unit to the whole enemy force.
+Combat Tip #2: Any shot not taken is a miss. Just ask if it's worth the heat.
+Combat Tip #3: A Gausszilla is only as dangerous as the local geography is flat. Careful positioning defeats mad courage every time.
+Combat Tip #4: Be careful about hugging enemies, or you just might end up shooting your own units in the back. Or your allies might do it for you.
+Combat Tip #5: Stray shots are just as deadly as well aimed ones. Even if a shot doesn't hit its target, it may hit a unit nearby. This goes both ways.
+Combat Tip #6: Friendly fire isn't.
+Combat Tip #7: Double check before you fire. There might be something in front or behind your target that you really do not want to hit.
+Combat Tip #8: The colored dots on the ground show different types of terrain — for example, green dots represent damage-reducing cover such as forests or rubble.
+Combat Tip #9: Weapons fire can damage terrain — forests can burn away and buildings can be destroyed.
+Combat Tip #10: Buildings burn well. Buildings burn very well.
+Combat Tip #11: Trees are decent ablative armor, until they get set on fire.
+Combat Tip #12: After a forest tile has been burned, it offers no cover and negatively affects the stability of 'Mechs standing in it.
+Combat Tip #13: 'Mechs standing in rubble or rough ground take additional stability damage.
+Combat Tip #14: Dealing enough stability damage causes a 'Mech to become Unsteady, which removes all Evasion AND Guarded! Perfect for a follow up volley.
+Combat Tip #15: Units retain their evasion when being shot at. Remove evasion from units by making them Unsteady through stability damage, or via the "Sensor Lock" pilot skill.
+Combat Tip #16: A 'Mech must first become Unsteady before it can fall prone, unless a leg is destroyed.
+Combat Tip #17: A prone 'Mech is harder to hit unless the attacker is directly adjacent.
+Combat Tip #18: A 'Mech that stands from being prone takes a significant accuracy penalty for that turn.
+Combat Tip #19: Watch your heat. Riding the red line will slow you down or blow you sky-high.
+Combat Tip #20: Riding the red line is dangerous, but oh-so-fun.
+Combat Tip #21: Hitting an already overheated enemy with flamers or heat-generating weapons gives bonus damage!
+Combat Tip #22: Vehicles, turrets, and buildings convert incoming heat damage into regular damage at a 1:1 ratio.
+Combat Tip #23: Overheating 'Mechs suffer from accuracy and movement penalties that increase with the level of heat. At high heat, 'Mechs may shut down, or ammunition bins may explode!
+Combat Tip #24: Called Shots can be made for free against prone or shutdown targets.
+Combat Tip #25: Multi-Target cannot select units equipped with any form of Stealth Armor.
+Combat Tip #26: Offensive Push allows you to spend Resolve to make a Called Shot at any time.
+Combat Tip #27: Offensive Push requires you to have vision of your target. Remember that darkness and forests can reduce visual range.
+Combat Tip #28: Headshots are disabled in Offensive Push, unless your unit is equipped with "BC Headshot," or "FCS Headshot."
+Combat Tip #29: Most Armored Fighting Vehicles (AFVs) have heavily armored fronts, but weaker sides and rear.
+Combat Tip #30: Vehicles designated as weapon carriers, such as LRM Carriers normally have low durability, but high firepower. Prioritize and destroy.
+Combat Tip #31: Vehicle pilots are most likely to die if the Front is destroyed. In a dire situation show your tank's side or rear if you value the pilot.
+Combat Tip #32: Weapons have their Through-Armor-Critical (TAC) values doubled when striking vehicles.
+Combat Tip #33: Through-Armor-Critical (TAC) chance is influenced by weapon type; a Gauss slug has a high penetration rate, but a Laser only melts the surface.
+Combat Tip #34: High mobility units makes it easier to play objectives, rather than slugging it out with every enemy on the field.
+Combat Tip #35: Light, fast units make effective flankers and spotters and may retreat to tie up your back line if left unchecked.
+Combat Tip #36: Holding your cursor over the hit chance percentage in a unit's weapons tray will give a detailed breakdown of accuracy modifiers. This can tell you why one unit may be harder to hit than another.
+Combat Tip #37: Attacks against the side and rear of a target have an increased chance to hit.
+Combat Tip #38: Hitting a unit with Target Acquisition Gear (TAG) makes the unit easier to see and detect on sensors. It also grants bonus accuracy against the tagged unit.
+Combat Tip #39: 90% to hit is still 10% to miss. Dice don't follow your expectations.
+Combat Tip #40: Generous use of Thunder LRMs or other mine-laying ammunition can destroy lighter 'Mechs before they get close by removing their legs.
+Combat Tip #41: Switch between your equipped ammunition types by clicking on the name of your current ammunition in the 'Mech's weapon panel.
+Combat Tip #42: When a PPC-type weapon hits the ground, it clears nearby landmines. You can do this intentionally with the "Attack Ground" ability!
+Combat Tip #43: High-explosive munitions can clear nearby landmines! Check the tooltip of ammo or weapons to see if this applies to them.
+Combat Tip #44: Burning terrain has a chance to destroy landmines within, unless they are inferno landmines.
+Combat Tip #45: Some Battle Armor can make Swarm Attacks. These special melee attacks 'stick' the Battle Armor to the unit. Use the "Swat" ability to brush them off, or use "Erratic Maneuvers" and move as far as you can!
+Combat Tip #46: Battle Armor inside the bay of a vehicle have a 33% chance of being destroyed along with the vehicle if the vehicle takes lethal damage.
+Combat Tip #47: Machine Guns, Flamers and Small Pulse lasers gain bonus accuracy and damage vs Battle Armor Squads.
+Combat Tip #48: Untrained MechWarriors are more likely to panic. Punch through their armor to make them reach for that eject button.
+Combat Tip #49: Scare your enemy into bailing out! Destroying their allies, flanking, and reducing their offensive capability all lead to panic.
+Combat Tip #50: Panicked pilots will calm over time if not under fire. A high Guts skill reduces panic rate.
+Combat Tip #51: Wounded pilots will start to panic as their bleed-out timer gets low.
+Combat Tip #52: A wounded pilot can administer emergency first aid. It won't remove the bleeding, but it might keep them alive long enough to extract!
+Combat Tip #53: First Aid not only delays bleed-out for a turn, it gives the pilot a bonus to their next Panic check.
+Combat Tip #54: The weapons panel can scroll up and down to display a large number of items and activatable equipment.
+Combat Tip #55: Holding your cursor over the cyber-eye icon in your unit's status tray, above the armor display, will allow you to see their sensor rolls and bonuses for the turn.
+Combat Tip #56: Holding your cursor over the ECM Suite icon in your unit's status tray, above the armor display, will allow you to see all Electronic Warfare (EWAR) bonuses currently affecting them.
+Combat Tip #57: Holding your cursor over the ECM Suite icon in an enemy unit's status tray, below their armor display, will allow you to see all Electronic Warfare (EWAR) bonuses currently affecting them.
+Combat Tip #58: Holding your cursor over the weather icon in your unit's status tray, above the armor display, will allow you to see the effects of the weather on the field.
+Combat Tip #59: Weather conditions can affect sight and sensor ranges.
+Combat Tip #60: Some VTOL carry powerful bombs, watch out for the big ones!
+Combat Tip #61: Killing Rocket Launcher units before they blow their load is tactically advisable.
+Combat Tip #62: Many missions have lances designated as reinforcements. Your deployments may not always be a milk run.
+Combat Tip #63: Losing your ranged weapons does not mean the battle is lost. It just means that the battle is about to get less civilized.
+Combat Tip #64: A 'Mech splits its melee damage across the number of hits it makes — a 'Mech with two hands making a 30-damage punch attack hits twice for 15 damage.
+Combat Tip #65: Enemy airstrikes can be nullified by strong anti-air (AA) presence. Units can enter "AA Stance" to contribute the AA Factor of their weapons to a total chance of preventing an airstrike.
+Combat Tip #66: If you are in a tight spot you can try to wrap up the mission by completing only the main objective then escaping. If it isn't possible, sometimes withdrawing in bad faith is better than losing your lance completely.
+Combat Tip #67: Firing weapons makes a unit twice as easy to detect. If you want to hide a unit move it out of sight and don't fire.
+Combat Tip #68: A unit carrying a Command Console, Communications Gear, or C3 equipment can buff all units on its team. Identify and eliminate enemy Command 'Mechs to gain the upper hand!
+Combat Tip #69: Nice.
+Combat Tip #70: A trained sniper not only has deadly weapons, but keen eyesight. Same applies to 'Mechs. Have a scout to see where to shoot.
+Combat Tip #71: Always keep an eye on the weaponry the enemy has. High sensor rolls will let you know if that UrbanMech is carrying a party horn or an AC/20.
+Combat Tip #72: Gunnery Skill reduces Jam/Misfire chance by a flat 1 percentage point per point. Other methods are multipliers.
+Combat Hotkeys #1: TAB can be used to cycle between valid targets.
+Combat Hotkeys #2: Press V to cycle between valid melee targets.
+Combat Hotkeys #3: Pressing CTRL+T will enable or disable the coloured attack direction indicators.
+Combat Hotkeys #4: When using "Attack Ground," holding Left ALT will allow you to target friendly units and structures.
+Combat Hotkeys #5: Press CTRL+A to toggle the visibility of aura effects, such as Electronic Warfare (EWAR) equipment.
+Combat Hotkeys #6: Hold SHIFT when deploying a UAV to select which type is deployed from the Argo's inventory.
+Combat Hotkeys #7: Clicking on an objective in the list focuses the camera on related units or locations.
+Deployment Tip #1: Clicking on a unit in a deployment slot will order the list of pilots by affinity with that unit from highest to lowest.
+Deployment Tip #2: Plan your lance according to the range & strategy you intend to use.
+Deployment Tip #3: Dropping a lance that has a higher rating than the mission rating has a chance to generate additional reinforcements, called "Support Lances". The greater the difference in rating; the higher the chance.
+EWAR Tip #1: EWAR stands for "Electronic Warfare," which covers a wide range of equipment used to disrupt the enemy's attempts to target your units.
+EWAR Tip #2: Electronic Warfare (EWAR) equipment such as ECM Suites can provide significant benefits to your lance. Read the tooltips of your equipment to see their effects!
+EWAR Tip #3: ECM stands for "Electronic Countermeasures."
+EWAR Tip #4: ECM Suites can be set to Passive or Active modes. Passive mode focuses on protecting the carrier and makes them harder to hit. Active mode focuses on jamming nearby enemies and reducing their accuracy, as well as reducing jamming on nearby allies.
+EWAR Tip #5: BAP stands for "Beagle Active Probe," but is commonly use to describe other types of Active Probe.
+EWAR Tip #6: Active Probes boost a unit's sensor check, improving the information gathered about enemies at longer ranges.
+EWAR Tip #7: Stealth Armors require a dedicated ECM Suite, such as a Guardian ECM, or an AR24 Sheathed Beacon. An item's tooltip will inform whether it fulfils the requirements for Stealth Armor.
+EWAR Tip #8: Sensor Stealth makes a unit harder to detect on sensors and provides defensive bonuses which increase with distance to target.
+EWAR Tip #9: Mimetic Stealth makes a unit much harder to see, but loses effectiveness based on how far the stealthed unit has moved that turn.
+EWAR Tip #10: Stealth Armors might make you feel like a ninja, but they lack the damage reduction of other advanced armor types. Be careful not to tempt fate.
+EWAR Tip #11: A Narc Pod attached to a unit makes that unit easier to see and detect on sensors. It also cuts through one level of ECM Shielding, Sensor Stealth, and Mimetic Stealth.
+EWAR Tip #12: IFF Jammers are specialist equipment which provide a low-level ECM Shield to the carrier. This stacks with other sources of ECM Shield.
+Mech Bay Tip #1: If a 'Mech's loadout is invalid, you can hit the "Confirm" button to see what issues it has.
+Mech Bay Tip #2: Items have important information listed in brightly coloured text in their tooltips.
+Mech Bay Tip #3: Basic components that come with a 'Mech like the default cockpit and gyro are easy to come by and replace. Don't worry if they blow up! They'll be replaced when the 'Mech is repaired.
+Mech Bay Tip #4: A 'Mech needs an engine core to function. Engine core rating dictates how fast a 'Mech can move and typically sets your tonnage budget for the remaining equipment and armor.
+Mech Bay Tip #5: In RogueTech, engine cores can be hotswapped. You don't need to hunt specifically for a VLAR 200 XL Engine.
+Mech Bay Tip #6: Sometimes a bigger or smaller core is better for your 'Mech. Don't be afraid to experiment and see what works for you.
+Mech Bay Tip #7: Clan Extralight (XL) Fusion Engines, and Light Fusion Engines take up two critical slots in each side torso. Losing a single side torso will heavily damage the engine; losing both side torsos will destroy it.
+Mech Bay Tip #8: Extralight (XL) Fusion Engines take up three critical slots in each side torso. Losing the torso will cause the engine to be destroyed.
+Mech Bay Tip #9: Engine cores have a chance to go critical when destroyed. Modern engines (Fusion, XL, etc.) have a lower chance to explode than Primitive engines.
+Mech Bay Tip #10: Heat Sink types cannot be mixed; a 'Mech with a Double Heat Sink (DHS) kit cannot use single Heat Sinks.
+Mech Bay Tip #11: Double Heat Sinks (DHS) require a DHS Kit, which can be installed in the cooling slot.
+Mech Bay Tip #12: Equipment is key. A well-equipped Light can kill a poorly equipped Assault.
+Mech Bay Tip #13: C.A.S.E. prevents damage from internal explosions from travelling towards the Center Torso. Like fire extinguishers and condoms, it's better to have it and not need it, than need it and not have it.
+Mech Bay Tip #14: C.A.S.E protects a location from all internal explosions, including volatile weapons and equipment, in addition to ammo explosions.
+Mech Bay Tip #15: C.A.S.E II prevents the majority of damage from an internal explosion by venting the force out the back of the 'Mech. This can save the location, but strips the rear armor!
+Mech Bay Tip #16: Clan armor types have C.A.S.E incorporated into every location, though it is less effective than the standalone version.
+Mech Bay Tip #17: C.A.S.E. PROTECTS! C.A.S.E. IS LIFE!
+Mech Bay Tip #18: The repair costs of armor can vary depending on the type of armor and your company's MechTech rating.
+Mech Bay Tip #19: Armor type matters! Primitive armor is cheap and easy to maintain, but provides less armor per ton. Hardened armor is expensive and heavy, but offers superior protection.
+Mech Bay Tip #20: Ammo explodes. Don't have too much of it. Also, don't run out of ammo. But you do you, chief.
+Mech Bay Tip #21: Every weapon has an AA Factor, which informs how much it contributes to preventing an airstrike. Equipping a 'Mech with multiple high AA Factor weapons can make it an effective deterrent for enemy airstrikes.
+Mech Bay Tip #22: Pulse Lasers and Streak Missiles allow a 'Mech to ignore a number of Evasive pips on the target, making them ideal for hunting down fast moving units.
+Mech Bay Tip #23: Railguns and Gauss rifles deal tremendous damage at equally tremendous ranges. Reach out and touch someone.
+Mech Bay Tip #24: Ultra Autocannons (UACs), Rotary Autocannons (RACs) and LB-X Autocannons all benefit from Autocannon-specific equipment, such as "FCS AC." Most artillery pieces do, too!
+Mech Bay Tip #25: ER PPC stands for "Extended-Range Particle Projector Cannon." These weapons have huge range and high damage, but generate a lot of heat.
+Mech Bay Tip #26: Equip your 'Mechs with specialized melee actuators to massively increase their effectiveness in close quarters.
+Mech Bay Tip #27: Anti-Missile Systems (AMS) will intercept missiles fired at the 'Mech using them. Advanced models even intercept enemy missiles in a radius around the 'Mech.
+Mech Bay Tip #28: Extended-Range (ER) Lasers have much longer range than their standard counterparts, but build up significantly more heat!
+Mech Bay Tip #29: Big weapons are scary, but if you can't land shots, they won't do any good! Try using many smaller weapons instead to increase your effectiveness with more inexperienced pilots.
+Mech Bay Tip #30: Quantity over quality! Being able to fire multiple medium lasers with proper heat management will be worth more than that single large laser that might not even hit.
+Mech Bay Tip #31: Stack the odds in your favor! Take precision or Artemis ammunition, and equip targeting computers or TAGs to drastically increase your chance to hit!
+Mech Bay Tip #32: Those without the resources or money for proper BattleMechs may field Agro or IndustrialMechs! Even these unassuming 'Mechs can be dangerous in the right hands!
+Mech Bay Tip #33: Vehicles can't be optimized like 'Mechs, but they often have good firepower relative to their tiny effect on your lance rating and costs.
+Mech Bay Tip #34: Many weapons and some equipment have alternative ammunition types. Experiment with different ammo bins for different scenarios!
+Mech Bay Tip #35: Handheld weapons block other weapons in that arm from firing until they are dropped.
+Mech Bay Tip #36: Vehicles carry as much armor as 'Mechs, but spread over fewer locations, making each individual location tougher. However, vehicles are destroyed as soon as any location reaches zero structure.
+Mech Bay Tip #37: Don't have too many weapons, else your mobility may suffer.  However, dont have too few weapons either, but you do you, Boss.
+Mech Bay Tip #38: Clan equipment is generally lighter, or more powerful than it's Inner Sphere equivalents, but it runs hotter too.
+Mech Bay Tip #39: A C3 network requires a C3 Master to work, or a command module with C3 Master capabilities. C3i networks do not.
+Mech Bay Tip #40: Parts of Omnimechs are generally more valuable than Battlemechs due to in-built engines and gear.
+Mech Bay Tip #41: Beacon items don't need to be equiped on the unit with the Deploy item to be used.
+Mech Bay Hotkeys #1: CTRL+Click on the "Strip Equipment" button to only remove weapons and ammo.
+Mech Bay Hotkeys #2: SHIFT+Click when adding or removing armor to add or remove a single point. This is great for finessing tonnage juuuust right.
+Mech Bay Hotkeys #2: CTRL+Click when adding or removing armor to add or remove the maximum allowed by the location.
+Mech Bay Hotkeys #4: When viewing a 'Mech from the main Mech Bay screen, click on the Spanner icon below the info card in the lower-right to set default weapon order by click-and-dragging. Double click a weapon to select default ammo type.
+Movement Tip #1: It's hard to aim on the move! Movement applies an accuracy penalty to your pilots, based on what kind of movement used. The penalty for walking is lowest, followed by sprinting, and then jumping.
+Movement Tip #2: Terrain types can influence a unit's walking or sprinting speed - roads make most units move faster, while forests or water can slow units down.
+Movement Tip #3: Jump Jets offer a whole new degree of maneuverability and can allow quick repositioning for defense or offense!
+Movement Tip #4: Jump Jets distance is unaffected by terrain type, but can be reduced by weather.
+Movement Tip #5: Tracked, Wheeled and Hover vehicles all handle terrain differently. For example, hover vehicles can cross deep water, and wheeled vehicles gain bonus movement on roads.
+Movement Tip #6: Hover vehicle can move quickly over water, but move much more slowly up and down slopes.
+Movement Tip #7: Tracked vehicles can handle much steeper slopes than most other unit types.
+Movement Tip #8: Wheeled vehicles move much faster over roads than other unit types. Keep an eye on them in Urban maps!
+Movement Tip #9: The danger zones in a DropShip landing area are no joke, no matter what your fellow MechWarriors told you.
+Movement Tip #10: There are multiple ways to improve Battle Armor mobility - From APCs, transport helicopters, and riding Omni units, to LAM BA compartments.
+Movement Tip #11: Dismounting is a free action for Battle Armor. It does not start their turn. You can dismount them, then reserve or select another unit.
+Movement Hotkeys #1: Holding Left ALT will allow you to see all terrain nodes around your cursor.
+Movement Hotkeys #2: Holding CTRL when dismounting a building with Battle Armor will dismount your unit to the roof of the building.
+Weapon Hotkeys #1: CTRL+Click on the ammo column of weapons to dump all bins of that ammo type. This can only be done before moving.
+Weapon Hotkeys #2: CTRL+Click on the ammo column of handheld weapons to discard the weapon. It will be collected at the end of the battle, unless the location housing it is destroyed.
+Weapon Hotkeys #3: SHIFT+Click when changing weapon settings, such as ammo or firemodes, to sync the changes to all weapons of the same type. This allows even allows you to turn all weapons of the same type on or off at once!
+UI Hotkeys #1: Press Ctrl-Shift-U to toggle visibility of the game UI. This lets you take screenshots without any of the UI elements present!
+"Are you a Capellan spy? You have to tell me if you're a Capellan spy." - Brandon Fosdok, NAIS Junior Researcher
+"If I had a C-Bill for every time the mission briefing was accurate; I might have one C-Bill." - Sumire
+"Murderer? Well, that's a harsh word. I prefer to think of myself as a 'mortality technician.'" - Pete DiBiasio, Tri-M Graduate
+"Of course I'm taking it in for the recall! I don't want to get rear-ended and burst into flames." - Jason "Bunny" Berkhoff, rookie MechWarrior
+"If you're using a Heavy Gauss Rifle, you only need to hit the target once. If the target's still standing, you oughta be somewhere else anyway." - Defiance Industries
+"Entrust your House bills to our blessed accounts." - Ad for ComStar Financial Affairs Branch
+"For some, the paycheck is more important than who's paying. Profit before patriotism." - Well-known adage on Solaris VII
+"If it moves, shoot it. If it doesn't, get behind it." - Light 'Mech Pilot's Handbook
+"Up is easy. Down is sort of unsettling." - Shujin Marius Lawler, Atlas pilot
+"All she needs is a little paint, a little wiring, and duct tape - lots of duct tape." - Joseph MacDonald, AsTech for Rhonda's Irregulars
+"The Mercenary Review and Bonding Commission settled differences between employers and Merc units in an equal and fair way - unless you knew someone on the Commission, that is." - Sr. Colonel Elliot Knight, Capellan Armed Services
+"You can't always get what you want, but if you know the right people, you just might get what you need." - Tai-sa Naramasa Asano, 1st Genyosha
+"Make it a priority to locate your enemy's ammo bin. Once you figure out where the ammunition is stored, the rest is easy." - Light 'Mech Pilot's Handbook, Chapter 12, Section 3 
+"Armor doesn't make you invincible. Use cover at every opportunity." - Light 'Mech Pilot's Handbook, Chapter 4, Section 3
+"Single combat? You spent too much time on Solaris! Coordinate your attack or you'll die alone." - Captain Joan Silverburg, Devnon Company, Denizli
+"The most lucrative clause of a mercenary contract is the allowed percentage of salvage rights." - Colonel Wolfgang Hansen, Hansen's Roughriders
+"It's not so much the jumping that's risky. It's coming down in a hot LZ that can give you fits." - Leftenant Kirsten Parks, 10th Lyran Guards, Twycross
+"What do you mean, "the Atlas jumped"?!?" - Last words of Lieutenant Percy Jones
+"The proper business of the warrior is death. His only concern must be to destroy the enemy, or else to die fighting." - Dictum Honorium Volume II, On Proper Behavior of the Warrior
+"We know they're coming. They know they're coming. But they don't know that we know they're coming." - Lieutenant Peer Kröger, House Kurita
+"When we bring VIPs on the field they ride in a Demolisher. That way they've got a decent chance of not coming off the field in a body bag." - Sergeant Delkon Meers, 20th Avalon Hussars
+"Kings of the battlefield? Hah! From where I sit, 'Mechs are nothing but targets." - Pilot Carew, Clan Wolf
+"I know a guy in the Yakuza who knows someone in the Confederation who can get you a field upgrade kit... for a price." - Cy Armstrong, owner of Cy's 'Mech City, Solaris VII
+"Our lawyers have informed us that it's not legally decapitation unless the head comes completely off." - Spencer and Son Insurance Claims Adjustor
+"A warrior putting on his sword for battle should not boast like a warrior who has already won." - Ahab's Proverb
+"Before you seek revenge with someone, be sure and dig two graves." - Ancient Japanese Proverb
+"Sometimes reasonable men must do unreasonable things." - Marvin Hemeyer
+"When you're wounded and left on Afghanistan's plains; And the women come out to cut up what remains; Jest roll to your rifle and blow out your brains; An' go to your Gawd like a soldier." - Rudyard Kipling
+"The man who can smile when things go wrong has thought of someone he can blame it on." - Jones's Law
+"Infantry win firefights. Tanks win battles. Artillery win wars." - Codex: Imperial Guard
+"Pillage, then burn." - 1st Maxim of Maximally Effective Mercenaries
+"A Sergeant in motion outranks a Lieutenant who doesn't know what's going on." - 2nd Maxim of Maximally Effective Mercenaries
+"An ordnance technician at a dead run outranks everybody." - 3rd Maxim of Maximally Effective Mercenaries
+"Close air support covereth a multitude of sins." - 4th Maxim of Maximally Effective Mercenaries
+"Close air support and friendly fire should be easier to tell apart." - 5th Maxim of Maximally Effective Mercenaries
+"If violence wasn't your last resort, you failed to resort to enough of it." - 6th Maxim of Maximally Effective Mercenaries
+"If the food is good enough, the grunts will stop complaining about the incoming fire." - 7th Maxim of Maximally Effective Mercenaries
+"Mockery and derision have their place. Usually, it's on the far side of the airlock." - 8th Maxim of Maximally Effective Mercenaries
+"Never turn your back on an enemy." - 10th Maxim of Maximally Effective Mercenaries
+"Sometimes the only way out is through...through the hull." - 10th Maxim of Maximally Effective Mercenaries
+"Everything is air-droppable at least once." - 11th Maxim of Maximally Effective Mercenaries
+"A soft answer turneth away wrath. Once wrath is looking the other way, shoot it in the head." - 12th Maxim of Maximally Effective Mercenaries
+"Do unto others." - 13th Maxim of Maximally Effective Mercenaries
+"'Mad Science' means never stopping to ask 'what's the worst thing that could happen?'" - 14th Maxim of Maximally Effective Mercenaries
+"Only you can prevent friendly fire." - 15th Maxim of Maximally Effective Mercenaries
+"Your name is in the mouth of others: be sure it has teeth." - 16th Maxim of Maximally Effective Mercenaries
+"The longer everything goes according to plan, the bigger the impending disaster." - 17th Maxim of Maximally Effective Mercenaries
+"If the officers are leading from in front, watch out for an attack from the rear." - 18th Maxim of Maximally Effective Mercenaries
+"The world is richer when you turn enemies into friends, but that's not the same as you being richer." - 19th Maxim of Maximally Effective Mercenaries
+"If you're not willing to shell your own position, you're not willing to win." - 20th Maxim of Maximally Effective Mercenaries
+"Give a man a fish, feed him for a day. Take his fish away and tell him he's lucky just to be alive, and he'll figure out how to catch another one for you to take tomorrow." - 21st Maxim of Maximally Effective Mercenaries
+"If you can see the whites of their eyes, somebody's done something wrong." - 22nd Maxim of Maximally Effective Mercenaries
+"The company mess and friendly fire should be easier to tell apart." - 23rd Maxim of Maximally Effective Mercenaries
+"Any sufficiently advanced technology is indistinguishable from a big gun." - 24th Maxim of Maximally Effective Mercenaries
+"If the damage you do is covered by a manufacturer’s warranty, you didn't do enough damage." - 25th Maxim of Maximally Effective Mercenaries
+"'Fire and Forget' is fine, provided you never actually forget." - 26th Maxim of Maximally Effective Mercenaries
+"Don't be afraid to be the first to resort to violence." - 27th Maxim of Maximally Effective Mercenaries
+"If the price of collateral damage is high enough, you might be able to get paid for bringing ammunition home with you." - 28th Maxim of Maximally Effective Mercenaries
+"The enemy of my enemy is my enemy's enemy. No more. No less." - 29th Maxim of Maximally Effective Mercenaries
+"A little trust goes a long way. The less you use, the further you'll go." - 30th Maxim of Maximally Effective Mercenaries
+"Only cheaters prosper." - 31st Maxim of Maximally Effective Mercenaries. (NB: Do not cheat in RogueTech Online.)
+"Anything is amphibious if you can get it back out of the water." - 32nd Maxim of Maximally Effective Mercenaries
+"If you're leaving tracks, you're being followed." - 33rd Maxim of Maximally Effective Mercenaries
+"If you're leaving scorch-marks, you need a bigger gun." - 34th Maxim of Maximally Effective Mercenaries
+"That which does not kill you has made a tactical error." - 35th Maxim of Maximally Effective Mercenaries
+"When the going gets tough, the tough call for close air support." - 36th Maxim of Maximally Effective Mercenaries
+"There is no 'overkill'. Only open fire and reload." - 37th Maxim of Maximally Effective Mercenaries
+"Just because it's easy for you doesn't mean it can't be hard on your clients." - 38th Maxim of Maximally Effective Mercenaries
+"There's a difference between spare parts and extra parts." - 39th Maxim of Maximally Effective Mercenaries
+"Not all good news is enemy action." - 40th Maxim of Maximally Effective Mercenaries
+"'Do you have a backup?' means 'I can't fix this.'" - 41st Maxim of Maximally Effective Mercenaries
+"'They'll never expect this' really means 'I want to try something stupid.'" - 42nd Maxim of Maximally Effective Mercenaries
+"If it's stupid and it works, it's still stupid but you got lucky." - 43rd Maxim of Maximally Effective Mercenaries
+"If it will blow a hole in the ground, it will double as an entrenching tool." - 44th Maxim of Maximally Effective Mercenaries
+"The size of the combat bonus is inversely proportional to the likelihood of surviving to collect it." - 45th Maxim of Maximally Effective Mercenaries
+"Don't try to save money by conserving ammunition." - 46th Maxim of Maximally Effective Mercenaries
+"Don't expect the enemy to cooperate in the creation of your dream engagement." - 47th Maxim of Maximally Effective Mercenaries
+"If it ain't broke, it hasn't been issued to the infantry." - 48th Maxim of Maximally Effective Mercenaries
+"Every client is one missed payment away from becoming a target and every target is one bribe away from becoming a client." - 49th Maxim of Maximally Effective Mercenaries
+"If it only works in exactly the way the manufacturer intended, it is defective." - 50th Maxim of Maximally Effective Mercenaries
+"Let them see you sharpen the sword before you fall on it." - 51st Maxim of Maximally Effective Mercenaries
+"The army you've got is never the army you want." - 52nd Maxim of Maximally Effective Mercenaries
+"The intel you've got is never the intel you want." - 53rd Maxim of Maximally Effective Mercenaries
+"It's only too many troops if you can't pay them." - 54th Maxim of Maximally Effective Mercenaries
+"It's only too many weapons if they're pointing in the wrong direction." - 55th Maxim of Maximally Effective Mercenaries
+"Infantry exists to paint targets for people with real guns." - 56th Maxim of Maximally Effective Mercenaries
+"Artillery exists to launch large chunks of budget at an enemy it cannot actually see." - 57th Maxim of Maximally Effective Mercenaries
+"The pen is mightiest when it writes orders for more swords." - 58th Maxim of Maximally Effective Mercenaries
+"Two wrongs is probably not going to be enough." - 59th Maxim of Maximally Effective Mercenaries
+"Any weapon's rate of fire is inversely proportional to the number of available targets." - 60th Maxim of Maximally Effective Mercenaries
+"Don't bring big grenades into small rooms." - 61st Maxim of Maximally Effective Mercenaries
+"Anything labelled "This end toward enemy" is dangerous at both ends." - 62nd Maxim of Maximally Effective Mercenaries
+"The brass knows how to do it by knowing who can do it." - 63rd Maxim of Maximally Effective Mercenaries
+"An ounce of sniper is worth a pound of suppressing fire." - 64th Maxim of Maximally Effective Mercenaries
+"After the toss, be the one with the pin, not the one with the grenade." - 65th Maxim of Maximally Effective Mercenaries
+"Necessity is the mother of deception." - 66th Maxim of Maximally Effective Mercenaries
+"If you can't carry cash, carry a weapon." - 67th Maxim of Maximally Effective Mercenaries
+"Negotiating from a position of strength does not mean you shouldn't also negotiate from a position near the exits." - 68th Maxim of Maximally Effective Mercenaries
+"Sometimes rank is a function of firepower." - 69th (nice) Maxim of Maximally Effective Mercenaries
+"Failure is not an option - it is mandatory. The option is whether or not to let failure be the last thing you do." - 70th Maxim of Maximally Effective Mercenaries
+"The flesh is weak." - Pre-Spaceflight idiom
+"Iron within, iron without." - Mantra of the Iron Warriors
+"Some mistakes are too fun to make only once." - Margaret Mitchell, pre-Spaceflight novelist
+"Live each day like it's your last. Or at least today, because... Oh I don't want to spoil it." - Canopian Socialite
+"If you know the enemy and know yourself, you need not fear the result of a hundred battles. If you know yourself but not the enemy, for every victory gained you will also suffer a defeat. If you know neither the enemy nor yourself, you will succumb in every battle." - Sun Tzu
+"If there are two or more ways to do something, and one of those ways can result in a catastrophe, then someone will do it." - Murphy's Law
+"As soon as you make something idiot-proof, along comes another idiot." - Grave's Law
 "Everybody's going to die." - This message brought to you by The Church of the Cosmic Skull
 "It is a tale told by an idiot, full of sound and fury, signifying nothing." - Macbeth
-"Well, other than that Mrs. Lincoln, how was the play?"
-Weapons have their Through Armor Critical (TAC) values doubled when striking non-mech Vehicles.
-Beacon items don't need to be equiped on the unit with the Deploy item to be used.
-Mouse Over All The Things! - Roguetech has many tooltips and pop-up info panels.
-Never half ass two things, whole ass one thing.
+"Well, other than that Mrs. Lincoln, how was the play?" - Pre-Spaceflight Joke
+"If things seem under control, you are just not going fast enough." - Mario Andretti
+"Politicians are the same all over. They promise to build a bridge even where there is no river." - Nikita Khrushchev
+"Half the lies our opponents tell about us are not true." - Sir Boyle Roche
+"Why should we put ourselves out of our way to do anything for posterity? For what has posterity ever done for us?" - Sir Boyle Roche
+"Prediction is very difficult, especially about the future." - Niels Bohr
+"If you find yourself in a fair fight, your tactics suck." - John Steinbeck
+"The phrase 'Someone ought to do something' was not, by itself, a helpful one. People who used it never added the rider 'and that someone is me'." - Terry Pratchet
+"If an injury has to be done to a man it should be so severe that his vengeance need not be feared." - Niccolo Machiavelli, The Prince
+"All courses of action are risky, so prudence is not in avoiding danger, but calculating risk and acting decisively. Make mistakes of ambition and not mistakes of sloth. Develop the strength to do bold things, not the strength to suffer." - Niccolo Machiavelli
+"Let it work, For 'tis the sport to have the engineer hoist with his own petard" - Hamlet, Act 3, Scene 4
+"That the impact of your army may be like a grindstone dashed against an egg, this is effected by the science of weak points and strong." - Sun Tzu
+"In all fighting, the direct method may be used for joining battle, but indirect methods will be needed in order to secure victory." - Sun Tzu
+"Military tactics are like unto water; for water in its natural course runs away from high places and hastens downwards. So in war, the way is to avoid what is strong and to strike at what is weak. " - Sun Tzu
+"In battle, there are not more than two methods of attack: the direct and the indirect; yet these two in combination give rise to an endless series of manoeuvres." - Sun Tzu
+"It is a military axiom not to advance uphill against the enemy, nor to oppose him when he comes downhill." - Sun Tzu
+"If you know the enemy and know yourself, you need not fear the result of a hundred battles. If you know yourself but not the enemy, for every victory gained you will also suffer a defeat." - Sun Tzu
+"A general of great merit should be said to be a man who has met with at least one great defeat." - Asakura Soteki
+"Victorious warriors win first and then go to war, while defeated warriors go to war first and then seek to win." - Sun Tzu
+"Valour is superior to numbers." - Vegetius
+"So ends the bloody business of the day." - Homer
+"Ah, yes, mere infantry - poor beggars..." - Plautus
+"Generally, management of many is the same as management of few. It is a matter of organization. And to control many is the same as to control few. This is a matter of formations and signals." - Sun Tzu
+"You should not have a favorite weapon. To become over-familiar with one weapon is as much a fault as not knowing it sufficiently well." - Miyamoto Musashi
+"They have an abundance of gold and silver, and these make war, like other things, go smoothly." - Hermocrates of Syracuse
+"A little piece of gold may be highly valued, but if it gets in one's eye, the result will be darkness." - Unknown
+"There's only two things in this galaxy I hate. People who are intolerant of other people's cultures and the Lyrans." - Old Marik Proverb
+"Man has killed man from the beginning of time, and each new frontier has brought new ways and new places to die. Why should the future be different?" - Col. Corazon Santiago
+"He held his arm too stiffly, and so was thrown back repeatedly, until at last I seized his forearm and snapped it back against itself. His training suffered while the arm healed, of course, but I felt this was a lesson he must learn early, and well." - Spartan Kel, "Honing the Ki"
+"The first thing you have to understand about any knife fight is that you WILL get cut. Trade a cut for a kill." - Sgt Timothy Drake, Concord Army Special Operations
+"HURHUR AC GOES BRRRT" - Pvt. Morphyum
+"How do you pronounce HHR? HHHHHuuuhhhhrrrrr." - Unknown (not really, it was Dan)
+"Are ya winnin', son?" - Dad
+"Roguetech is about family." - Dom
+"So we keep asking, over and over, until a handful of earth stops our mouths- But is that an answer?" - Heinrich Heine, 1854
+"That is not dead which can eternal lie; and with strange aeons even death may die." - H.P. Lovecraft
+"We live on a placid island of ignorance in the midst of black seas of infinity, and it was not meant that we should voyage far." - H.P. Lovecraft
+“Ph’nglui mglw’nafh Cthulhu R’lyeh wgah’nagl fhtagn.”
+"For the last time, there is no procedure "110-Montauk", so stop telling the newbies to ask for an instructions printout." - Darius Oliveira, Argo XO
+"The next wise-ass who sends a green Mechjock to requisition a 'fallopian tube' for their SRM launcher will scrubbing MechWarrior sweat from inside cockpits for a week." - Yang
+"Obviously, procedure 110-Montauk is putting pineapples on pizza." - Anonymous Pilot
+"If trouble comes when you least expect it, then maybe the thing to do is to always expect it." - Cormac McCarthy
+"There's a difference between quittin' and knowin' when you're beat." - Cormac McCarthy
+"Nobody wants to be here and nobody wants to leave." - Cormac McCarthy
+"War was always here. Before man was, war waited for him. The ultimate trade awaiting its ultimate practitioner." - Cormac McCarthy
+"In every trade save war men of talent and vigor prosper. In war they die." - Cormac McCarthy
+"The way below winds deeper. Longer. Unspeakable it's patterns laid. The lost forever damned to wander this thing a quiet madness made." - SCP-3935
+"I'm only truly dead once I've been forgotten" - Anonymous
+"Pain don't hurt" - Dalton
+"A handsome young cyborg named Ace; wooed women at every base; but once ladies glanced at his special enhancement; they vanished with nary a trace." - Barracks Graffiti, Sparta Command
+"I'm not superstitious, but I am a little stitious" - Glitch
+"I`ve never won anything in my life but people say I'm eligible for a Darwin Award!" - Decker
+"For these wounded wings; I've never left this barren soil; Where all my wishes slowly fade away" - Insomnium, Heart Like a Grave
+"Do you still remember?; Would you still believe?; That this blackened soul of mine; Was once untarnished?" - Insomnium, Heart Like a Grave
+"Fortunately, I have my stethoscope. We undertakers cannot be too careful. If we bury people before they are dead, they get very cross." - Monsieur Alfonse

--- a/Core/RogueTechCore/GameTips/general.txt
+++ b/Core/RogueTechCore/GameTips/general.txt
@@ -1,12 +1,12 @@
 Look for ways to make your units and company cheaper without losing much effectiveness.
 Sometimes fancy tech is a lot of money for a small improvement.
 READ THE WIKI!
-Mouse Over All The Things! - Roguetech has many tooltips and pop-up info panels.
+Mouse Over All The Things! - RogueTech has many tooltips and pop-up info panels.
 Never half ass two things, whole ass one thing.
 Loading Tip: Did you know these loading screens contain tips?
 If this keeps spinning freely, it may have soft-locked. Please visit our Discord to submit a ticket before restarting.
 If the loading wheel isn't spinning, it probably hasn't crashed.
-RogueTech is the story of your little company surviving the harsh life of a Merc.
+RogueTech is the story of your little company surviving the harsh life of a mercenary.
 Losing is fun!
 Beware of the S.H.I.T.S. : Severe Hazardous Irritable Taco Syndrome
 You will stop procrastinating. Later.
@@ -456,7 +456,7 @@ UI Hotkeys #1: Press Ctrl-Shift-U to toggle visibility of the game UI. This lets
 "HURHUR AC GOES BRRRT" - Pvt. Morphyum
 "How do you pronounce HHR? HHHHHuuuhhhhrrrrr." - Unknown (not really, it was Dan)
 "Are ya winnin', son?" - Dad
-"Roguetech is about family." - Dom
+"RogueTech is about family." - Dom
 "So we keep asking, over and over, until a handful of earth stops our mouths- But is that an answer?" - Heinrich Heine, 1854
 "That is not dead which can eternal lie; and with strange aeons even death may die." - H.P. Lovecraft
 "We live on a placid island of ignorance in the midst of black seas of infinity, and it was not meant that we should voyage far." - H.P. Lovecraft


### PR DESCRIPTION
Another thing I wanted to get done a while ago. This PR tidies up the loading tips and makes it clear which tips are genuine gameplay advice and which are memes, references, or crew in-jokes.

Additionally, this removes or corrects some outdated information (such as the conversion of heat damage for buildings & vehicles.)

The PR looks like a lot more than it actually is due to me shifting big sections around to keep it ordered for my own sanity. At a later date I may make another pass to fix up grammar and spelling in some of the places I'm sure I missed.