### PR TITLE
Hopeful Airstrike Softlock Fix

### DIFF
--- a/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Alekto.json
+++ b/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Alekto.json
@@ -7,7 +7,7 @@
   },
   "ActivationTime": "CommandAbility",
   "Resource": "CommandAbility",
-  "ActivationETA": 20,
+  "ActivationETA": 30,
   "ActivationCooldown": 3,
   "StartInCooldown": true,
   "NumberOfUses": 2,

--- a/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Fiona.json
+++ b/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Fiona.json
@@ -7,7 +7,7 @@
   },
   "ActivationTime": "CommandAbility",
   "Resource": "CommandAbility",
-  "ActivationETA": 20,
+  "ActivationETA": 30,
   "ActivationCooldown": 3,
   "StartInCooldown": true,
   "NumberOfUses": 2,

--- a/Core/StrategicOperations/abilities/AbilityDefCMD_Strafe_AI.json
+++ b/Core/StrategicOperations/abilities/AbilityDefCMD_Strafe_AI.json
@@ -7,7 +7,7 @@
   },
   "ActivationTime": "CommandAbility",
   "Resource": "CommandAbility",
-  "ActivationETA": 20,
+  "ActivationETA": 30,
   "ActivationCooldown": 3,
   "StartInCooldown": true,
   "NumberOfUses": 2,


### PR DESCRIPTION
Increase strafe delay from 20 phases to 30 phases. Hopefully this avoids the double-strike softlocks.