### PR TITLE
StBurt Event Chain Updates

### DIFF
--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKBP.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKBP.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw4"
+            "hasPilot_pilot_unknown_mw4",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_CB",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKBP_5.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKBP_5.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw4"
+            "hasPilot_pilot_unknown_mw4",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_CB",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKBP_8.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKBP_8.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw4"
+            "hasPilot_pilot_unknown_mw4",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_CB",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKCB.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKCB.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw3"
+            "hasPilot_pilot_unknown_mw3",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKCB_5.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKCB_5.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw3"
+            "hasPilot_pilot_unknown_mw3",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKCB_8.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKCB_8.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw3"
+            "hasPilot_pilot_unknown_mw3",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKET.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKET.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw2"
+            "hasPilot_pilot_unknown_mw2",
+            "event_JD_SW",
+            "event_JD_CB",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKET_5.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKET_5.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw2"
+            "hasPilot_pilot_unknown_mw2",
+            "event_JD_SW",
+            "event_JD_CB",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKET_8.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKET_8.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw2"
+            "hasPilot_pilot_unknown_mw2",
+            "event_JD_SW",
+            "event_JD_CB",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_CGB.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_CGB.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_CGB_5.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_CGB_5.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_CGB_8.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_CGB_8.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_FRR.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_FRR.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_FRR_5.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_FRR_5.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_FRR_8.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_FRR_8.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_GBD.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_GBD.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_GBD_5.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_GBD_5.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_GBD_8.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_GBD_8.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_LC_5_fallback.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_LC_5_fallback.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_LC_8_fallback.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_LC_8_fallback.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_LC_fallback.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSTB_LC_fallback.json
@@ -93,7 +93,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw"
+            "hasPilot_pilot_unknown_mw",
+            "event_JD_SW",
+            "event_JD_ET",
+            "event_JD_BP",
+            "event_JD_CB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSW.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSW.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw1"
+            "hasPilot_pilot_unknown_mw1",
+            "event_JD_ET",
+            "event_JD_CB",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSW_5.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSW_5.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw1"
+            "hasPilot_pilot_unknown_mw1",
+            "event_JD_ET",
+            "event_JD_CB",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSW_8.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Contracts/CaptureEscort_UNKSW_8.json
@@ -97,7 +97,11 @@
         "ExclusionTags": {
           "items": [
             "event_STB",
-            "hasPilot_pilot_unknown_mw1"
+            "hasPilot_pilot_unknown_mw1",
+            "event_JD_ET",
+            "event_JD_CB",
+            "event_JD_BP",
+            "event_JD_STB"
           ],
           "tagSetSourceFile": ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_BP.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_BP.json
@@ -21,11 +21,7 @@
             "items" : [
                 "event_STBComplete",
                 "event_unknown_mw_delay",
-                "event_JD_BP_Done",
-                "event_JD_SW",
-                "event_JD_ET",
-                "event_JD_CB",
-                "event_JD_STB"
+                "event_JD_BP_Done"
             ],
             "tagSetSourceFile" : ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_CB.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_CB.json
@@ -21,11 +21,7 @@
             "items" : [
                 "event_STBComplete",
                 "event_unknown_mw_delay",
-                "event_JD_CB_Done",
-                "event_JD_SW",
-                "event_JD_ET",
-                "event_JD_BP",
-                "event_JD_STB"
+                "event_JD_CB_Done"
             ],
             "tagSetSourceFile" : ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_ET.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_ET.json
@@ -21,11 +21,7 @@
             "items" : [
                 "event_STBComplete",
                 "event_unknown_mw_delay",
-                "event_JD_ET_Done",
-                "event_JD_SW",
-                "event_JD_CB",
-                "event_JD_BP",
-                "event_JD_STB"
+                "event_JD_ET_Done"
             ],
             "tagSetSourceFile" : ""
         },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_STB.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_STB.json
@@ -36,11 +36,7 @@
                 "items" : [
                     "event_STBComplete",
                     "event_unknown_mw_delay",
-                    "event_JD_STB_Done",
-                    "event_JD_SW",
-                    "event_JD_ET",
-                    "event_JD_BP",
-                    "event_JD_CB"
+                    "event_JD_STB_Done"
                 ],
                 "tagSetSourceFile" : ""
             },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_STB_H.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_STB_H.json
@@ -36,11 +36,7 @@
                 "items" : [
                     "event_STBComplete",
                     "event_unknown_mw_delay",
-                    "event_JD_STB_Done",
-                    "event_JD_SW",
-                    "event_JD_ET",
-                    "event_JD_BP",
-                    "event_JD_CB"
+                    "event_JD_STB_Done"
                 ],
                 "tagSetSourceFile" : ""
             },

--- a/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_SW.json
+++ b/Optionals/RTOLegendsMechs/OperationRevival/Events/event_co_JohnDoe_SW.json
@@ -21,11 +21,7 @@
             "items" : [
                 "event_STBComplete",
                 "event_unknown_mw_delay",
-                "event_JD_SW_Done",
-                "event_JD_ET",
-                "event_JD_CB",
-                "event_JD_BP",
-                "event_JD_STB"
+                "event_JD_SW_Done"
             ],
             "tagSetSourceFile" : ""
         },


### PR DESCRIPTION
Shifted checks for UNK pilot exclusions to contracts, this should allow multiple UNK pilots to now "wake up" and turn into the correct mechwarrior.