### PR TITLE
Update Wherethafuqawe items

### DIFF
--- a/Optionals/Eventualities/Wherethafuqawe/bonusDescriptions/BonusDescriptions_Wherethafuqawe.json
+++ b/Optionals/Eventualities/Wherethafuqawe/bonusDescriptions/BonusDescriptions_Wherethafuqawe.json
@@ -5,6 +5,30 @@
       "Short": "ROI_KFC",
       "Long": "Result Oriented Item for Misjump Event",
       "Full": "This is not an installable item. It will appear in your inventory, but only to trigger an event action"
+    },
+    {
+      "Bonus": "KFC_KerbyInjectors",
+      "Short": "KFC_KerbyInjectors",
+      "Long": "Collectible part for the KFC Drive Assembly and Repairs",
+      "Full": "Requires Fu Capacitor, Cheatah NavComputer and KFC Blueprints to build KF Console"
+    },
+    {
+      "Bonus": "KFC_FuCapacitor",
+      "Short": "KFC_FuCapacitor",
+      "Long": "Collectible part for the KFC Drive Assembly and Repairs",
+      "Full": "Requires Kerby Injectors, Cheatah NavComputer and KFC Blueprints to build KF Console"
+    },
+    {
+      "Bonus": "KFC_CheatahNavCom",
+      "Short": "KFC_CheatahNavCom",
+      "Long": "Collectible part for the KFC Drive Assembly and Repairs",
+      "Full": "Requires Kerby Injectors, Fu Capacitors and KFC Blueprints to build KF Console"
+    },
+    {
+      "Bonus": "KFC_Blueprints",
+      "Short": "KFC_Blueprints",
+      "Long": "Collectible part for the KFC Drive Assembly and Repairs",
+      "Full": "Requires Kerby Injectors, Fu Capacitors and Cheatah NavComputer to build KF Console"
     }
   ]
 }

--- a/Optionals/Eventualities/Wherethafuqawe/items/Gear_CheatahNavComputer.json
+++ b/Optionals/Eventualities/Wherethafuqawe/items/Gear_CheatahNavComputer.json
@@ -1,7 +1,8 @@
 {
   "Custom": {
     "BonusDescriptions": [
-      "ROI_KFC"
+      "ROI_KFC",
+      "KFC_CheatahNavCom"
     ],
     "Flags": [
       "not_broken"

--- a/Optionals/Eventualities/Wherethafuqawe/items/Gear_FuCapacitor.json
+++ b/Optionals/Eventualities/Wherethafuqawe/items/Gear_FuCapacitor.json
@@ -1,7 +1,8 @@
 {
   "Custom": {
     "BonusDescriptions": [
-      "ROI_KFC"
+      "ROI_KFC",
+      "KFC_FuCapacitor"
     ],
     "Flags": [
       "not_broken"

--- a/Optionals/Eventualities/Wherethafuqawe/items/Gear_KFCBlueprints.json
+++ b/Optionals/Eventualities/Wherethafuqawe/items/Gear_KFCBlueprints.json
@@ -1,7 +1,8 @@
 {
   "Custom": {
     "BonusDescriptions": [
-      "ROI_KFC"
+      "ROI_KFC",
+      "KFC_Blueprints"
     ],
     "Flags": [
       "not_broken"

--- a/Optionals/Eventualities/Wherethafuqawe/items/Gear_KerbyInjectors.json
+++ b/Optionals/Eventualities/Wherethafuqawe/items/Gear_KerbyInjectors.json
@@ -1,7 +1,8 @@
 {
   "Custom": {
     "BonusDescriptions": [
-      "ROI_KFC"
+      "ROI_KFC",
+      "KFC_KerbyInjectors"
     ],
     "Flags": [
       "not_broken"


### PR DESCRIPTION
Cosmetic QoL update to four required items for KF Console construction that adds extra "trait" info so players understand there are four more components.