### PR TITLE
Swap Unique 'Mech replacement for BSK-M

### DIFF
--- a/Eras/ClanInvasion3061/Uniques HeavyMetal/chassis/chassisdef_bullshark_BSK-M.json
+++ b/Eras/ClanInvasion3061/Uniques HeavyMetal/chassis/chassisdef_bullshark_BSK-M.json
@@ -9,7 +9,7 @@
       "Include": true
     },
     "LootableUniqueMech": {
-      "ReplaceID": "mechdef_bullshark_BSK-M3"
+      "ReplaceID": "mechdef_bullshark_BSK-4"
     }
   },
   "CustomParts": {


### PR DESCRIPTION
BSK-4 is a better replacement for BSK-M since they are both Clan 'Mechs. The BSK-M3 is an Inner Sphere 'Mech.