### PR TITLE
Small Fixes

### DIFF
--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Laser.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Laser.json
@@ -17,8 +17,8 @@
       "AMSDmg: 2",
       "AMSAcc: 55%",
       "AMSShots: 12",
-      "AMSHeat: 4",
-      "LanceMode: -15%, +4, 20, +50m",
+      "AMSHeat: 6",
+      "LanceMode: -15%, +4, 20%, +50m",
       "AMSActivationsAlt: 2"
     ],
     "Flags": [

--- a/Core/RogueModuleTech/AMS/Weapon_AMS_Laser_Clan.json
+++ b/Core/RogueModuleTech/AMS/Weapon_AMS_Laser_Clan.json
@@ -10,12 +10,13 @@
     ],
     "BonusDescriptions": [
       "LAMS",
-      "AMSSINGLE",
-      "AMSDmg: 2",
-      "AMSAcc: 40%",
-      "AMSShots: 18",
-      "AMSHeat: 5",
-      "DamageMode: +2, -10%, +5, 50%"
+      "AMSDmg: 4",
+      "AMSAcc: 50%",
+      "AMSShots: 15",
+      "AMSHeat: 15",
+      "AMSActivations: 2",
+      "AMSActivationsAlt: 1",
+      "AMSAltMode: Safe, 2, 60%, 15, 10, no"
     ],
     "Flags": [
       "not_broken"
@@ -51,7 +52,7 @@
   ],
   "AmmoCategory": "NotSet",
   "StartingAmmoCapacity": 0,
-  "HeatGenerated": 10,
+  "HeatGenerated": 15,
   "Damage": 0,
   "HeatDamage": 0,
   "Instability": 0,
@@ -100,29 +101,29 @@
   "CriticalComponent": false,
   "Modes": [
     {
-      "Id": "Safe",
-      "UIName": "Safe",
-      "Name": "Safe",
-      "Description": "LAMS Fires 15 Shots",
-      "isBaseMode": false,
-      "ShotsWhenFired": 15,
-      "IsAMS": true,
-      "AMSHitChance": 0.6,
-      "AMSDamage": 2,
-      "AMSActivationsPerTurn": 1
-    },
-    {
       "Id": "Damage",
       "UIName": "Damage",
       "Name": "Damage",
       "Description": "LAMS Fires 15 Shots at +2 damage",
       "isBaseMode": true,
-      "HeatGenerated": 5,
       "ShotsWhenFired": 15,
       "IsAMS": true,
       "AMSHitChance": 0.5,
       "AMSDamage": 4,
       "FlatJammingChance": 0.5
+    },
+    {
+      "Id": "Safe",
+      "UIName": "Safe",
+      "Name": "Safe",
+      "Description": "LAMS Fires 15 Shots",
+      "isBaseMode": false,
+      "HeatGenerated": -5,
+      "ShotsWhenFired": 15,
+      "IsAMS": true,
+      "AMSHitChance": 0.6,
+      "AMSDamage": 2,
+      "AMSActivationsPerTurn": -1
     },
     {
       "Id": "Off",

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Large.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Large.json
@@ -14,7 +14,6 @@
       "VariableDmg: 10",
       "ChemicalLaser",
       "AAFactor: 5%",
-      "ReqLandAirMech",
       "EjectableWeapon",
       "InternalAmmoShots: 16",
       "AmmoCost: 185"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Medium.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemLaser_Medium.json
@@ -13,7 +13,6 @@
       "WingMountDrag",
       "VariableDmg: 5",
       "ChemicalLaser",
-      "ReqLandAirMech",
       "EjectableWeapon",
       "InternalAmmoShots: 16",
       "AmmoCost: 100"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemPulse.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_ChemPulse.json
@@ -16,7 +16,6 @@
       "DamageUnitBoth: +100%, Squads",
       "AccuracyUnit: Squads & Vehicles",
       "AccuracyUnit2: +4",
-      "ReqLandAirMech",
       "EjectableWeapon",
       "InternalAmmoShots: 10",
       "AmmoCost: 40"

--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_Vulcan.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_Vulcan.json
@@ -16,7 +16,6 @@
       "DamageUnitBoth: +100%, Squads",
       "AccuracyUnit: Squads & Vehicles",
       "AccuracyUnit2: +4",
-      "ReqLandAirMech",
       "EjectableWeapon",
       "InternalAmmoShots: 10",
       "AmmoCost: 25"

--- a/Core/RogueModuleTech/Quirks/Upgrades/Quirk_VariableRangeTargeting.json
+++ b/Core/RogueModuleTech/Quirks/Upgrades/Quirk_VariableRangeTargeting.json
@@ -6,6 +6,7 @@
       }
     ],
     "BonusDescriptions": [
+      "VariableTargetingQuirk: +1",
       "Activatable",
       "Quirk"
     ],

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_Gauss_Prototype_Heavy.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_Gauss_Prototype_Heavy.json
@@ -12,9 +12,9 @@
       "HAMMERFIST: 10%",
       "WpnCrits: +100%",
       "DmgFallOff: 45%",
-      "WpnRecoil: 4",
-      "WeaponJAM: 5",
-      "BraceToFire: 52",
+      "WpnRecoil: 5",
+      "WeaponJAMFlat: 25%",
+      "BraceToFire: 54",
       "IsHeavyGauss",
       "WeaponExplosionInertAmmo: 87.5, 43.8, 21.9"
     ],
@@ -35,23 +35,23 @@
   "Category": "Ballistic",
   "Type": "Gauss",
   "WeaponSubType": "Gauss",
-  "MinRange": 0,
-  "MaxRange": 630,
+  "MinRange": 90,
+  "MaxRange": 810,
   "RangeSplit": [
-    190,
-    310,
-    450
+    270,
+    450,
+    630
   ],
   "AmmoCategory": "HGAUSS",
   "StartingAmmoCapacity": 0,
   "HeatGenerated": 12,
-  "Damage": 175,
+  "Damage": 180,
   "HeatDamage": 0,
   "Instability": 43.75,
   "DamageVariance": 0,
   "AccuracyModifier": 0,
   "EvasivePipsIgnored": 0,
-  "RefireModifier": 4,
+  "RefireModifier": 5,
   "OverheatedDamageMultiplier": 0,
   "EvasiveDamageMultiplier": 0,
   "CriticalChanceMultiplier": 2,
@@ -70,8 +70,8 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.01,
   "GunneryJammingBase": 1,
-  "RecoilJammingChance": 0.05,
-  "AttackRecoil": 10,
+  "FlatJammingChance": 0.25,
+  "AttackRecoil": 5,
   "WeaponEffectID": "WeaponEffect-Weapon_GaussRifle",
   "Description": {
     "Cost": 875000,
@@ -82,7 +82,7 @@
     "UIName": "Prototype HGR",
     "Id": "Unique_Weapon_Gauss_Prototype_Heavy",
     "Name": "Heavy Gauss Rifle",
-    "Details": "This Prototype Hammerfist Heavy Gauss Rifle is permanently affixed to the Dreka Chassis, sporting superior Range and Damage to the final production model at cost of runnign very hot with a chance that the Capacitor may fail to charge in time.<b><color=#099ff2>VOLATILE!</color></b>",
+    "Details": "This Prototype Hammerfist Heavy Gauss Rifle is permanently affixed to the Dreka Chassis. It sports superior range and damage to the final production model, at the cost of heat and a chance that the Capacitor may fail to charge in time.<b><color=#099ff2>VOLATILE!</color></b>",
     "Icon": "GAUSS"
   },
   "BonusValueA": "",
@@ -145,7 +145,7 @@
       "statisticData": {
         "statName": "SelfInstability_OnFire",
         "operation": "Float_Add",
-        "modValue": "52",
+        "modValue": "54",
         "modType": "System.Single"
       }
     }

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_AMS.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_AMS.json
@@ -247,6 +247,12 @@
       "Full": "Damage mode is {0} damage, {1} accuracy, {2} heat, and {3} jam chance."
     },
     {
+      "Bonus": "AMSAltMode",
+      "Short": "Alt{1}Dmg",
+      "Long": "Alt: {1} dmg, {2} acc, {3} shots, {4} heat, {5} jam",
+      "Full": "{0} mode: {1} damage, {2} accuracy, {3} shots, {4} heat, and {5} jam chance."
+    },
+    {
       "Bonus": "PirateLAMS",
       "Short": "No Off mode",
       "Long": "No off mode, {0} jam",

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_CAE.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_CAE.json
@@ -407,6 +407,12 @@
       "Short": "AA Multi {0}",
       "Long": "AA Factor Mult {0}",
       "Full": "{0} multiplier to Anti-Air Factor of this unit's weapons when active"
+    },
+    {
+      "Bonus": "VariableTargetingQuirk",
+      "Short": "VRangeAcc{0}",
+      "Long": "{0} Acc at variable range",
+      "Full": "Provides a toggleable {0} accuracy bonus at either longer or shorter ranges."
     }
   ]
 }

--- a/RtConfig.xml
+++ b/RtConfig.xml
@@ -3,7 +3,7 @@
 	<LancherUpdateUrl>https://discourse.modsinexile.com/t/rogue-tech/134</LancherUpdateUrl>
 	<RequiredBattleTechVersion>1.9.1</RequiredBattleTechVersion>
 	<RequiredLauncherVersion>1.3.12</RequiredLauncherVersion>
-	<SecureHash>FqMWcRbtFl8WTxatFtAWrBakFpoWGhbjFlsWTxafFkY=</SecureHash>
+	<SecureHash>FkQWzxZ2FrIWzRbeFhYWHxamFrQWoRbXFuEWzxYXFnw=</SecureHash>
 	<showCoreItems>false</showCoreItems>
 	<Tasks>
 		<InstallTask>
@@ -193,7 +193,7 @@
 			<saveBreaking>false</saveBreaking>
 			<sourcePath>InstallOptions/GlobalDifficulty/GlobalDifficultyByCompany/settings.json</sourcePath>
 			<targetPath>Core/DropCostsEnhanced/settings.json</targetPath>
-			<uiDescription>Base difficulty goes up the more money your mechs are worth. 14,000,000 cbills per half-skull. It counts the your averaged deployment value for the last several missions. +5% Online Progress.</uiDescription>
+			<uiDescription>Base difficulty goes up the more money your mechs are worth. 10,000,000 cbills per half-skull. It counts the your averaged deployment value for the last several missions. +5% Online Progress.</uiDescription>
 			<uiName>Difficulty by Company Strength</uiName>
 		</InstallTask>
 		<InstallTask>
@@ -782,7 +782,7 @@
 			<saveBreaking>true</saveBreaking>
 			<sourcePath>Optionals/Urbocalypse</sourcePath>
 			<targetPath>Optionals/Urbocalypse</targetPath>
-			<uiDescription>UrbanMechs, UrbanMech's everyhwere! +1% Online Progress.</uiDescription>
+			<uiDescription>UrbanMechs, UrbanMechs everywhere! +1% Online Progress.</uiDescription>
 			<uiName>Urbocalypse</uiName>
 		</InstallTask>
 		<InstallTask>
@@ -1048,7 +1048,7 @@
 			<saveBreaking>false</saveBreaking>
 			<sourcePath>InstallOptions/ConcreteJungle</sourcePath>
 			<targetPath>Options/ConcreteJungle</targetPath>
-			<uiDescription>Urban Biomes my includes ambushes, traps and destroyed environment. +2% Online Progress.</uiDescription>
+			<uiDescription>Urban Biomes may include ambushes, traps, and destroyed environment. +2% Online Progress.</uiDescription>
 			<uiName>Change Urban Biomes to wartorn Nightmares</uiName>
 		</InstallTask>
 		<InstallTask>
@@ -1523,7 +1523,7 @@
 			<saveBreaking>false</saveBreaking>
 			<sourcePath>InstallOptions/Screams/Screams/CustomAmmoCategoriesSettings.json</sourcePath>
 			<targetPath>Core/CustomAmmoCategories/CustomAmmoCategoriesSettings.json</targetPath>
-			<uiDescription>Civilians have not properly evacuated and may be stomped on in their Cars. War is a messy buisness.</uiDescription>
+			<uiDescription>Civilians have not properly evacuated and may be stomped on in their Cars. War is a messy business.</uiDescription>
 			<uiName>Civilians didn't evacuate Cities</uiName>
 		</InstallTask>
 		<InstallTask>


### PR DESCRIPTION
- Wingmounts: Remove incorrect "requires LAM" description from a couple wingmounted weapons.
- Install Settings: Fix a couple typos.
- Prototype HGR: 
- - Recoil increased from 4 to 5
- - Self-Instability increased from 52 to 54.
- - Jam Chance adjusted from 5% per recoil to a flat 25%.
- - Range adjusted from 0-630 to 90-810.
- - Damage increased from 175 to 180.
- Add a trait description to the Variable Range Targeting Quirk
- Laser AMS: Update the traits to match the actual behavior.
- Laser AMS (C): Update the traits to match the actual behavior.
- Laser AMS (C): Remove unintended extra activations in "safe" mode.