### PR TITLE
Fix: Event Breaking Typo

### DIFF
--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Arcadia.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Arcadia.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Babylon.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Babylon.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Bearclaw.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Bearclaw.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Circe.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Circe.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Dagda.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Dagda.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Eden.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Eden.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Fasa.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Fasa.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Radulov.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Radulov.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_StranaMechty.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_StranaMechty.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",

--- a/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Tokasha.json
+++ b/Optionals/RTOLegendsMechs/RogueSociety/events/event_mw_KDK_Tokasha.json
@@ -584,7 +584,7 @@
                             "Actions" : [
                                 {
                                     "Type" : "System_AddContract",
-                                    "value" : "CaptureBase_KhaosTheory_BS",
+                                    "value" : "CaptureBase_KhaosTheory_B",
                                     "valueConstant" : "",
                                     "additionalValues" : [
                                         "AuriganPirates",


### PR DESCRIPTION
Contract Spawn for Khaos Theory Mech fixed to remove typo preventing event from continuing