### PR TITLE
Added missing uses ammo text

### DIFF
--- a/Core/RogueModuleTech/Weapons/Weapon_Plasma_Rifle.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_Plasma_Rifle.json
@@ -84,7 +84,7 @@
     "UIName": "Plasma Rifle",
     "Id": "Weapon_Plasma_Rifle",
     "Name": "Plasma Rifle",
-    "Details": "The plasma rifle was developed by the Capellan Confederation. Based upon their man-portable version, the Confederation created what is essentially a massive flamer. Plasma weapons use the power of the fusion engine or power amplifiers to power an electromagnetic accelerator to a stream, pulse, or toroid of plasma (i.e. very hot, energetic, and excited matter). The plasma is created by using a lasing process to flash cartridges of plastic foam into white-hot projectiles that cause thermal, as well as physical, damage. Because this foam ammo is inert, it will not explode even if destroyed.",
+    "Details": "The plasma rifle was developed by the Capellan Confederation. Based upon their man-portable version, the Confederation created what is essentially a massive flamer. Plasma weapons use the power of the fusion engine or power amplifiers to power an electromagnetic accelerator to a stream, pulse, or toroid of plasma (i.e. very hot, energetic, and excited matter). The plasma is created by using a lasing process to flash cartridges of plastic foam into white-hot projectiles that cause thermal, as well as physical, damage. Because this foam ammo is inert, it will not explode even if destroyed.<b><color=#ffcc00>Uses Plasma Ammo.</color></b>",
     "Icon": "plasma-bolt"
   },
   "BonusValueA": "",


### PR DESCRIPTION
Plasma Rifle is missing the "Uses Plasma Ammo" text from the description.

![Screenshot_20250320_102152](https://github.com/user-attachments/assets/12755929-72da-4356-98a2-46d71a161862)
