### PR TITLE
Fixes

### DIFF
--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_10.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_10.json
@@ -140,7 +140,7 @@
       "range_long",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_10_Light.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_10_Light.json
@@ -140,7 +140,7 @@
       "range_long",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_2.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_2.json
@@ -137,7 +137,7 @@
       "range_extreme",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_20.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_20.json
@@ -111,7 +111,7 @@
       "range_standard",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_20_Light.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_20_Light.json
@@ -111,7 +111,7 @@
       "range_standard",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_2_Light.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_2_Light.json
@@ -137,7 +137,7 @@
       "range_very-long",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_5.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_5.json
@@ -140,7 +140,7 @@
       "range_very-long",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_5_Light.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_AC_5_Light.json
@@ -140,7 +140,7 @@
       "range_long",
       "BAIncompatible",
       "RecoilDamperAttachable.{location}",
-      "RecoilDamperSupported-SingleShot"
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_ProtoAC_2_Clan.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_ProtoAC_2_Clan.json
@@ -107,7 +107,9 @@
       "OmniRestriction.{location}",
       "component_type_stock",
       "range_extreme",
-      "BAIncompatible"
+      "BAIncompatible",
+      "RecoilDamperAttachable.{location}",
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_ProtoAC_4_Clan.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_ProtoAC_4_Clan.json
@@ -111,7 +111,9 @@
       "OmniRestriction.{location}",
       "component_type_stock",
       "range_very-long",
-      "BAIncompatible"
+      "BAIncompatible",
+      "RecoilDamperAttachable.{location}",
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Weapons/Weapon_Autocannon_ProtoAC_8_Clan.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Autocannon_ProtoAC_8_Clan.json
@@ -111,7 +111,9 @@
       "OmniRestriction.{location}",
       "component_type_stock",
       "range_long",
-      "BAIncompatible"
+      "BAIncompatible",
+      "RecoilDamperAttachable.{location}",
+      "RecoilDamperSupported-DoubleShot"
     ],
     "tagSetSourceFile": ""
   }


### PR DESCRIPTION
Fixed Protomech AC not being able to attach recoil dampener but saying they could.

Fixed dampener template for ACs that have gained a Rapid mode.