### PR TITLE
Update AirCademy and WhamBaLAM events

### DIFF
--- a/Core/Aircademy/events/event_co_VTOL_BYPassed_Death.json
+++ b/Core/Aircademy/events/event_co_VTOL_BYPassed_Death.json
@@ -1,0 +1,154 @@
+{
+    "Description" : {
+        "Id" : "event_co_VTOL_BYPassed_Death",
+        "Name" : "You won't believe this!",
+        "Details" : "A knock sounds on your office door and you call out, \"Come in...\"\r\n\r\nThe door opens and Darius strides in with a datapad and is barely holding back the urge to laugh, \"Commander, you... <i>giggle</i>... you know how [[DEAD_MW,{DEAD_MW.Callsign}]] returned without being given any credentials stating to that they had actually passed VTOL training, and we lost them in during that contract?\"\r\n\r\nYou look up from your monitor, \"Yeah, but I fail to see what you think is so funny about that.\"\r\n\r\nDarius hands a datapad over to you, \"Well, it appears they did pass their training.  All the paperwork certifying that [[DEAD_MW,{DEAD_MW.Callsign}]] is fully qualified to pilot a VTOL has just come in.  Apparently a misrouted HPG message caused the delay in notifying us.  The details are all there.  Should we pin a copy of their certification on the <i>MEMORIAL WALL</i>?\"",
+        "Icon" : "uixTxrSpot_VTOLGrad.png"
+    },
+    "Scope" : "DeadMechWarrior",
+    "Weight" : 100000,
+    "Requirements" : {
+        "Scope" : "DeadMechWarrior",
+        "RequirementTags" : {
+            "items" : [
+                "pilot_VTOL_School"
+            ],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [
+        {
+            "Scope" : "Company",
+            "RequirementTags" : {
+                "items" : [],
+                "tagSetSourceFile" : ""
+            },
+            "ExclusionTags" : {
+                "items" : [],
+                "tagSetSourceFile" : "Tags/CompanyTags"
+            },
+            "RequirementComparisons" : [
+                {
+                    "obj" : "PilotEnrolled",
+                    "op" : "Equal",
+                    "val" : 1,
+                    "valueConstant" : "1"
+                }
+            ]
+        }
+    ],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "the loss of <i>[[DEAD_MW,{DEAD_MW.Callsign}]]</i>",
+                "Details" : "TOAST",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : "Tags/CompanyTags"
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "PilotEnrolled",
+                            "op" : "Equal",
+                            "val" : 1,
+                            "valueConstant" : "1"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Seriously??",
+                        "Details" : "You don't even bother to look at the certification on the datapad, instead reaching over and opening a drawer in your desk.  Pulling out a bottle and two glasses, you pour yourself and Darius a drink, \"[[DEAD_MW,{DEAD_MW.Callsign}]] was a damned fine MechWarrior.  They will be always be missed.\"\r\n\r\nDaruis takes his glass and <i>chinks</i> against yours, \"I couldn't agree more, Commander.",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : [
+                        {
+                            "Scope" : "DeadMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_VTOL_School"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "PilotEnrolled",
+                                    "value" : "0",
+                                    "set" : true,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "FUNERAL",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}

--- a/Core/WhamBaLAM/events/event_co_LAM_BYPassed_Death.json
+++ b/Core/WhamBaLAM/events/event_co_LAM_BYPassed_Death.json
@@ -1,0 +1,154 @@
+{
+    "Description" : {
+        "Id" : "event_co_LAM_BYPassed_Death",
+        "Name" : "You won't believe this!",
+        "Details" : "A knock sounds on your office door and you call out, \"Come in...\"\r\n\r\nThe door opens and Darius strides in with a datapad and is barely holding back the urge to laugh, \"Commander, you... <i>giggle</i>... you know how [[DEAD_MW,{DEAD_MW.Callsign}]] returned without being given any credentials stating to that they had actually passed LAM training, and we lost them in during that contract?\"\r\n\r\nYou look up from your monitor, \"Yeah, but I fail to see what you think is so funny about that.\"\r\n\r\nDarius hands a datapad over to you, \"Well, it appears they did pass their training.  All the paperwork certifying that [[DEAD_MW,{DEAD_MW.Callsign}]] is fully qualified to pilot a LAM has just come in.  Apparently a misrouted HPG message caused the delay in notifying us.  The details are all there.  Should we pin a copy of their certification on the <i>MEMORIAL WALL</i>?\"",
+        "Icon" : "uixTxrSpot_LAMGrad.png"
+    },
+    "Scope" : "DeadMechWarrior",
+    "Weight" : 100000,
+    "Requirements" : {
+        "Scope" : "DeadMechWarrior",
+        "RequirementTags" : {
+            "items" : [
+                "pilot_LAM_School"
+            ],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "RequirementComparisons" : []
+    },
+    "AdditionalRequirements" : [
+        {
+            "Scope" : "Company",
+            "RequirementTags" : {
+                "items" : [],
+                "tagSetSourceFile" : ""
+            },
+            "ExclusionTags" : {
+                "items" : [],
+                "tagSetSourceFile" : "Tags/CompanyTags"
+            },
+            "RequirementComparisons" : [
+                {
+                    "obj" : "LAMPilotEnrolled",
+                    "op" : "Equal",
+                    "val" : 1,
+                    "valueConstant" : "1"
+                }
+            ]
+        }
+    ],
+    "AdditionalObjects" : [],
+    "Options" : [
+        {
+            "Description" : {
+                "Id" : "outcome_0",
+                "Name" : "the loss of <i>[[DEAD_MW,{DEAD_MW.Callsign}]]</i>",
+                "Details" : "TOAST",
+                "Icon" : null
+            },
+            "RequirementList" : [
+                {
+                    "Scope" : "Company",
+                    "RequirementTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : ""
+                    },
+                    "ExclusionTags" : {
+                        "items" : [],
+                        "tagSetSourceFile" : "Tags/CompanyTags"
+                    },
+                    "RequirementComparisons" : [
+                        {
+                            "obj" : "LAMPilotEnrolled",
+                            "op" : "Equal",
+                            "val" : 1,
+                            "valueConstant" : "1"
+                        }
+                    ]
+                }
+            ],
+            "ResultSets" : [
+                {
+                    "Description" : {
+                        "Id" : "outcome_0_0",
+                        "Name" : "Seriously??",
+                        "Details" : "You don't even bother to look at the certification on the datapad, instead reaching over and opening a drawer in your desk.  Pulling out a bottle and two glasses, you pour yourself and Darius a drink, \"[[DEAD_MW,{DEAD_MW.Callsign}]] was a damned fine MechWarrior.  They will be always be missed.\"\r\n\r\nDaruis takes his glass and <i>chinks</i> against yours, \"I couldn't agree more, Commander.",
+                        "Icon" : null
+                    },
+                    "Weight" : 100,
+                    "Results" : [
+                        {
+                            "Scope" : "DeadMechWarrior",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [
+                                    "pilot_LAM_School"
+                                ],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : null,
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        },
+                        {
+                            "Scope" : "Company",
+                            "Requirements" : null,
+                            "AddedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "RemovedTags" : {
+                                "items" : [],
+                                "tagSetSourceFile" : ""
+                            },
+                            "Stats" : [
+                                {
+                                    "typeString" : "System.Int32",
+                                    "name" : "LAMPilotEnrolled",
+                                    "value" : "0",
+                                    "set" : true,
+                                    "valueConstant" : null
+                                }
+                            ],
+                            "Actions" : null,
+                            "ForceEvents" : null,
+                            "TemporaryResult" : false,
+                            "ResultDuration" : 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements" : {
+                "Scope" : "Company",
+                "RequirementTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "ExclusionTags" : {
+                    "items" : [],
+                    "tagSetSourceFile" : ""
+                },
+                "RequirementComparisons" : []
+            }
+        }
+    ],
+    "PublishState" : "PUBLISHED",
+    "ValidationState" : "UNTESTED",
+    "EventType" : "FUNERAL",
+    "OneTimeEvent" : false,
+    "Tags" : {
+        "items" : [],
+        "tagSetSourceFile" : "tags/EventTags"
+    }
+}


### PR DESCRIPTION
Added events to account for possible pilot death PRIOR to finishing LAM or VTOL training due to the bug that can keep the final event from spawning which allows pilot to be used in combat/events until the BYPASS can trigger.  Pilot death without the BYPASS event would inadvertently lock player out of any further training of that type