### PR TITLE
Fixed untagged pilots in s7 contracts

### DIFF
--- a/Core/Solaris7/contracts/solaris_assault_league/solaris_assault_4x4freeforall_mech_2.json
+++ b/Core/Solaris7/contracts/solaris_assault_league/solaris_assault_4x4freeforall_mech_2.json
@@ -5235,9 +5235,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5281,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5327,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5373,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_assault_league/solaris_assault_4x4freeforall_mech_5.json
+++ b/Core/Solaris7/contracts/solaris_assault_league/solaris_assault_4x4freeforall_mech_5.json
@@ -5235,9 +5235,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5281,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5327,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5373,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_assault_league/solaris_assault_4x4freeforall_mech_8.json
+++ b/Core/Solaris7/contracts/solaris_assault_league/solaris_assault_4x4freeforall_mech_8.json
@@ -5235,9 +5235,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5281,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5327,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5373,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_heavy_league/solaris_heavy_4x4freeforall_mech_2.json
+++ b/Core/Solaris7/contracts/solaris_heavy_league/solaris_heavy_4x4freeforall_mech_2.json
@@ -5235,9 +5235,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5281,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5327,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5373,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_heavy_league/solaris_heavy_4x4freeforall_mech_5.json
+++ b/Core/Solaris7/contracts/solaris_heavy_league/solaris_heavy_4x4freeforall_mech_5.json
@@ -5235,9 +5235,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5281,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5327,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5373,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_heavy_league/solaris_heavy_4x4freeforall_mech_8.json
+++ b/Core/Solaris7/contracts/solaris_heavy_league/solaris_heavy_4x4freeforall_mech_8.json
@@ -5235,9 +5235,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5281,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5327,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5373,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4battle_mech_2.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4battle_mech_2.json
@@ -545,9 +545,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -588,9 +591,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -631,9 +637,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -674,9 +683,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4battle_mech_5.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4battle_mech_5.json
@@ -545,9 +545,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -588,9 +591,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -631,9 +637,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -674,9 +683,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4battle_mech_8.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4battle_mech_8.json
@@ -545,9 +545,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -588,9 +591,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -631,9 +637,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -674,9 +683,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4ctf_mech_2.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4ctf_mech_2.json
@@ -827,9 +827,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -870,9 +873,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -913,9 +919,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -956,9 +965,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4ctf_mech_5.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4ctf_mech_5.json
@@ -826,9 +826,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -869,9 +872,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -912,9 +918,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -955,9 +964,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4ctf_mech_8.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4ctf_mech_8.json
@@ -826,9 +826,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -869,9 +872,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -912,9 +918,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -955,9 +964,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4freeforall_mech_2.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4freeforall_mech_2.json
@@ -3707,9 +3707,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3749,9 +3752,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3791,9 +3797,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3833,9 +3842,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5235,9 +5247,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5293,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5339,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5385,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4freeforall_mech_5.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4freeforall_mech_5.json
@@ -3707,9 +3707,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3749,9 +3752,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3791,9 +3797,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3833,9 +3842,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5235,9 +5247,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5293,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5339,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5385,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d7",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4freeforall_mech_8.json
+++ b/Core/Solaris7/contracts/solaris_light_league/solaris_light_4x4freeforall_mech_8.json
@@ -3707,9 +3707,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3749,9 +3752,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3791,9 +3797,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -3833,9 +3842,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5235,9 +5247,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5278,9 +5293,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5321,9 +5339,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5364,9 +5385,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_medium_league/solaris_medium_4x4freeforall_mech_2.json
+++ b/Core/Solaris7/contracts/solaris_medium_league/solaris_medium_4x4freeforall_mech_2.json
@@ -5234,9 +5234,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5276,9 +5279,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5318,9 +5324,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5360,9 +5369,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d5",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_medium_league/solaris_medium_4x4freeforall_mech_5.json
+++ b/Core/Solaris7/contracts/solaris_medium_league/solaris_medium_4x4freeforall_mech_5.json
@@ -5860,9 +5860,10 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [                "pilot_npc_d7"
+],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {

--- a/Core/Solaris7/contracts/solaris_medium_league/solaris_medium_4x4freeforall_mech_8.json
+++ b/Core/Solaris7/contracts/solaris_medium_league/solaris_medium_4x4freeforall_mech_8.json
@@ -5234,9 +5234,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5276,9 +5279,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5318,9 +5324,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {
@@ -5360,9 +5369,12 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilotDef_InheritLance",
+            "pilotDefId": "Tagged",
             "pilotTagSet": {
-              "items": [],
+              "items": [
+                "pilot_npc_d9",
+                "pilot_npc_high"
+              ],
               "tagSetSourceFile": "tags/PilotTags"
             },
             "pilotExcludedTagSet": {


### PR DESCRIPTION
Swapped pilotdef_inheritlance on s7 contracts calling tagged units 