### PR TITLE
Fix jam chance on RISC RAC 5

### DIFF
--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_Autocannon_RAC_5_RISC.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_Autocannon_RAC_5_RISC.json
@@ -93,7 +93,7 @@
       "HeatGenerated": -10,
       "ShotsWhenFired": -2,
       "RefireModifier": -2,
-      "FlatJammingChance": 0.8
+      "FlatJammingChance": 0.08
     },
     {
       "Id": "x2",


### PR DESCRIPTION
Fixed single-fire mode on the RISC Rotary AC/5 missing a decimal place, causing 80% jam chance instead of 8%.