### PR TITLE
Headshot fcs/bc = fixed to mechs

### DIFF
--- a/Core/DynamicShops/data/RT_Clan_Gear_Uncommon.csv
+++ b/Core/DynamicShops/data/RT_Clan_Gear_Uncommon.csv
@@ -49,7 +49,6 @@ Gear_TargetingTrackingSystem_Range_Extreme,Upgrade,1,5
 Gear_TargetingTrackingSystem_Gunnery,Upgrade,1,5
 Gear_TargetingTrackingSystem_Guts,Upgrade,1,5
 Gear_TargetingTrackingSystem_Missile,Upgrade,1,5
-Gear_TargetingTrackingSystem_Headshot,Upgrade,1,5
 Gear_TargetingTrackingSystem_Heat,Upgrade,1,5
 Gear_TargetingTrackingSystem_Indirect,Upgrade,1,5
 Gear_TargetingTrackingSystem_Ballistic,Upgrade,1,5

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Headhunter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Headhunter.json
@@ -1,0 +1,76 @@
+{
+  "id": "AffinityDef_fixed_Headhunter",
+  "affinityType": "Quirk",
+  "affinityData": {
+    "quirkNames": [
+      "Gear_FCS_Headshot",
+      "Gear_TargetingTrackingSystem_Headshot"
+    ],
+    "affinityLevels": [
+      {
+        "missionsRequired": 40,
+        "levelName": "Pinpoint",
+        "decription": "+1 Called Shot Accaurcy",
+        "affinities": [],
+        "effectData": [
+          {
+            "durationData": {
+              "duration": -1,
+              "stackLimit": -1
+            },
+            "targetingData": {
+              "effectTriggerType": "Passive",
+              "effectTargetType": "Creator"
+            },
+            "effectType": "StatisticEffect",
+            "nature": "Buff",
+            "Description": {
+              "Id": "TC-CalledShotAcc",
+              "Name": "Quirk Affinity Careful Aim: Improved Called Shot Hit Chance",
+              "Details": "PASSIVE: Attacking with a single weapon ignores COVER and GUARDED on the target.",
+              "Icon": "uixSvgIcon_ability_precisionstrike"
+            },
+            "statisticData": {
+              "statName": "IRTCalledShotMod",
+              "operation": "Int_Add",
+              "modValue": "-1",
+              "modType": "System.Int32"
+            }
+          }
+        ]
+      },
+      {
+        "missionsRequired": 120,
+        "levelName": "Headhunter",
+        "decription": "+1 Called Shot Accaurcy",
+        "affinities": [],
+        "effectData": [
+          {
+            "durationData": {
+              "duration": -1,
+              "stackLimit": -1
+            },
+            "targetingData": {
+              "effectTriggerType": "Passive",
+              "effectTargetType": "Creator"
+            },
+            "effectType": "StatisticEffect",
+            "nature": "Buff",
+            "Description": {
+              "Id": "TC-CalledShotAcc",
+              "Name": "Quirk Affinity Careful Aim: Improved Called Shot Hit Chance",
+              "Details": "PASSIVE: Attacking with a single weapon ignores COVER and GUARDED on the target.",
+              "Icon": "uixSvgIcon_ability_precisionstrike"
+            },
+            "statisticData": {
+              "statName": "IRTCalledShotMod",
+              "operation": "Int_Add",
+              "modValue": "-1",
+              "modType": "System.Int32"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Core/MonsterMashup/MonsterMashLoot/itemCollection_loot_MonsterMash_Rattler_SLDF.csv
+++ b/Core/MonsterMashup/MonsterMashLoot/itemCollection_loot_MonsterMash_Rattler_SLDF.csv
@@ -16,7 +16,6 @@ Gear_Gyro_Ultralight,Upgrade,1,15
 Gear_HighPrecisionConvergeSystem,Upgrade,1,15
 Gear_StabilizedHousing,Upgrade,1,15
 Gear_TargetingTrackingSystem_Optics,Upgrade,1,15
-Gear_TargetingTrackingSystem_Headshot,Upgrade,1,15
 Gear_TargetingTrackingSystem_Jam,Upgrade,1,15
 Lootable_Gyro_Ultralight_Stabilized,Upgrade,1,15
 HandHeld_Weapon_CombatShotgun,Weapon,1,15

--- a/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_FCS_Headshot-RTO.json
+++ b/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_FCS_Headshot-RTO.json
@@ -7,7 +7,7 @@
     ],
     "BonusDescriptions": [
       "AllowsHeadshot",
-      "OffensivePushAcc: -2",
+      "OffensivePushAcc: +2",
       "FCS"
     ],
     "Flags": [
@@ -24,14 +24,14 @@
     }
   },
   "Description": {
-    "Cost": 500000,
-    "Rarity": 5,
-    "Purchasable": true,
+    "Cost": 5000000,
+    "Rarity": 99,
+    "Purchasable": false,
     "Manufacturer": "Octogon",
     "Model": "Octagon Accutrack I",
-    "UIName": "FCS Headshot",
+    "UIName": "FCS Headshot RTO",
     "Id": "Gear_FCS_Headshot",
-    "Name": "FCS Headshot",
+    "Name": "FCS Headshot RTO",
     "Details": "The Octagon Accutrack I was commissioned in 3025 as the ongoing mech conflicts found more and more skilled pilots utilizing obstructions in order to reduce oncoming fire. Outfitted with a simple prediction system, it allowed a 'Mech pilot a temporary window to land accurate shots on targets without fear of hitting the cover around the enemy.",
     "Icon": "targeting"
   },
@@ -93,7 +93,7 @@
       "statisticData": {
         "statName": "IRTCalledShotMod",
         "operation": "Int_Add",
-        "modValue": "+2",
+        "modValue": "-2",
         "modType": "System.Int32"
       }
     }

--- a/Core/RogueModuleTech/TargetTrackingSystem/Gear_TargetingTrackingSystem_Headshot.json
+++ b/Core/RogueModuleTech/TargetTrackingSystem/Gear_TargetingTrackingSystem_Headshot.json
@@ -7,6 +7,7 @@
     ],
     "BonusDescriptions": [
       "AllowsHeadshot",
+      "OffensivePushAcc: -3",
       "CalledShotBC: 4%",
       "BattleComputer"
     ],
@@ -79,6 +80,30 @@
       "effectType": "StatisticEffect",
       "nature": "Buff",
       "Description": {
+        "Id": "TC-CalledShotAcc",
+        "Name": "FCS Adv TC (C): Improved Called Shot Hit Chance",
+        "Details": "PASSIVE: Attacking with a single weapon ignores COVER and GUARDED on the target.",
+        "Icon": "uixSvgIcon_ability_precisionstrike"
+      },
+      "statisticData": {
+        "statName": "IRTCalledShotMod",
+        "operation": "Int_Add",
+        "modValue": "+3",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
         "Id": "TC-Headshot",
         "Name": "BC Headshot: Enable Always Allow Called Shot",
         "Details": "PASSIVE: Attacking with a single weapon ignores COVER and GUARDED on the target.",
@@ -94,6 +119,8 @@
   ],
   "ComponentTags": {
     "items": [
+      "BLACKLISTED",
+      "LootMagnetBlacklist",
       "component_type_variant",
       "BattleComputer",
       "SquadIncompatible"

--- a/Core/RogueModuleTech/Unique/Gear/Unique_FCS_Erinya.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_FCS_Erinya.json
@@ -28,8 +28,7 @@
     },
     "IBLS": {
       "StorageSize": 1
-    },
-    "Lootable": "Gear_FCS_Headshot"
+    }
   },
   "Description": {
     "Cost": 850000,

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_conjurer_HND-3.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_conjurer_HND-3.json
@@ -20,6 +20,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_enforcer_iii_ENF-6T.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_enforcer_iii_ENF-6T.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_goliath_GOL-5D.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_goliath_GOL-5D.json
@@ -31,6 +31,13 @@
   },
   "FixedEquipment": [
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Quirk_MultiTrack",
       "ComponentDefType": "Upgrade",

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_ostsol_OTL-6D.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_ostsol_OTL-6D.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_supernova_SNV-3.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_supernova_SNV-3.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_wolverine_WVR-8D.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_wolverine_WVR-8D.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_conjurer_HND-3.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_conjurer_HND-3.json
@@ -146,13 +146,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_300",
       "ComponentDefType": "HeatSink",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_enforcer_iii_ENF-6T.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_enforcer_iii_ENF-6T.json
@@ -148,13 +148,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_goliath_GOL-5D.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_goliath_GOL-5D.json
@@ -135,13 +135,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_MultiTrack",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_ostsol_OTL-6D.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_ostsol_OTL-6D.json
@@ -156,13 +156,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_MultiTrack",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_supernova_SNV-3.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_supernova_SNV-3.json
@@ -149,13 +149,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_wolverine_WVR-8D.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_wolverine_WVR-8D.json
@@ -147,13 +147,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_275",
       "ComponentDefType": "HeatSink",

--- a/Eras/CivilWar3062-3067/Uniques Heavy Metal/chassis/chassisdef_assassin_ASN-SRV.json
+++ b/Eras/CivilWar3062-3067/Uniques Heavy Metal/chassis/chassisdef_assassin_ASN-SRV.json
@@ -49,6 +49,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/CivilWar3062-3067/Uniques Heavy Metal/mech/mechdef_assassin_ASN-SRV.json
+++ b/Eras/CivilWar3062-3067/Uniques Heavy Metal/mech/mechdef_assassin_ASN-SRV.json
@@ -148,13 +148,6 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Recon",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/CivilWar3062-3067/Uniques/mech/mechdef_marauder_ii_MAD-BH.json
+++ b/Eras/CivilWar3062-3067/Uniques/mech/mechdef_marauder_ii_MAD-BH.json
@@ -194,13 +194,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_blackjack_BJ-G.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_blackjack_BJ-G.json
@@ -20,6 +20,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_blackknight_BL-9-KNT.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_blackknight_BL-9-KNT.json
@@ -46,6 +46,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_dire_wolf_DW-F3.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_dire_wolf_DW-F3.json
@@ -42,6 +42,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Engine_XL_Clan",
       "ComponentDefType": "HeatSink",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_stormcrow_SCR-TC.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_stormcrow_SCR-TC.json
@@ -42,6 +42,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Engine_XL_Clan",
       "ComponentDefType": "HeatSink",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_tempest_TP-1.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_tempest_TP-1.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_turkina_TKR-B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_turkina_TKR-B.json
@@ -47,6 +47,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_285",
       "ComponentDefType": "HeatSink",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_warhammer_WHM-6W.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_warhammer_WHM-6W.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_warhammer_WHM-6W3.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_warhammer_WHM-6W3.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_blackjack_BJ-G.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_blackjack_BJ-G.json
@@ -134,13 +134,6 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Sniper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_blackknight_BL-9-KNT.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_blackknight_BL-9-KNT.json
@@ -129,13 +129,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Gyro_Melee_Plus",
       "ComponentDefType": "Upgrade",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_dire_wolf_DW-F3.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_dire_wolf_DW-F3.json
@@ -163,13 +163,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_stormcrow_SCR-TC.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_stormcrow_SCR-TC.json
@@ -163,13 +163,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_tempest_TP-1.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_tempest_TP-1.json
@@ -177,13 +177,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_turkina_TKR-B.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_turkina_TKR-B.json
@@ -148,13 +148,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_warhammer_WHM-6W.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_warhammer_WHM-6W.json
@@ -142,13 +142,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_warhammer_WHM-6W3.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_warhammer_WHM-6W3.json
@@ -143,13 +143,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Uniques FlashPoint/chassis/chassisdef_crab_CRB-S.json
+++ b/Eras/ClanInvasion3061/Uniques FlashPoint/chassis/chassisdef_crab_CRB-S.json
@@ -34,6 +34,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Uniques FlashPoint/mech/mechdef_crab_CRB-S.json
+++ b/Eras/ClanInvasion3061/Uniques FlashPoint/mech/mechdef_crab_CRB-S.json
@@ -139,13 +139,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range_Extreme",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_marauder_MAD-BH.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_marauder_MAD-BH.json
@@ -22,6 +22,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_rifleman_iic_RFL-IIC-CH.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_rifleman_iic_RFL-IIC-CH.json
@@ -34,6 +34,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_thunder_stallion_TST-1_mitchell.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_thunder_stallion_TST-1_mitchell.json
@@ -38,6 +38,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_MechTrait_Quad",
       "ComponentDefType": "Upgrade",

--- a/Eras/ClanInvasion3061/Uniques/mech/mechdef_rifleman_iic_RFL-IIC-CH.json
+++ b/Eras/ClanInvasion3061/Uniques/mech/mechdef_rifleman_iic_RFL-IIC-CH.json
@@ -187,13 +187,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Gyro_XL",
       "ComponentDefType": "Upgrade",

--- a/Eras/ClanInvasion3061/Uniques/mech/mechdef_thunder_stallion_TST-1_mitchell.json
+++ b/Eras/ClanInvasion3061/Uniques/mech/mechdef_thunder_stallion_TST-1_mitchell.json
@@ -147,13 +147,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_avalanche_AVL-1ON.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_avalanche_AVL-1ON.json
@@ -21,6 +21,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_EndoSteel",
       "ComponentDefType": "Upgrade",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_deimos_DEI-E.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_deimos_DEI-E.json
@@ -33,6 +33,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_EndoSteel_Clan",
       "ComponentDefType": "Upgrade",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_sagittaire_SGT-14R.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_sagittaire_SGT-14R.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_skinwalker_R-III-C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_skinwalker_R-III-C.json
@@ -34,6 +34,13 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Structure_EndoSteel_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_skinwalker_R-III-F.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_skinwalker_R-III-F.json
@@ -47,6 +47,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_330",
       "ComponentDefType": "HeatSink",

--- a/Eras/DarkAge3131-/Base/mech/mechdef_avalanche_AVL-1ON.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_avalanche_AVL-1ON.json
@@ -140,13 +140,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Tactics",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/mech/mechdef_deimos_DEI-E.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_deimos_DEI-E.json
@@ -145,13 +145,6 @@
     },
     {
       "MountedLocation": "RightArm",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/mech/mechdef_sagittaire_SGT-14R.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_sagittaire_SGT-14R.json
@@ -149,13 +149,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/mech/mechdef_skinwalker_R-III-C.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_skinwalker_R-III-C.json
@@ -137,13 +137,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_HeatSinkKit_Double_Clan",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Base/mech/mechdef_skinwalker_R-III-F.json
+++ b/Eras/DarkAge3131-/Base/mech/mechdef_skinwalker_R-III-F.json
@@ -137,13 +137,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Recoil",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/DarkAge3131-/Uniques/chassis/chassisdef_tian-zong_TNZ-N3_jasminda.json
+++ b/Eras/DarkAge3131-/Uniques/chassis/chassisdef_tian-zong_TNZ-N3_jasminda.json
@@ -22,6 +22,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/DarkAge3131-/Uniques/mech/mechdef_tian-zong_TNZ-N3_jasminda.json
+++ b/Eras/DarkAge3131-/Uniques/mech/mechdef_tian-zong_TNZ-N3_jasminda.json
@@ -193,13 +193,6 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_HighPowered",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_charger_CGR-3Kr.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_charger_CGR-3Kr.json
@@ -46,6 +46,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellstar_HST-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellstar_HST-2.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_karhu_KAR-D.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_karhu_KAR-D.json
@@ -42,6 +42,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_Engine_XL_Clan",
       "ComponentDefType": "HeatSink",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_kodiak_KDK-3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_kodiak_KDK-3.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_lancelot_LNC25-06.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_lancelot_LNC25-06.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_nova_cat_NCT-F.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_nova_cat_NCT-F.json
@@ -36,6 +36,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_EngineCore_280",
       "ComponentDefType": "HeatSink",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_preta_C-PRT-OB_infernus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_preta_C-PRT-OB_infernus.json
@@ -28,6 +28,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "Head",
       "ComponentDefID": "Unique_FCS_BufferedVDNI",
       "ComponentDefType": "Upgrade",

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_charger_CGR-3Kr.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_charger_CGR-3Kr.json
@@ -151,13 +151,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_hellstar_HST-2.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_hellstar_HST-2.json
@@ -150,13 +150,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_karhu_KAR-D.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_karhu_KAR-D.json
@@ -145,13 +145,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_kodiak_KDK-3.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_kodiak_KDK-3.json
@@ -149,13 +149,6 @@
     },
     {
       "MountedLocation": "LeftArm",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftArm",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range_Extreme",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_lancelot_LNC25-06.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_lancelot_LNC25-06.json
@@ -156,13 +156,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_nova_cat_NCT-F.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_nova_cat_NCT-F.json
@@ -153,13 +153,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_seraph_C-SRP-OB_infernus.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_seraph_C-SRP-OB_infernus.json
@@ -128,13 +128,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_awesome_AWS-10KM_cameron.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_awesome_AWS-10KM_cameron.json
@@ -22,6 +22,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_griffin_GRF-6S_FrancineII.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_griffin_GRF-6S_FrancineII.json
@@ -22,6 +22,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_awesome_AWS-10KM_cameron.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_awesome_AWS-10KM_cameron.json
@@ -167,13 +167,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_griffin_GRF-6S_FrancineII.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_griffin_GRF-6S_FrancineII.json
@@ -146,13 +146,6 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Sniper",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_banshee_BNC-9S2.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_banshee_BNC-9S2.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_blackknight_BL-18-KNT.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_blackknight_BL-18-KNT.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_warhammer_WHD-10CT.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_warhammer_WHD-10CT.json
@@ -19,6 +19,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Eras/Republic3081-3130/Base/mech/mechdef_banshee_BNC-9S2.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_banshee_BNC-9S2.json
@@ -156,13 +156,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_MultiTrack",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_blackknight_BL-18-KNT.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_blackknight_BL-18-KNT.json
@@ -139,13 +139,6 @@
     },
     {
       "MountedLocation": "RightTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "RightTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_warhammer_WHD-10CT.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_warhammer_WHD-10CT.json
@@ -149,13 +149,6 @@
     },
     {
       "MountedLocation": "LeftTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "LeftTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Heat",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Eras/Republic3081-3130/Uniques/chassis/chassisdef_juggernaut_JG-R9T14.json
+++ b/Eras/Republic3081-3130/Uniques/chassis/chassisdef_juggernaut_JG-R9T14.json
@@ -24,6 +24,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Unique_Weapon_Gauss_MagshotBattery_Clan",
       "ComponentDefType": "Weapon",

--- a/Eras/Republic3081-3130/Uniques/mech/mechdef_juggernaut_JG-R9T14.json
+++ b/Eras/Republic3081-3130/Uniques/mech/mechdef_juggernaut_JG-R9T14.json
@@ -157,13 +157,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/Quicsell/Chassis/chassisdef_vindicator_VND-QS1.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_vindicator_VND-QS1.json
@@ -47,6 +47,13 @@
       "DamageLevel": "Functional"
     },
     {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
       "MountedLocation": "CenterTorso",
       "ComponentDefID": "Lootable_Engine_FuelCell",
       "ComponentDefType": "HeatSink",

--- a/Optionals/Quicsell/Mech/mechdef_vindicator_VND-QS1.json
+++ b/Optionals/Quicsell/Mech/mechdef_vindicator_VND-QS1.json
@@ -151,13 +151,6 @@
     },
     {
       "MountedLocation": "Head",
-      "ComponentDefID": "Gear_FCS_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Head",
       "ComponentDefID": "Gear_Sensors_Searchlight_Quicsell",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/Superheavys/Urbocalypse-PirateTech/chassis/chassisdef_urbiestator_UMS-P00P.json
+++ b/Optionals/Superheavys/Urbocalypse-PirateTech/chassis/chassisdef_urbiestator_UMS-P00P.json
@@ -24,6 +24,13 @@
     },
     {
       "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_SuperheavyFrame_Colossal",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/Superheavys/Urbocalypse-PirateTech/mech/mechdef_urbiestator_UMS-P00P.json
+++ b/Optionals/Superheavys/Urbocalypse-PirateTech/mech/mechdef_urbiestator_UMS-P00P.json
@@ -174,13 +174,6 @@
     },
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "CenterTorso",
       "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/Urbocalypse/RISCtech/chassis/chassisdef_urbanlord_UBL-RX.json
+++ b/Optionals/Urbocalypse/RISCtech/chassis/chassisdef_urbanlord_UBL-RX.json
@@ -20,6 +20,13 @@
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
     }
   ],
   "Description": {

--- a/Optionals/Urbocalypse/RISCtech/mech/mechdef_urbanlord_UBL-RX.json
+++ b/Optionals/Urbocalypse/RISCtech/mech/mechdef_urbanlord_UBL-RX.json
@@ -213,13 +213,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Headshot",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "LeftTorso",
       "ComponentDefID": "Linked_Gyro_XXL",
       "ComponentDefType": "Upgrade",


### PR DESCRIPTION
FCS Headshot
Item Fixed on all mechs using it
Item Blacklisted
Item Given +2 offensive push accuracy penalty
Penalty can be mitigated to 0 by 40 and 120 point item affinity*.

BC Headshot
Item Fixed on all mechs using it
Item Blacklisted
Item Given +3 offensive push accuracy penalty
Penalty can be mitigated to 1 by 40 and 120 point item affinity*.

FCS Headshot-RTO Added
Same as original item, but has -2 called shot buff instead of the original items Debuff.

FCS Headhunter fixed affinity added