### PR TITLE
Early game BA retags

### DIFF
--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_achileus_ACS-GSS.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_achileus_ACS-GSS.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_achileus_ACS-GSS_Sqd6.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_achileus_ACS-GSS_Sqd6.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_achileus_ACS-WOB_Sqd6.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_achileus_ACS-WOB_Sqd6.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-FL.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-FL.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-FL_Sqd6.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-FL_Sqd6.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-L.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-L.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-L_Sqd6.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-L_Sqd6.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-MG.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-MG.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-MG_Sqd6.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-MG_Sqd6.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-TAG.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-TAG.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-TAG_Sqd6.json
+++ b/Eras/ClanInvasion3061/Base/mech/mechdef_achileus_ACS-TAG_Sqd6.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_med",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_angerona_scout_suit_ARA-REC.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_angerona_scout_suit_ARA-REC.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_high",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_angerona_scout_suit_ARA-STD.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_angerona_scout_suit_ARA-STD.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_high",
       "unit_squad",
       "unit_role_brawler",
       "unit_lance_assassin",

--- a/Optionals/RISCtech/Base/mech/mechdef_angerona_scout_suit_ARA-PDS.json
+++ b/Optionals/RISCtech/Base/mech/mechdef_angerona_scout_suit_ARA-PDS.json
@@ -4,7 +4,7 @@
       "unit_mech",
       "unit_light",
       "unit_advanced",
-      "unit_bracket_low",
+      "unit_bracket_high",
       "unit_squad",
       "unit_role_scout",
       "unit_lance_assassin",


### PR DESCRIPTION
Retagging Angerona squads from Low to High threat. Retagging Achileus squads from Low to Medium.

They're were both units with advanced stealth that had a rather high chance of spawning in your first mission or two. Which caused play that was more annoying than challenging. Because they are both recon suits with light weapons and no battle claws.