### PR TITLE
KFConsole Event Fixes

### DIFF
--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFC.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFC.json
@@ -21,7 +21,9 @@
             "tagSetSourceFile" : "Tags/CompanyTags",
             "items" : [
                 "KFC_Damaged",
-                "KFC_Offline"
+                "KFC_Offline",
+                "event_Knock",
+                "event_Badabing"
             ]
         },
         "RequirementComparisons" : [

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCBadaBoomRepairs.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCBadaBoomRepairs.json
@@ -46,9 +46,7 @@
                     "Scope" : "Company",
                     "RequirementTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Inactive"
-                        ]
+                        "items" : []
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
@@ -79,7 +77,8 @@
                             "RemovedTags" : {
                                 "tagSetSourceFile" : "",
                                 "items" : [
-                                    "KFC_Repaired"
+                                    "KFC_Repaired",
+                                    "event_knock"
                                 ]
                             },
                             "Stats" : [
@@ -128,9 +127,7 @@
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Active"
-                        ]
+                        "items" : []
                     },
                     "RequirementComparisons" : []
                 }
@@ -161,6 +158,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
                                     "Misjumped_Delta", 
@@ -225,6 +223,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Gamma", 
                                     "Misjumped_Delta", 
@@ -289,6 +288,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Delta", 
@@ -353,6 +353,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -417,6 +418,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -481,6 +483,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -545,6 +548,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -609,6 +613,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -673,6 +678,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -737,6 +743,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -801,6 +808,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -865,6 +873,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -929,6 +938,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -993,6 +1003,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1057,6 +1068,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1121,6 +1133,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1185,6 +1198,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1249,6 +1263,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1313,6 +1328,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1377,6 +1393,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1441,6 +1458,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 
@@ -1505,6 +1523,7 @@
                                 "items" : [
                                     "KFC_Inactive",
                                     "KFC_Repaired",
+                                    "event_knock",
                                     "Misjumped_Alpha", 
                                     "Misjumped_Beta", 
                                     "Misjumped_Gamma", 

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCBadabing.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCBadabing.json
@@ -95,7 +95,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -185,7 +186,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -291,7 +293,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -381,7 +384,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -471,7 +475,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -561,7 +566,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -651,7 +657,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -741,7 +748,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -831,7 +839,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -921,7 +930,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1060,7 +1070,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1150,7 +1161,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1240,7 +1252,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1330,7 +1343,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1420,7 +1434,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1510,7 +1525,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1600,7 +1616,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1690,7 +1707,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1780,7 +1798,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -1870,7 +1889,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2009,7 +2029,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2099,7 +2120,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2189,7 +2211,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2279,7 +2302,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2369,7 +2393,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2459,7 +2484,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2549,7 +2575,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2639,7 +2666,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2729,7 +2757,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -2819,7 +2848,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Active",
-                                    "KFC_Warmup"
+                                    "KFC_Warmup",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCCheatahFixed.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCCheatahFixed.json
@@ -46,9 +46,7 @@
                     "Scope" : "Company",
                     "RequirementTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Inactive"
-                        ]
+                        "items" : []
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
@@ -130,9 +128,7 @@
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Active"
-                        ]
+                        "items" : []
                     },
                     "RequirementComparisons" : []
                 }

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCFuFixed.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCFuFixed.json
@@ -46,9 +46,7 @@
                     "Scope" : "Company",
                     "RequirementTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Inactive"
-                        ]
+                        "items" : []
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
@@ -130,9 +128,7 @@
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Active"
-                        ]
+                        "items" : []
                     },
                     "RequirementComparisons" : []
                 }

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCKerbyFixed.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCKerbyFixed.json
@@ -46,9 +46,7 @@
                     "Scope" : "Company",
                     "RequirementTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Inactive"
-                        ]
+                        "items" : []
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
@@ -130,9 +128,7 @@
                     },
                     "ExclusionTags" : {
                         "tagSetSourceFile" : "",
-                        "items" : [
-                            "KFC_Active"
-                        ]
+                        "items" : []
                     },
                     "RequirementComparisons" : []
                 }

--- a/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCRepairDelay.json
+++ b/Optionals/Eventualities/Wherethafuqawe/events/event_co_KFCRepairDelay.json
@@ -101,7 +101,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -195,7 +196,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -289,7 +291,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -383,7 +386,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -477,7 +481,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -571,7 +576,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -665,7 +671,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -759,7 +766,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -853,7 +861,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [
@@ -947,7 +956,8 @@
                                 "tagSetSourceFile" : "",
                                 "items" : [
                                     "KFC_Inactive",
-                                    "KFC_RepairDelay"
+                                    "KFC_RepairDelay",
+                                    "event_Knock"
                                 ]
                             },
                             "Stats" : [


### PR DESCRIPTION
Added missing exclusion to NORMAL spawn events;
Removed Req/Excl from FORCEEVENT "Fixed" chain series; Added missing event_knock tag