### PR TITLE
New MWO Bull Sharks

### DIFF
--- a/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-1.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-1.json
@@ -1,0 +1,271 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.15
+    },
+    "AssemblyVariant": {
+      "PrefabID": "bullshark",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_Intimidating",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Majesty Metals and Manufacturing",
+    "Model": "BSK-1",
+    "UIName": "Bull Shark",
+    "Id": "chassisdef_bullshark_BSK-1",
+    "Name": "Bull Shark",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-1 is mostly faithful to the original 'Mech, though it lacks the iconic artillery piece and standardizes the weapons selection for a more consistent range.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark"
+  },
+  "VariantName": "BSK-1",
+  "ChassisTags": {
+    "items": [
+      "ArmLimitUpperLeft",
+      "ArmLimitUpperRight"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "We've started to see more of these so-called <i>Bull Sharks</i> recently. Seems like whoever copied those schematics finally made a breakthrough in manufacturing.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_bullshark",
+  "PrefabIdentifier": "chrPrfMech_bullsharkBase-001",
+  "PrefabBase": "bullshark",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 200,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-2.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-2.json
@@ -1,0 +1,276 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.15
+    },
+    "AssemblyVariant": {
+      "PrefabID": "bullshark",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_Intimidating",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Majesty Metals and Manufacturing",
+    "Model": "BSK-2",
+    "UIName": "Bull Shark",
+    "Id": "chassisdef_bullshark_BSK-2",
+    "Name": "Bull Shark",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-2 is a reimagining of the original 'Mech as an \"energy boat\" design.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark"
+  },
+  "VariantName": "BSK-2",
+  "ChassisTags": {
+    "items": [
+      "ArmLimitUpperLeft",
+      "ArmLimitUpperRight"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "We've started to see more of these so-called <i>Bull Sharks</i> recently. Seems like whoever copied those schematics finally made a breakthrough in manufacturing.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_bullshark",
+  "PrefabIdentifier": "chrPrfMech_bullsharkBase-001",
+  "PrefabBase": "bullshark",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 200,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-3.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-3.json
@@ -1,0 +1,280 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.15
+    },
+    "AssemblyVariant": {
+      "PrefabID": "bullshark",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_Intimidating",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Majesty Metals and Manufacturing",
+    "Model": "BSK-3",
+    "UIName": "Bull Shark",
+    "Id": "chassisdef_bullshark_BSK-3",
+    "Name": "Bull Shark",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-3 reimagines the classic <i>Bull Shark</i> as a long-range fire support platform.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark"
+  },
+  "VariantName": "BSK-3",
+  "ChassisTags": {
+    "items": [
+      "ArmLimitUpperLeft",
+      "ArmLimitUpperRight"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "We've started to see more of these so-called <i>Bull Sharks</i> recently. Seems like whoever copied those schematics finally made a breakthrough in manufacturing.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_bullshark",
+  "PrefabIdentifier": "chrPrfMech_bullsharkBase-001",
+  "PrefabBase": "bullshark",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 200,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-4.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-4.json
@@ -1,0 +1,269 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.15
+    },
+    "AssemblyVariant": {
+      "PrefabID": "bullshark",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_Intimidating",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Clan Wolverine",
+    "Model": "BSK-4",
+    "UIName": "Bull Shark",
+    "Id": "chassisdef_bullshark_BSK-4",
+    "Name": "Bull Shark",
+    "Details": "A 95-ton Assault 'Mech, the Bull Shark traces its origins back to the disgraced Clan Wolverine. As with many of the Not-Named Clan's accomplishments, the Bull Shark schematics were silently seized by the other clans, who went on to produce their own distinct versions.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark"
+  },
+  "VariantName": "BSK-4",
+  "ChassisTags": {
+    "items": [
+      "ArmLimitUpperLeft",
+      "ArmLimitUpperRight",
+      "ClanMech"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "We've seen a few of these Clan 'Mechs cropping up recently. Interestingly, their specs and overall appearance match up pretty closely with some mystery 'Mech that turned up in a wrecked JumpShip a while back. ... Eh, probably a coincidence, right, Boss?",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_bullshark",
+  "PrefabIdentifier": "chrPrfMech_bullsharkBase-001",
+  "PrefabBase": "bullshark",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 200,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-5.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-5.json
@@ -1,0 +1,260 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.15
+    },
+    "AssemblyVariant": {
+      "PrefabID": "bullshark",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_Intimidating",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Majesty Metals and Manufacturing",
+    "Model": "BSK-5",
+    "UIName": "Bull Shark",
+    "Id": "chassisdef_bullshark_BSK-5",
+    "Name": "Bull Shark",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-5 is mostly faithful to the original 'Mech, though it lacks the iconic artillery piece and standardizes the weapons selection for a more consistent range.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark"
+  },
+  "VariantName": "BSK-5",
+  "ChassisTags": {
+    "items": [
+      "ArmLimitUpperLeft",
+      "ArmLimitUpperRight"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "We've started to see more of these so-called <i>Bull Sharks</i> recently. Seems like whoever copied those schematics finally made a breakthrough in manufacturing.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_bullshark",
+  "PrefabIdentifier": "chrPrfMech_bullsharkBase-001",
+  "PrefabBase": "bullshark",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 200,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-6.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/chassis/chassisdef_bullshark_BSK-6.json
@@ -1,0 +1,279 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.15
+    },
+    "AssemblyVariant": {
+      "PrefabID": "bullshark",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_Intimidating",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Majesty Metals and Manufacturing",
+    "Model": "BSK-6",
+    "UIName": "Bull Shark",
+    "Id": "chassisdef_bullshark_BSK-6",
+    "Name": "Bull Shark",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-6 is mostly faithful to the original 'Mech, though it lacks the iconic artillery piece and standardizes the weapons selection for a more consistent range.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark"
+  },
+  "VariantName": "BSK-6",
+  "ChassisTags": {
+    "items": [
+      "ArmLimitUpperLeft",
+      "ArmLimitUpperRight"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "We've started to see more of these so-called <i>Bull Sharks</i> recently. Seems like whoever copied those schematics finally made a breakthrough in manufacturing.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_bullshark",
+  "PrefabIdentifier": "chrPrfMech_bullsharkBase-001",
+  "PrefabBase": "bullshark",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 200,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-1.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-1.json
@@ -1,0 +1,306 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_generic",
+      "unit_bracket_high",
+      "unit_role_sniper",
+      "unit_lance_vanguard",
+      "unit_lance_tank",
+      "unit_core",
+      "unit_dlc",
+      "unit_era_clan_invasion",
+      "unit_release",
+      "unit_mwo",
+      "unit_chassis_bullshark",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_0",
+      "locals",
+      "magistracyofcanopus",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_low",
+      "ai_lance_normal",
+      "ai_lethalself_high",
+      "ai_move_low",
+      "ai_priority_normal",
+      "ai_reserve_high",
+      "ai_shooting_normal",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_bullshark_BSK-1",
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Bull Shark BSK-1",
+    "Id": "mechdef_bullshark_BSK-1",
+    "Name": "Bull Shark BSK-1",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-1 is mostly faithful to the original 'Mech, though it standardizes the weapons selection for a more consistent range.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark",
+    "Commentary": "Source: MechWarrior Online"
+  },
+  "simGameMechPartCost": 1380031,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_5",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_5",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_6",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_6",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_5",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_5",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-2.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-2.json
@@ -1,0 +1,299 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_generic",
+      "unit_bracket_high",
+      "unit_role_sniper",
+      "unit_lance_vanguard",
+      "unit_lance_tank",
+      "unit_core",
+      "unit_dlc",
+      "unit_era_clan_invasion",
+      "unit_release",
+      "unit_mwo",
+      "unit_chassis_bullshark",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_0",
+      "locals",
+      "magistracyofcanopus",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_low",
+      "ai_lance_normal",
+      "ai_lethalself_high",
+      "ai_move_low",
+      "ai_priority_normal",
+      "ai_reserve_high",
+      "ai_shooting_normal",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_bullshark_BSK-2",
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Bull Shark BSK-2",
+    "Id": "mechdef_bullshark_BSK-2",
+    "Name": "Bull Shark BSK-2",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-2 is a reimagining of the original 'Mech as an \"energy boat\" design.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark",
+    "Commentary": "Source: MechWarrior Online"
+  },
+  "simGameMechPartCost": 1380031,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_325",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_PPC",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_PPC",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_PPC",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_PPC",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_JumpJet_Assault",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_JumpJet_Assault",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_JumpJet_Assault",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-3.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-3.json
@@ -1,0 +1,348 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_generic",
+      "unit_bracket_high",
+      "unit_indirectFire",
+      "unit_role_sniper",
+      "unit_lance_assassin",
+      "unit_core",
+      "unit_dlc",
+      "unit_era_clan_invasion",
+      "unit_release",
+      "unit_mwo",
+      "unit_chassis_bullshark",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_0",
+      "locals",
+      "magistracyofcanopus",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_low",
+      "ai_lance_normal",
+      "ai_lethalself_high",
+      "ai_move_low",
+      "ai_priority_normal",
+      "ai_reserve_high",
+      "ai_shooting_normal",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_bullshark_BSK-3",
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Bull Shark BSK-3",
+    "Id": "mechdef_bullshark_BSK-3",
+    "Name": "Bull Shark BSK-3",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-3 reimagines the classic <i>Bull Shark</i> as a long-range fire support platform.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark",
+    "Commentary": "Source: MechWarrior Online"
+  },
+  "simGameMechPartCost": 1380031,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_300",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Weapon_TAG",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_LRM_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_LRM_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_LRM_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_LRM_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_LRM_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-4.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-4.json
@@ -1,0 +1,356 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_generic",
+      "unit_bracket_high",
+      "unit_role_sniper",
+      "unit_lance_vanguard",
+      "unit_lance_tank",
+      "unit_core",
+      "unit_dlc",
+      "unit_era_clan_invasion",
+      "unit_release",
+      "unit_mwo",
+      "unit_chassis_bullshark",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_0",
+      "clansgeneric",
+      "clanburrock",
+      "clancloudcobra",
+      "clancoyote",
+      "clandiamondshark",
+      "clanfiremandrill",
+      "clangoliathscorpion",
+      "clanhellshorses",
+      "clanicehellion",
+      "clanjadefalcon",
+      "clannovacat",
+      "clanstaradder",
+      "clansteelviper",
+      "clansmokejaguar",
+      "clansnowraven",
+      "clanwolf",
+      "ClanWolfInExile",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_low",
+      "ai_lance_normal",
+      "ai_lethalself_high",
+      "ai_move_low",
+      "ai_priority_normal",
+      "ai_reserve_high",
+      "ai_shooting_normal",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_bullshark_BSK-4",
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Bull Shark BSK-4",
+    "Id": "mechdef_bullshark_BSK-4",
+    "Name": "Bull Shark BSK-4",
+    "Details": "A 95-ton Assault 'Mech, the Bull Shark traces its origins back to the disgraced Clan Wolverine. As with many of the Not-Named Clan's accomplishments, the Bull Shark schematics were silently seized by the other clans, who went on to produce their own distinct versions.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark",
+    "Commentary": "Source: MechWarrior Online"
+  },
+  "simGameMechPartCost": 1380031,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_320",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_LBX_20_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_6_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_SRM_6_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_SRM_6_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_6_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_SRM_6_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_LBX_20_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Slug",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Cluster",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Cluster_Half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Slug",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_20_Cluster",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-5.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-5.json
@@ -1,0 +1,278 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_generic",
+      "unit_bracket_high",
+      "unit_role_sniper",
+      "unit_lance_assassin",
+      "unit_lance_tank",
+      "unit_core",
+      "unit_dlc",
+      "unit_era_clan_invasion",
+      "unit_release",
+      "unit_mwo",
+      "unit_chassis_bullshark",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_0",
+      "locals",
+      "magistracyofcanopus",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_low",
+      "ai_lance_normal",
+      "ai_lethalself_high",
+      "ai_move_low",
+      "ai_priority_normal",
+      "ai_reserve_high",
+      "ai_shooting_normal",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_bullshark_BSK-5",
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Bull Shark BSK-5",
+    "Id": "mechdef_bullshark_BSK-5",
+    "Name": "Bull Shark BSK-5",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-5 is mostly faithful to the original 'Mech, though it standardizes the weapons selection for a more consistent range.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark",
+    "Commentary": "Source: MechWarrior Online"
+  },
+  "simGameMechPartCost": 1380031,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 210,
+      "CurrentRearArmor": 65,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 210,
+      "AssignedRearArmor": 65,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 150,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 150,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 185,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 185,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 185,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 185,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_PPC",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_10",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_PPC",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_10",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_10",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_10",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_JumpJet_Assault",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_JumpJet_Assault",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_JumpJet_Assault",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-6.json
+++ b/Eras/ClanInvasion3061/Base HeavyMetal/mech/mechdef_bullshark_BSK-6.json
@@ -1,0 +1,334 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_generic",
+      "unit_bracket_high",
+      "unit_role_sniper",
+      "unit_lance_vanguard",
+      "unit_lance_tank",
+      "unit_core",
+      "unit_dlc",
+      "unit_era_clan_invasion",
+      "unit_release",
+      "unit_mwo",
+      "unit_chassis_bullshark",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_0",
+      "locals",
+      "magistracyofcanopus",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_low",
+      "ai_lance_normal",
+      "ai_lethalself_high",
+      "ai_move_low",
+      "ai_priority_normal",
+      "ai_reserve_high",
+      "ai_shooting_normal",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_bullshark_BSK-6",
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Bull Shark BSK-6",
+    "Id": "mechdef_bullshark_BSK-6",
+    "Name": "Bull Shark BSK-6",
+    "Details": "A 95-ton Assault 'Mech of unknown origin, the <i>Bull Shark</i> was originally discovered aboard an abandoned jump ship named <i>Dobrev</i>. Since then, the design has been studied and copied by Majesty Metals and Manufacturing within the Inner Sphere. The BSK-6 is mostly faithful to the original 'Mech, though it lacks the iconic artillery piece and standardizes the weapons selection for a more consistent range.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark",
+    "Commentary": "Source: MechWarrior Online"
+  },
+  "simGameMechPartCost": 1380031,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Structure_EndoSteel",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Autocannon_AC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Autocannon_AC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Large",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Autocannon_AC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Autocannon_AC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_AC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_AC_2",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Uniques HeavyMetal/chassis/chassisdef_bullshark_BSK-M.json
+++ b/Eras/ClanInvasion3061/Uniques HeavyMetal/chassis/chassisdef_bullshark_BSK-M.json
@@ -38,7 +38,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "ClanMech"
+      "ClanMech",
+      "UniqueMech"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Uniques HeavyMetal/chassis/chassisdef_bullshark_BSK-M.json
+++ b/Eras/ClanInvasion3061/Uniques HeavyMetal/chassis/chassisdef_bullshark_BSK-M.json
@@ -1,0 +1,276 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.15
+    },
+    "AssemblyVariant": {
+      "PrefabID": "bullshark",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_Intimidating",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Clan Wolverine",
+    "Model": "BSK-M",
+    "UIName": "Bull Shark",
+    "Id": "chassisdef_bullshark_BSK-M",
+    "Name": "Bull Shark",
+    "Details": "A 95-ton Assault 'Mech, the Bull Shark traces its origins back to the disgraced Clan Wolverine. As with many of the Not-Named Clan's accomplishments, the Bull Shark schematics were silently seized by the other clans, who went on to produce their own distinct versions, such as the storied 'Mako'.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark"
+  },
+  "VariantName": "BSK-M",
+  "ChassisTags": {
+    "items": [
+      "ArmLimitUpperLeft",
+      "ArmLimitUpperRight",
+      "ClanMech"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Juggernaut",
+  "YangsThoughts": "We've seen a few of these Clan 'Mechs cropping up recently. Interestingly, their specs and overall appearance match up pretty closely with some mystery 'Mech that turned up in a wrecked JumpShip a while back. ... Eh, probably a coincidence, right, Boss?",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_bullshark",
+  "PrefabIdentifier": "chrPrfMech_bullsharkBase-001",
+  "PrefabBase": "bullshark",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 200,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/ClanInvasion3061/Uniques HeavyMetal/mech/mechdef_bullshark_BSK-M.json
+++ b/Eras/ClanInvasion3061/Uniques HeavyMetal/mech/mechdef_bullshark_BSK-M.json
@@ -55,7 +55,7 @@
     "Cost": 6900156,
     "Rarity": 5,
     "Purchasable": false,
-    "UIName": "Bull Shark BSK-M",
+    "UIName": "Bull Shark BSK-M 'Mako'",
     "Id": "mechdef_bullshark_BSK-M",
     "Name": "Bull Shark BSK-M",
     "Details": "A 95-ton Assault 'Mech, the Bull Shark traces its origins back to the disgraced Clan Wolverine. As with many of the Not-Named Clan's accomplishments, the Bull Shark schematics were silently seized by the other clans, who went on to produce their own distinct versions.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",

--- a/Eras/ClanInvasion3061/Uniques HeavyMetal/mech/mechdef_bullshark_BSK-M.json
+++ b/Eras/ClanInvasion3061/Uniques HeavyMetal/mech/mechdef_bullshark_BSK-M.json
@@ -1,0 +1,352 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_generic",
+      "unit_legendary",
+      "unit_unique",
+      "unit_indirectFire",
+      "unit_bracket_high",
+      "unit_role_sniper",
+      "unit_lance_assassin",
+      "unit_lance_tank",
+      "unit_core",
+      "unit_dlc",
+      "unit_era_clan_invasion",
+      "unit_release",
+      "unit_mwo",
+      "unit_chassis_bullshark",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_0",
+      "clansgeneric",
+      "clanburrock",
+      "clancloudcobra",
+      "clancoyote",
+      "clandiamondshark",
+      "clanfiremandrill",
+      "clangoliathscorpion",
+      "clanhellshorses",
+      "clanicehellion",
+      "clanjadefalcon",
+      "clannovacat",
+      "clanstaradder",
+      "clansteelviper",
+      "clansmokejaguar",
+      "clansnowraven",
+      "clanwolf",
+      "ClanWolfInExile",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_low",
+      "ai_lance_normal",
+      "ai_lethalself_high",
+      "ai_move_low",
+      "ai_priority_normal",
+      "ai_reserve_high",
+      "ai_shooting_normal",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_bullshark_BSK-M",
+  "Description": {
+    "Cost": 6900156,
+    "Rarity": 5,
+    "Purchasable": false,
+    "UIName": "Bull Shark BSK-M",
+    "Id": "mechdef_bullshark_BSK-M",
+    "Name": "Bull Shark BSK-M",
+    "Details": "A 95-ton Assault 'Mech, the Bull Shark traces its origins back to the disgraced Clan Wolverine. As with many of the Not-Named Clan's accomplishments, the Bull Shark schematics were silently seized by the other clans, who went on to produce their own distinct versions.\n\n<b><color=#e62e00>Quirk: Intimidating</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.15</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Icon": "uixTxrIcon_bullshark",
+    "Commentary": "Source: MechWarrior Online"
+  },
+  "simGameMechPartCost": 1380031,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 225,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 225,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 45,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 45,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 155,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 155,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 195,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 195,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Structure_EndoSteel_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_2",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_LBX_10_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_UAC_5_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_LRM_15_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Small_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_LRM_15_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Small_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_LBX_10_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_UAC_5_Clan",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_10_Slug",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_UAC_5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_LBX_10_Cluster",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_UAC_5",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM_Clan",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_HeatSink_Double_Clan",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}


### PR DESCRIPTION
Adds new MWO Bull Shark 'Mechs.

### Clan Invasion (Heavy Metal required)
- BSK-1, Inner Sphere 95-ton Assault BattleMech
- BSK-2, Inner Sphere 95-ton Assault BattleMech
- BSK-3, Inner Sphere 95-ton Assault BattleMech
- BSK-4, Clan 95-ton Assault BattleMech
- BSK-5, Inner Sphere 95-ton Assault BattleMech
- BSK-6, Inner Sphere 95-ton Assault BattleMech
- BSK-M, Clan 95-ton 'hero' Assault BattleMech