### PR TITLE
Reconciling LowVis and EDM weather modifiers

### DIFF
--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskArcticNightFoggy.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskArcticNightFoggy.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "DesignMaskArcticNightFoggy",
     "Name": "Foggy Arctic Night",
-    "Details": "Polar biomes increase a unit's Heat-sinking ability by 20%, and visibility on sensors by a similar amount. On a foggy night visibility is reduced to 70% of normal and all units have +1 defense.",
+    "Details": "Polar biomes increase a unit's Heat-sinking ability by 20%, and visibility on sensors by a similar amount. On a foggy night visibility is reduced to 70% of normal nighttime and all units have +1 defense.",
     "Icon": "fog-arctic"
   },
   "heatSinkMultiplier": 1.2,

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskArcticNightFrozen.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskArcticNightFrozen.json
@@ -2,11 +2,11 @@
   "Description": {
     "Id": "DesignMaskArcticNightFrozen",
     "Name": "Arctic Night",
-    "Details": "Polar biomes increase a unit's Heat-sinking ability by 20%, and visibility on sensors by a similar amount. At night visibility is reduced to 80% of normal.",
+    "Details": "Polar biomes increase a unit's Heat-sinking ability by 20%, and visibility on sensors by a similar amount. Visibility is normal for nighttime.",
     "Icon": "uixSvgIcon_biome_Polar"
   },
   "heatSinkMultiplier": 1.2,
-  "visibilityMultiplier": 0.8,
+  "visibilityMultiplier": 1.0,
   "signatureMultiplier": 1.2,
   "audioSwitchSurfaceType": "snow",
   "audioSwitchRainingSurfaceType": "snow",

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskAridNightClear.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskAridNightClear.json
@@ -2,11 +2,11 @@
   "Description": {
     "Id": "DesignMaskAridNightClear",
     "Name": "Desert Night",
-    "Details": "Units in the Desert sink only 85% of their normal Heat. At night visibility is reduced to 80% of normal.",
+    "Details": "Units in the Desert sink only 85% of their normal Heat. Visibility is normal for nighttime.",
     "Icon": "uixSvgIcon_biome_Heated"
   },
   "heatSinkMultiplier": 0.85,
-  "visibilityMultiplier": 0.8,
+  "visibilityMultiplier": 1.0,
   "audioSwitchSurfaceType": "sand",
   "audioSwitchRainingSurfaceType": "mud",
   "stickyEffect": {

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskAridNightFoggy.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskAridNightFoggy.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "DesignMaskAridNightFoggy",
     "Name": "Foggy Desert Night",
-    "Details": "Units in the Badlands sink only 85% of their normal Heat. On a foggy night visibility is reduced to 70% of normal and all units have +1 defense.",
+    "Details": "Units in the Badlands sink only 85% of their normal Heat. On a foggy night visibility is reduced to 70%  of normal nighttime and all units have +1 defense.",
     "Icon": "fog-arid"
   },
   "heatSinkMultiplier": 0.85,

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskJungleNightMisty.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskJungleNightMisty.json
@@ -2,11 +2,11 @@
   "Description": {
     "Id": "DesignMaskJungleNightMisty",
     "Name": "Jungle Night",
-    "Details": "Tropical biomes increase a unit's Heat-sinking ability by 10% due to moisture clinging to exhaust vents. At night, visibility is reduced to 80% of normal and all units have +1 defense.",
+    "Details": "Tropical biomes increase a unit's Heat-sinking ability by 10% due to moisture clinging to exhaust vents. Visibility is normal for nighttime and all units have +1 defense.",
     "Icon": "uixSvgIcon_biome_Tropical"
   },
   "heatSinkMultiplier": 1.1,
-  "visibilityMultiplier": 0.8,
+  "visibilityMultiplier": 1.0,
   "targetabilityModifier": 1,
   "stickyEffect": {
 

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskLunarNight.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskLunarNight.json
@@ -2,11 +2,11 @@
   "Description": {
     "Id": "DesignMaskLunarNight",
     "Name": "Lunar Night",
-    "Details": "At night, visibility is reduced to 90% of normal. Units in a vacuum sink only 65% of their normal Heat and VTOL units have 300% movement cost due to the lack of atmosphere. Ballistic and missile weapons, as well as jump jets, gain 30% more max range thanks to reduced gravity.",
+    "Details": "Visibility is normal for nighttime. Units in a vacuum sink only 65% of their normal Heat and VTOL units have 300% movement cost due to the lack of atmosphere. Ballistic and missile weapons, as well as jump jets, gain 30% more max range thanks to reduced gravity.",
     "Icon": "uixSvgIcon_biome_Vacuum"
   },
   "heatSinkMultiplier": 0.65,
-  "visibilityMultiplier": 0.9,
+  "visibilityMultiplier": 1.0,
   "audioSwitchSurfaceType": "dirt",
   "audioSwitchRainingSurfaceType": "mud",
   "stickyEffect": {

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskMartianNight.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskMartianNight.json
@@ -2,11 +2,11 @@
   "Description": {
     "Id": "DesignMaskMartianNight",
     "Name": "Martian Night",
-    "Details": "At night, visibility is reduced to 80% of normal.  Units in a partial vacuum sink only 75% of their normal Heat and VTOL units have 200% movement cost due to the lack of proper atmosphere. Ballistic and missile weapons, as well as jump jets, gain 15% more max range thanks to reduced gravity.",
+    "Details": "Visibility is normal for nighttime.  Units in a partial vacuum sink only 75% of their normal Heat and VTOL units have 200% movement cost due to the lack of proper atmosphere. Ballistic and missile weapons, as well as jump jets, gain 15% more max range thanks to reduced gravity.",
     "Icon": "uixSvgIcon_biome_PartialVacuum"
   },
   "heatSinkMultiplier": 0.75,
-  "visibilityMultiplier": 0.8,
+  "visibilityMultiplier": 1.0,
   "audioSwitchSurfaceType": "dirt",
   "audioSwitchRainingSurfaceType": "dirt",
   "vfxNameModifier": "_mars",

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskUrbanNightFoggy.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskUrbanNightFoggy.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "DesignMaskUrbanNightFoggy",
     "Name": "Foggy Night",
-    "Details": "On a foggy night visibility is reduced to 70% of normal and all units have +1 defense. Wheeled Units have 5% lower move cost in urban environments.",
+    "Details": "On a foggy night visibility is reduced to 70% of normal nighttime and all units have +1 defense. Wheeled Units have 5% lower move cost in urban environments.",
     "Icon": "fog"
   },
   "visibilityMultiplier": 0.7,

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskVerdantNightFoggy.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskVerdantNightFoggy.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "DesignMaskVerdantNightFoggy",
     "Name": "Foggy Night",
-    "Details": "On a foggy night visibility is reduced to 70% of normal and all units have +1 defense.",
+    "Details": "On a foggy night visibility is reduced to 70% of normal nighttime and all units have +1 defense.",
     "Icon": "fog"
   },
   "visibilityMultiplier": 0.7,

--- a/Core/EnviromentalDesignMasks/designmasks/DesignMaskVerdantNightFullMoon.json
+++ b/Core/EnviromentalDesignMasks/designmasks/DesignMaskVerdantNightFullMoon.json
@@ -2,9 +2,9 @@
   "Description": {
     "Id": "DesignMaskVerdantNightFullMoon",
     "Name": "Full Moon",
-    "Details": "The full moon improves visibility at night to 90% of normal. All units have +1 defense.",
+    "Details": "The full moon improves visibility at night by 10%. All units have +1 defense.",
     "Icon": "uixSvgIcon_biome_Normal"
   },
-  "visibilityMultiplier": 0.9,
+  "visibilityMultiplier": 1.1,
   "targetabilityModifier": 1
 }

--- a/Core/LowVisibility/mod.json
+++ b/Core/LowVisibility/mod.json
@@ -67,9 +67,9 @@
             "RangeBright": 1800.0,
             "RangeDim": 900.0,
             "RangeDark": 150.0,
-            "RangeMultiRainSnow": 0.8,
-            "RangeMultiLightFog": 0.8,
-            "RangeMultiHeavyFog": 0.7,
+            "RangeMultiRainSnow": 1.0,
+            "RangeMultiLightFog": 1.0,
+            "RangeMultiHeavyFog": 1.0,
             "MinimumRange": 90.0,
             "ScanRange": 90.0,
             "Hardcap": 3000


### PR DESCRIPTION
Loads off all specific weather effects to EDM, adjust descriptions to more clearly indicate visibility effects to players, LowVis fog modifiers are set to 1.0