### PR TITLE
Update TBAS Events

### DIFF
--- a/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_ArmL.json
+++ b/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_ArmL.json
@@ -39,14 +39,7 @@
 						"disable_debilHeal"
 					]
 				},
-				"RequirementComparisons": [
-					{
-						"obj": "Injuries",
-						"op": "GreaterThan",
-						"val": 0,
-						"valueConstant": "0"
-					}
-				]
+				"RequirementComparisons": []
 			}
 		}
 	],

--- a/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_ArmR.json
+++ b/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_ArmR.json
@@ -39,14 +39,7 @@
 						"disable_debilHeal"
 					]
 				},
-				"RequirementComparisons": [
-					{
-						"obj": "Injuries",
-						"op": "GreaterThan",
-						"val": 0,
-						"valueConstant": "0"
-					}
-				]
+				"RequirementComparisons": []
 			}
 		}
 	],

--- a/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_Head.json
+++ b/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_Head.json
@@ -39,14 +39,7 @@
 						"disable_debilHeal"
 					]
 				},
-				"RequirementComparisons": [
-					{
-						"obj": "Injuries",
-						"op": "GreaterThan",
-						"val": 0,
-						"valueConstant": "0"
-					}
-				]
+				"RequirementComparisons": []
 			}
 		}
 	],

--- a/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_LegL.json
+++ b/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_LegL.json
@@ -39,14 +39,7 @@
 						"disable_debilHeal"
 					]
 				},
-				"RequirementComparisons": [
-					{
-						"obj": "Injuries",
-						"op": "GreaterThan",
-						"val": 0,
-						"valueConstant": "0"
-					}
-				]
+				"RequirementComparisons": []
 			}
 		}
 	],

--- a/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_LegR.json
+++ b/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_LegR.json
@@ -39,14 +39,7 @@
 						"disable_debilHeal"
 					]
 				},
-				"RequirementComparisons": [
-					{
-						"obj": "Injuries",
-						"op": "GreaterThan",
-						"val": 0,
-						"valueConstant": "0"
-					}
-				]
+				"RequirementComparisons": []
 			}
 		}
 	],

--- a/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_Torso.json
+++ b/Core/TisButAScratch/events/tbone_event_co_DEBILITATED_Torso.json
@@ -39,14 +39,7 @@
 						"disable_debilHeal"
 					]
 				},
-				"RequirementComparisons": [
-					{
-						"obj": "Injuries",
-						"op": "GreaterThan",
-						"val": 0,
-						"valueConstant": "0"
-					}
-				]
+				"RequirementComparisons": []
 			}
 		}
 	],


### PR DESCRIPTION
Removed Injury check for TBAS events related to DEBILITATED_ tag to allow event to spawn should player retrain injured pilot and inadvertently remove the previously required INJURIES > 0 check.