### PR TITLE
Fix copypaste error in Four Bolts

### DIFF
--- a/Core/RGoBoom/events/event_mw_therearefourbolts_theSequel.json
+++ b/Core/RGoBoom/events/event_mw_therearefourbolts_theSequel.json
@@ -171,7 +171,7 @@
                             "ForceEvents" : [
                                 {
                                     "Scope" : "Company",
-                                    "EventID" : "forceevent_co_safetychecks_sequel_sequel",
+                                    "EventID" : "forceevent_co_safetychecks_sequel",
                                     "MinDaysWait" : 0,
                                     "MaxDaysWait" : 0,
                                     "Probability" : 100,


### PR DESCRIPTION
one part of Four Bolts event incorrectly lists typo'd target forcedevent.