### PR TITLE
Adding a buff to increase RangeBonusDistance on items that could be... 

### DIFF
--- a/Core/RogueModuleTech/Cockpit/FCS/Gear_FCS_Energy_Range.json
+++ b/Core/RogueModuleTech/Cockpit/FCS/Gear_FCS_Energy_Range.json
@@ -172,6 +172,32 @@
         "targetCollection": "Weapon",
         "targetWeaponCategory": "Energy"
       }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "FCS3NRGBONUSRANGE",
+        "Name": "FCS Energy Range: Increased Energy Range Bonus Distance",
+        "Details": "DF Minrange by 50m",
+        "Icon": "uixSvgIcon_ability_mastertactician"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.1",
+        "modType": "System.Single",
+        "targetCollection": "Weapon",
+        "targetWeaponCategory": "Energy"
+      }
     }
   ],
   "ComponentTags": {

--- a/Core/RogueModuleTech/Cockpit/FCS/Gear_FCS_RangeBoost.json
+++ b/Core/RogueModuleTech/Cockpit/FCS/Gear_FCS_RangeBoost.json
@@ -218,6 +218,31 @@
         "modType": "System.Single",
         "targetCollection": "Weapon"
       }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "FCSRANGER8",
+        "Name": "FCS Ranger: Increased Range Bonus Distance",
+        "Details": "",
+        "Icon": "uixSvgIcon_ability_mastertactician"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.1",
+        "modType": "System.Single",
+        "targetCollection": "Weapon"
+      }
     }
   ],
   "ComponentTags": {

--- a/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EnergyRange.json
+++ b/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_EnergyRange.json
@@ -186,6 +186,34 @@
         "targetCollection": "Weapon",
         "targetWeaponCategory": "Energy"
       }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "RangedWeaponSensors5",
+        "Name": "Sensors Eng. Range: Increased Energy Range Bonus Distance",
+        "Details": "Increased Sight/Sensors",
+        "Icon": "uixSvgIcon_equipment_Comms"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.1",
+        "modType": "System.Single",
+        "targetCollection": "Weapon",
+        "targetWeaponCategory": "Energy"
+      }
     }
   ],
   "ComponentTags": {

--- a/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_Huntress.json
+++ b/Core/RogueModuleTech/Cockpit/Sensors/Gear_Sensors_Huntress.json
@@ -210,6 +210,33 @@
         "modType": "System.Single",
         "targetCollection": "Weapon"
       }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "RangedWeaponSensors5",
+        "Name": "Sensors Range: Increased Range Bonus Distance",
+        "Details": "Increased Sight/Sensors",
+        "Icon": "uixSvgIcon_equipment_Comms"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.1",
+        "modType": "System.Single",
+        "targetCollection": "Weapon"
+      }
     }
   ],
   "ComponentTags": {

--- a/Core/RogueModuleTech/RTOSpecial/targettrackingsystem/Unique_Gear_TargetingTrackingSystem_Sniper-RTO.json
+++ b/Core/RogueModuleTech/RTOSpecial/targettrackingsystem/Unique_Gear_TargetingTrackingSystem_Sniper-RTO.json
@@ -204,6 +204,31 @@
       },
       "targetingData": {
         "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "StatusEffect_BCRANGE_BONUS",
+        "Name": "BC Sniper: Increased Range Bonus Distance",
+        "Details": "DF Minrange by 50m",
+        "Icon": "uixSvgIcon_ability_mastertactician"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.5",
+        "modType": "System.Single",
+        "targetCollection": "Weapon"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
         "effectTargetType": "Creator",
         "showInTargetPreview": false,
         "showInStatusPanel": false

--- a/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_FCS_ImprovedTC_Clan-RTO.json
+++ b/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_FCS_ImprovedTC_Clan-RTO.json
@@ -236,6 +236,31 @@
       },
       "targetingData": {
         "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "CLANTCRANGEMINMAX",
+        "Name": "FCS Improved TC (C) RTO: Increased Range Bonus Distance",
+        "Details": "DF Minrange by 50m",
+        "Icon": "uixSvgIcon_ability_mastertactician"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.1",
+        "modType": "System.Single",
+        "targetCollection": "Weapon"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
         "effectTargetType": "Creator",
         "showInTargetPreview": false,
         "showInStatusPanel": false

--- a/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_FCS_ImprovedTC_Clan-RTO.json
+++ b/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_FCS_ImprovedTC_Clan-RTO.json
@@ -241,7 +241,7 @@
       "effectType": "StatisticEffect",
       "nature": "Buff",
       "Description": {
-        "Id": "CLANTCRANGEMINMAX",
+        "Id": "CLANTCRANGEMINBONUS",
         "Name": "FCS Improved TC (C) RTO: Increased Range Bonus Distance",
         "Details": "DF Minrange by 50m",
         "Icon": "uixSvgIcon_ability_mastertactician"

--- a/Core/RogueModuleTech/TargetTrackingSystem/Gear_TargetingTrackingSystem_Range.json
+++ b/Core/RogueModuleTech/TargetTrackingSystem/Gear_TargetingTrackingSystem_Range.json
@@ -191,6 +191,31 @@
         "modType": "System.Single",
         "targetCollection": "Weapon"
       }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "StatusEffect_BCRANGE_BONUS",
+        "Name": "BC Range: Increased Range Bonus Distance",
+        "Details": "DF Minrange by 50m",
+        "Icon": "uixSvgIcon_ability_mastertactician"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.1",
+        "modType": "System.Single",
+        "targetCollection": "Weapon"
+      }
     }
   ],
   "ComponentTags": {

--- a/Optionals/ExperimentalWeapons/Base/Unique/Upgrade/Unique_Gear_TargetingTrackingSystem_Sniper.json
+++ b/Optionals/ExperimentalWeapons/Base/Unique/Upgrade/Unique_Gear_TargetingTrackingSystem_Sniper.json
@@ -206,6 +206,31 @@
       },
       "targetingData": {
         "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "StatusEffect_BCRANGE_BONUS",
+        "Name": "BC Sniper: Increased Range Bonus Distance",
+        "Details": "DF Minrange by 50m",
+        "Icon": "uixSvgIcon_ability_mastertactician"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.5",
+        "modType": "System.Single",
+        "targetCollection": "Weapon"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
         "effectTargetType": "Creator",
         "showInTargetPreview": false,
         "showInStatusPanel": false

--- a/Optionals/RISCtech/Base/Items/Upgrade/Unique_FCS_ImprovedTC.json
+++ b/Optionals/RISCtech/Base/Items/Upgrade/Unique_FCS_ImprovedTC.json
@@ -239,6 +239,31 @@
       },
       "targetingData": {
         "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "CLANTCRANGEMINBONUS",
+        "Name": "FCS Improved TC: Increased Range Bonus Distance",
+        "Details": "DF Minrange by 50m",
+        "Icon": "uixSvgIcon_ability_mastertactician"
+      },
+      "statisticData": {
+        "statName": "CAC_RangeBonusDistance_Mod",
+        "operation": "Float_Multiply",
+        "modValue": "1.1",
+        "modType": "System.Single",
+        "targetCollection": "Weapon"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
         "effectTargetType": "Creator",
         "showInTargetPreview": false,
         "showInStatusPanel": false


### PR DESCRIPTION
…used with VSPLs. The same code could be used on other gear that increases range brackets, but no other weapons use RangeBonusDistance at present.