### PR TITLE
Fixes

### DIFF
--- a/Core/RogueModuleTech/BattleArmor/Gear/Gear_BattleArmor_RemoteSensorDispenser.json
+++ b/Core/RogueModuleTech/BattleArmor/Gear/Gear_BattleArmor_RemoteSensorDispenser.json
@@ -34,7 +34,7 @@
         {
           "durationData": {
             "duration": 2,
-            "stackLimit": -1,
+            "stackLimit": 1,
             "ticksOnActivations": true,
             "useActivationsOfTarget": true
           },
@@ -62,7 +62,7 @@
         {
           "durationData": {
             "duration": 2,
-            "stackLimit": -1,
+            "stackLimit": 1,
             "ticksOnActivations": true,
             "useActivationsOfTarget": true
           },
@@ -144,7 +144,7 @@
         {
           "durationData": {
             "duration": 2,
-            "stackLimit": -1,
+            "stackLimit": 1,
             "ticksOnActivations": true,
             "useActivationsOfTarget": true
           },

--- a/Core/RogueModuleTech/Cockpit/FCS/Gear_FCS_AntiAir.json
+++ b/Core/RogueModuleTech/Cockpit/FCS/Gear_FCS_AntiAir.json
@@ -25,7 +25,7 @@
     "UIName": "FCS AA",
     "Id": "Gear_FCS_AntiAir",
     "Name": "Anti-Air FCS",
-    "Details": "AntiAir Flak Systems-1 is specialized FCS equipped with Aerospace Tracking Radar, very effective against flying targets.",
+    "Details": "Kallon's AntiAir Flak System-1A is a specialized FCS equipped with Aerospace Tracking Radar, very effective against flying targets.",
     "Icon": "targeting"
   },
   "BonusValueA": "",

--- a/Core/RogueModuleTech/Upgrade/Gear_Remote_Sensor_Dispenser.json
+++ b/Core/RogueModuleTech/Upgrade/Gear_Remote_Sensor_Dispenser.json
@@ -10,7 +10,7 @@
       "ActiveProbe: 1",
       "ActiveAdvancedSensors: 2",
       "ActivatableUses: 3",
-      "ActivatableDuration: 2",
+      "ActivatableDurationNoStack: 2",
       "ActiveSensors: 300%",
       "ActiveSight: 200%",
       "ActiveSkillTactics: +5"
@@ -24,13 +24,12 @@
       "ActivationMessage": "Deployed",
       "DeactivationMessage": "",
       "ChargesCount": 3,
-      "ActivateOncePerRound": true,
       "NoUniqueCheck": true,
       "statusEffects": [
         {
           "durationData": {
             "duration": 2,
-            "stackLimit": -1,
+            "stackLimit": 1,
             "ticksOnActivations": true,
             "useActivationsOfTarget": true
           },
@@ -140,7 +139,7 @@
         {
           "durationData": {
             "duration": 2,
-            "stackLimit": -1,
+            "stackLimit": 1,
             "ticksOnActivations": true,
             "useActivationsOfTarget": true
           },

--- a/Core/RogueTechCore/GameTips/general.txt
+++ b/Core/RogueTechCore/GameTips/general.txt
@@ -230,6 +230,8 @@ Combat Tip #69: Nice.
 Combat Tip #70: A trained sniper not only has deadly weapons, but keen eyesight. Same applies to 'Mechs. Have a scout to see where to shoot.
 Combat Tip #71: Always keep an eye on the weaponry the enemy has. High sensor rolls will let you know if that UrbanMech is carrying a party horn or an AC/20.
 Combat Tip #72: Gunnery Skill reduces Jam/Misfire chance by a flat 1 percentage point per point. Other methods are multipliers.
+Combat Tip #73: You can't prioritize targets until you know what's out there. Scout early. Scout often.
+Combat Tip #74: Your scouting only matters if you can actually recognize threats when you see them.
 Combat Hotkeys #1: TAB can be used to cycle between valid targets.
 Combat Hotkeys #2: Press V to cycle between valid melee targets.
 Combat Hotkeys #3: Pressing CTRL+T will enable or disable the coloured attack direction indicators.

--- a/Core/RogueTechCore/GameTips/general.txt
+++ b/Core/RogueTechCore/GameTips/general.txt
@@ -231,7 +231,7 @@ Combat Tip #70: A trained sniper not only has deadly weapons, but keen eyesight.
 Combat Tip #71: Always keep an eye on the weaponry the enemy has. High sensor rolls will let you know if that UrbanMech is carrying a party horn or an AC/20.
 Combat Tip #72: Gunnery Skill reduces Jam/Misfire chance by a flat 1 percentage point per point. Other methods are multipliers.
 Combat Tip #73: You can't prioritize targets until you know what's out there. Scout early. Scout often.
-Combat Tip #74: Your scouting only matters if you can actually recognize threats when you see them.
+Combat Tip #74: Scouting only matters if you can actually recognize threats when you see them.
 Combat Hotkeys #1: TAB can be used to cycle between valid targets.
 Combat Hotkeys #2: Press V to cycle between valid melee targets.
 Combat Hotkeys #3: Pressing CTRL+T will enable or disable the coloured attack direction indicators.

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_CAE.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_CAE.json
@@ -37,6 +37,12 @@
       "Full": "Item has {0} Turns duration."
     },
     {
+      "Bonus": "ActivatableDurationNoStack",
+      "Short": "{0} Turns",
+      "Long": "{0} Turns (no stacking)",
+      "Full": "Effect lasts {0} turn(s). Does not stack."
+    },
+    {
       "Bonus": "AlwaysActive",
       "Short": "Always Active",
       "Long": "Always Active",

--- a/Optionals/PirateTech/Base/chassis/chassisdef_centurion_CN11-OP.json
+++ b/Optionals/PirateTech/Base/chassis/chassisdef_centurion_CN11-OP.json
@@ -7,57 +7,7 @@
       "PrefabID": "OmniCenturion",
       "Exclude": false,
       "Include": true
-    },
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialMelee",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      },
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "LeftArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Melee_Hatchet_2tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialMelee",
-          "HandHeld"
-        ]
-      },
-      {
-        "Location": "LeftArm",
-        "DefID": "Default_HandHeld_Shield_2tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      }
-    ]
+    }
   },
   "CustomParts": {
     "CustomParts": []

--- a/Optionals/PirateTech/Base/mech/mechdef_centurion_CN11-OP.json
+++ b/Optionals/PirateTech/Base/mech/mechdef_centurion_CN11-OP.json
@@ -229,6 +229,20 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_2tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_Hatchet_2tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Supercharger",
       "ComponentDefType": "Upgrade",

--- a/Optionals/Quicsell/Chassis/chassisdef_banshee_BNC-QS2.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_banshee_BNC-QS2.json
@@ -29,33 +29,6 @@
           }
         ]
       }
-    ],
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Shield_10tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      }
     ]
   },
   "CustomParts": {

--- a/Optionals/Quicsell/Chassis/chassisdef_charger_CGR-QS2.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_charger_CGR-QS2.json
@@ -29,33 +29,6 @@
           }
         ]
       }
-    ],
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Shield_10tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      }
     ]
   },
   "CustomParts": {

--- a/Optionals/Quicsell/Chassis/chassisdef_quickdraw_QKD-QS2.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_quickdraw_QKD-QS2.json
@@ -29,33 +29,6 @@
           }
         ]
       }
-    ],
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Shield_7tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      }
     ]
   },
   "CustomParts": {

--- a/Optionals/Quicsell/Chassis/chassisdef_thunderbolt_TDR-QS2.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_thunderbolt_TDR-QS2.json
@@ -29,56 +29,6 @@
           }
         ]
       }
-    ],
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      },
-      {
-        "CategoryID": "SpecialMelee",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "LeftArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Shield_8tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      },
-      {
-        "Location": "LeftArm",
-        "DefID": "Default_HandHeld_Melee_Hatchet_8tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialMelee",
-          "HandHeld"
-        ]
-      }
     ]
   },
   "CustomParts": {

--- a/Optionals/Quicsell/Chassis/chassisdef_wolverine_WVR-QS2.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_wolverine_WVR-QS2.json
@@ -29,33 +29,6 @@
           }
         ]
       }
-    ],
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Shield_8tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      }
     ]
   },
   "CustomParts": {

--- a/Optionals/Quicsell/Mech/mechdef_banshee_BNC-QS2.json
+++ b/Optionals/Quicsell/Mech/mechdef_banshee_BNC-QS2.json
@@ -193,6 +193,13 @@
     },
     {
       "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_10tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_HarJel_Quicsell",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/Quicsell/Mech/mechdef_charger_CGR-QS2.json
+++ b/Optionals/Quicsell/Mech/mechdef_charger_CGR-QS2.json
@@ -208,6 +208,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_10tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftLeg",
       "ComponentDefID": "Gear_Actuator_Leg_Speedy_Quicsell",
       "ComponentDefType": "Upgrade",

--- a/Optionals/Quicsell/Mech/mechdef_quickdraw_QKD-QS2.json
+++ b/Optionals/Quicsell/Mech/mechdef_quickdraw_QKD-QS2.json
@@ -214,6 +214,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_7tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftArm",
       "ComponentDefID": "HandHeld_Weapon_GrenadeVarietyPack_x6_Quicsell",
       "ComponentDefType": "Weapon",

--- a/Optionals/Quicsell/Mech/mechdef_thunderbolt_TDR-QS2.json
+++ b/Optionals/Quicsell/Mech/mechdef_thunderbolt_TDR-QS2.json
@@ -203,7 +203,21 @@
     },
     {
       "MountedLocation": "LeftArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_Hatchet_8tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
       "ComponentDefID": "Gear_CASE2_Quicsell",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_8tons",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/Quicsell/Mech/mechdef_wolverine_WVR-QS2.json
+++ b/Optionals/Quicsell/Mech/mechdef_wolverine_WVR-QS2.json
@@ -173,6 +173,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_8tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_FCS_Recoil_Quicsell",
       "ComponentDefType": "Upgrade",

--- a/Optionals/RISCtech/Base/chassis/chassisdef_skinwalker_R-III-XP-E.json
+++ b/Optionals/RISCtech/Base/chassis/chassisdef_skinwalker_R-III-XP-E.json
@@ -19,33 +19,6 @@
           }
         ]
       }
-    ],
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialMelee",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Melee_VibroSword_3tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialMelee",
-          "HandHeld"
-        ]
-      }
     ]
   },
   "CustomParts": {

--- a/Optionals/RISCtech/Base/mech/mechdef_skinwalker_R-III-XP-E.json
+++ b/Optionals/RISCtech/Base/mech/mechdef_skinwalker_R-III-XP-E.json
@@ -162,6 +162,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_VibroSword_3tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightTorso",
       "ComponentDefID": "BoltOn_Weapon_GrenadeLauncher_5",
       "ComponentDefType": "Weapon",

--- a/Optionals/RogueOmnis/Base/chassis/chassisdef_crossbow_x_CRX-C.json
+++ b/Optionals/RogueOmnis/Base/chassis/chassisdef_crossbow_x_CRX-C.json
@@ -7,57 +7,7 @@
       "PrefabID": "CrossbowX",
       "Exclude": false,
       "Include": true
-    },
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "RightArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      },
-      {
-        "CategoryID": "SpecialMelee",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "LeftArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "RightArm",
-        "DefID": "Default_HandHeld_Shield_5tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      },
-      {
-        "Location": "LeftArm",
-        "DefID": "Default_HandHeld_Melee_Mace_6tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialMelee",
-          "HandHeld"
-        ]
-      }
-    ]
+    }
   },
   "CustomParts": {
     "CustomParts": []

--- a/Optionals/RogueOmnis/Base/mech/mechdef_crossbow_x_CRX-C.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_crossbow_x_CRX-C.json
@@ -222,6 +222,20 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_Mace_6tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_5tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "Head",
       "ComponentDefID": "Gear_TSM_Standard",
       "ComponentDefType": "Upgrade",

--- a/Optionals/Urbocalypse/Base/chassis/chassisdef_urbanmech_UM-WB.json
+++ b/Optionals/Urbocalypse/Base/chassis/chassisdef_urbanmech_UM-WB.json
@@ -10,34 +10,7 @@
     },
     "LootableUniqueMech": {
       "ReplaceID": "mechdef_urbanmech_UM-R60"
-    },
-    "ChassisCategory": [
-      {
-        "CategoryID": "SpecialShield",
-        "Limits": [
-          {
-            "Location": "All",
-            "Max": 1
-          },
-          {
-            "Location": "LeftArm",
-            "Min": 1,
-            "Max": 1
-          }
-        ]
-      }
-    ],
-    "MultiDefaults": [
-      {
-        "Location": "LeftArm",
-        "DefID": "Default_HandHeld_Shield_4tons",
-        "ComponentType": "Upgrade",
-        "Categories": [
-          "SpecialShield",
-          "HandHeld"
-        ]
-      }
-    ]
+    }
   },
   "CustomParts": {
     "FiringArc": 360,

--- a/Optionals/Urbocalypse/Base/mech/mechdef_urbanmech_UM-WB.json
+++ b/Optionals/Urbocalypse/Base/mech/mechdef_urbanmech_UM-WB.json
@@ -225,6 +225,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Lootable_HandHeld_Shield_4tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_Actuator_Arm_Upper_Spiked",
       "ComponentDefType": "Upgrade",


### PR DESCRIPTION
- Remote Sensor Dispenser:
  - Remove `ActivateOncePerRound`
  - normalize effect stack limit of 1
  - clarify non-stacking behavior in trait text.
- Add a couple new loading tips.
- Skinwalker R-III-XP-E: Vibrosword now lootable
- CN11-OP: Hatchet and Shield now lootable
- CRX-X: Mace and Shield now lootable
- UM-WB: Combat Shield now lootable
- BNC-QS2: Combat Shield now lootable
- CGR-QS2: Combat Shield now lootable
- QKD-QS2: Combat Shield now lootable
- TDR-QS2: Hatchet and Shield now lootable
- WVR-QS2: Combat Shield now lootable