### PR TITLE
update SH Console Gate events

### DIFF
--- a/Optionals/Superheavys/Base/events/event_sh_gate1.json
+++ b/Optionals/Superheavys/Base/events/event_sh_gate1.json
@@ -26,12 +26,6 @@
         "op": "GreaterThan",
         "val": 100,
         "valueConstant": "100"
-      },
-      {
-          "obj" : "DelayAssessment",
-          "op" : "LessThanOrEqual",
-          "val" : 0,
-          "valueConstant" : "0"
       }
     ]
   },
@@ -63,31 +57,6 @@
                 "items": [
                   "mrb_authorization_epsilon_wait"
                 ],
-                "tagSetSourceFile": "Tags/CompanyTags"
-              },
-              "RemovedTags": {
-                "items": [],
-                "tagSetSourceFile": ""
-              },
-              "Stats": [
-                {
-                    "typeString" : "System.Int32",
-                    "name" : "DelayAssessment",
-                    "value" : "1",
-                    "set" : false,
-                    "valueConstant" : null
-                }
-            ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 180
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
                 "tagSetSourceFile": "Tags/CompanyTags"
               },
               "RemovedTags": {

--- a/Optionals/Superheavys/Base/events/event_sh_gate2.json
+++ b/Optionals/Superheavys/Base/events/event_sh_gate2.json
@@ -28,12 +28,6 @@
         "op": "GreaterThan",
         "val": 20,
         "valueConstant": "20"
-      },
-      {
-          "obj" : "DelaySHAssessment",
-          "op" : "LessThanOrEqual",
-          "val" : 0,
-          "valueConstant" : "0"
       }
     ]
   },
@@ -62,34 +56,9 @@
               "Scope": "Company",
               "Requirements": null,
               "AddedTags": {
-                "tagSetSourceFile": "Tags/CompanyTags",
                 "items": [
                   "mrb_authorization_omega_wait"
-                ]
-              },
-              "RemovedTags": {
-                "tagSetSourceFile": "",
-                "items": []
-              },
-              "Stats": [
-                {
-                    "typeString" : "System.Int32",
-                    "name" : "DelaySHAssessment",
-                    "value" : "1",
-                    "set" : false,
-                    "valueConstant" : null
-                }
-            ],
-              "Actions": null,
-              "ForceEvents": null,
-              "TemporaryResult": true,
-              "ResultDuration": 180
-            },
-            {
-              "Scope": "Company",
-              "Requirements": null,
-              "AddedTags": {
-                "items": [],
+                ],
                 "tagSetSourceFile": "Tags/CompanyTags"
               },
               "RemovedTags": {


### PR DESCRIPTION
Removed Temporary Scope, Moved "wait" tag to permanent Company Scope

This disables the RNG event from spawning with the addition of the exclusion tag as a permanent addition upon selecting WAIT from event options.  ForceEvent callback will ignore tags and properly call the event 180 days later.  This will repeat each time WAIT is selected until console is built, at which time event will no longer trigger.