### PR TITLE
change proxy models; resize Fennec; Fennec quirk to Narrow/Low Profile

### DIFF
--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_pinion_PIN-1.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_pinion_PIN-1.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ClanMech",
-      "mr-resize-0.65"
+      "mr-resize-0.93-0.83-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +45,9 @@
   "YangsThoughts": "The Pinion is part testbed, part leftovers. Developed by Clan Jade Falcon and introduced into service in 3065, the Pinion BattleMech is the second Clan 'Mech to be produced by Olivetti Weapons on Sudeten. The second-line BattleMech was designed as a patrol and guard duty 'Mech, so it has modest speed coupled with good maneuverability thanks to its jump jet range of 150 meters. Additionally, the Pinion is meant to test the effectiveness and drawbacks of heavy lasers, as early reports from Clan Star Adder indicated heavy lasers are unreliable and possibly damaging to the MechWarrior. In order to properly judge the effect of this new weapon, the Falcons decided to use garrison MechWarriors as guinea pigs. Their vitals were carefully tracked and medical evaluations were administered weekly as part of these tests.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_victor",
-  "PrefabIdentifier": "chrPrfMech_victorBase-001",
-  "PrefabBase": "victor",
+  "HardpointDataDefID": "hardpointdatadef_thunder",
+  "PrefabIdentifier": "chrprfmech_thunderbase-001",
+  "PrefabBase": "thunder",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_verfolger_VR5-R.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_verfolger_VR5-R.json
@@ -32,7 +32,7 @@
     "Id": "chassisdef_verfolger_VR5-R",
     "Name": "Verfolger",
     "Details": "The Verfolger VR5-R carries a variety of weapons systems with the capability to engage an enemy at almost any range. For its long range striking capabilities, the design carries a powerful ER PPC. As an enemy unit closes, it faces increasing volumes of fire as the Verfolger's LB-X Autocannon/10 comes into play against any enemy units. For close combat, the Verfolger adds its three medium lasers to its short range arsenal, making the 'Mech a powerful infighter. It also has CASE in its side torsos to prevent the total destruction of the 'Mech in an ammunition explosion. To protect itself from missile-carrying units, the Verfolger has an anti-missile system.\n\n<b><color=#e62e00>Quirk: Hyper-Extending Actuators</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
-    "Icon": "uixTxrIcon_warhammer"
+    "Icon": "uixTxrIcon_sorcerer"
   },
   "VariantName": "VR5-R",
   "ChassisTags": {
@@ -45,9 +45,9 @@
   "YangsThoughts": "Designed to work with the lightweight Wolfhound BattleMech, the Verfolger (German for 'Pursuer') and Wolfhound together are capable of taking out much larger BattleMechs. The Verfolger is built on a lightweight Endo Steel chassis and is powered by a 325 XL engine that sacrifices durability for lighter weight and propels the 'Mech to a top speed of 86.4 km/h. The 'Mech uses its saved weight to carry an impressive twelve and a half tons of armor that allows the Verfolger to stand up to fire from most enemy units that it would encounter.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_bloodasp",
-  "PrefabIdentifier": "chrprfmech_bloodaspbase-001",
-  "PrefabBase": "bloodasp",
+  "HardpointDataDefID": "hardpointdatadef_sorcerer",
+  "PrefabIdentifier": "chrprfmech_sorcererbase-001",
+  "PrefabBase": "sorcerer",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/CivilWar3062-3067/Base/mech/mechdef_verfolger_VR5-R.json
+++ b/Eras/CivilWar3062-3067/Base/mech/mechdef_verfolger_VR5-R.json
@@ -44,7 +44,7 @@
     "Id": "mechdef_verfolger_VR5-R",
     "Name": "Verfolger VR5-R",
     "Details": "The Verfolger VR5-R carries a variety of weapons systems with the capability to engage an enemy at almost any range. For its long range striking capabilities, the design carries a powerful ER PPC. As an enemy unit closes, it faces increasing volumes of fire as the Verfolger's LB-X Autocannon/10 comes into play against any enemy units. For close combat, the Verfolger adds its three medium lasers to its short range arsenal, making the 'Mech a powerful infighter. It also has CASE in its side torsos to prevent the total destruction of the 'Mech in an ammunition explosion. To protect itself from missile-carrying units, the Verfolger has an anti-missile system.\n\n<b><color=#e62e00>Quirk: Hyper-Extending Actuators</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
-    "Icon": "uixTxrIcon_warhammer"
+    "Icon": "uixTxrIcon_sorcerer"
   },
   "simGameMechPartCost": 246748,
   "Locations": [

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_fennec_FEC-5CM.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_fennec_FEC-5CM.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-1.2"
+      "mr-resize-1.54-1.66-1.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5B.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5B.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-1-0.9-0.76"
+      "mr-resize-1.0"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "Originally developed by the defunct Marik-Stewart Commonwealth to produce a local Assault BattleMech, the Juliano would go on to serve in the ranks of the newly re-formed Free Worlds League. Produced on Angell II at Irian's Mech production facilities during the mid thirty-second century, this Assault BattleMech was named after the league's first Captain-General, Juliano Marik.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_pulverizer",
-  "PrefabIdentifier": "chrprfmech_pulverizerbase-001",
-  "PrefabBase": "pulverizer",
+  "HardpointDataDefID": "hardpointdatadef_hellbringer",
+  "PrefabIdentifier": "chrprfmech_hellbringerbase-001",
+  "PrefabBase": "hellbringer",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5C.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-1-0.9-0.76"
+      "mr-resize-1.0"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "Originally developed by the defunct Marik-Stewart Commonwealth to produce a local Assault BattleMech, the Juliano would go on to serve in the ranks of the newly re-formed Free Worlds League. Produced on Angell II at Irian's Mech production facilities during the mid thirty-second century, this Assault BattleMech was named after the league's first Captain-General, Juliano Marik.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_pulverizer",
-  "PrefabIdentifier": "chrprfmech_pulverizerbase-001",
-  "PrefabBase": "pulverizer",
+  "HardpointDataDefID": "hardpointdatadef_hellbringer",
+  "PrefabIdentifier": "chrprfmech_hellbringerbase-001",
+  "PrefabBase": "hellbringer",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_shockwave_SKW-8X.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_shockwave_SKW-8X.json
@@ -36,7 +36,7 @@
   "VariantName": "SKW-8X",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-0.75-0.83-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "The Shockwave was created by the Marik-Stewart Commonwealth in the years after the Jihad. Its high top speed, strong armor, and powerful weapons make it a popular choice around the Inner Sphere. Mobile and heavily-armed for a 50-ton 'Mech, the Shockwave can deliver a withering barrage and has the heat-sinks to keep it up almost indefinitely. The use of standard armor and commonly employed weapons allows the Shockwave to be used on nearly any battlefield.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_firefly",
-  "PrefabIdentifier": "chrprfmech_fireflybase-001",
-  "PrefabBase": "firefly",
+  "HardpointDataDefID": "hardpointdatadef_pulverizer",
+  "PrefabIdentifier": "chrprfmech_pulverizerbase-001",
+  "PrefabBase": "pulverizer",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_surtur_SUR-T1.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_surtur_SUR-T1.json
@@ -62,16 +62,18 @@
   },
   "VariantName": "SUR-T1",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.82-0.82-0.78"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Skirmisher",
   "YangsThoughts": "The Surtur is a fast medium BattleMech developed by the Hanseatic League as their first home built design. By 3120s, the League industrial/technology levels had achieved pre-Jihad level of technology. The governing Merchant Council decided it was time of the reason was pride in their nation's achievement, as indigenous design should be made. The Surtur is designed as a skirmisher, intended to get into close-quarters combat to render the enemies.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_wolverine",
-  "PrefabIdentifier": "chrPrfMech_wolverineBase-001",
-  "PrefabBase": "wolverine",
+  "HardpointDataDefID": "hardpointdatadef_valkyrieii",
+  "PrefabIdentifier": "chrprfmech_valkyrieiibase-001",
+  "PrefabBase": "valkyrieii",
   "Tonnage": 55.0,
   "InitialTonnage": 5.5,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_fennec_FEC-1CM.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_fennec_FEC-1CM.json
@@ -15,7 +15,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Quirk_Rugged",
+      "ComponentDefID": "Quirk_NarrowLowProfile",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -30,7 +30,7 @@
     "UIName": "Fennec",
     "Id": "chassisdef_fennec_FEC-1CM",
     "Name": "Fennec",
-    "Details": "The Fennec 1CM is built on an endo steel chassis, clad in nine and a half tons of ferro-fibrous armor to protect the 'Mech's advanced systems and 330 XL engine. MechWarriors piloting the 'Mech must be mindful of the significant heat produced by its weapons and engine, as the design has only 10 double heat sinks. One of the primary features of the 'Mech, a C3 master computer allows it to coordinate with other C3 lancemates. The 'Mech's long range weaponry consists of a pair of arm-mounted PPCs, which are backed up by a pair of medium pulse lasers for close combat.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Details": "The Fennec 1CM is built on an endo steel chassis, clad in nine and a half tons of ferro-fibrous armor to protect the 'Mech's advanced systems and 330 XL engine. MechWarriors piloting the 'Mech must be mindful of the significant heat produced by its weapons and engine, as the design has only 10 double heat sinks. One of the primary features of the 'Mech, a C3 master computer allows it to coordinate with other C3 lancemates. The 'Mech's long range weaponry consists of a pair of arm-mounted PPCs, which are backed up by a pair of medium pulse lasers for close combat.\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
     "Icon": "uixTxrIcon_fennec"
   },
   "VariantName": "FEC-1CM",
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-1.2"
+      "mr-resize-1.54-1.66-1.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_pinion_PIN-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_pinion_PIN-2.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ClanMech",
-      "mr-resize-0.65"
+      "mr-resize-0.93-0.83-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +45,9 @@
   "YangsThoughts": "The Pinion is part testbed, part leftovers. Developed by Clan Jade Falcon and introduced into service in 3065, the Pinion BattleMech is the second Clan 'Mech to be produced by Olivetti Weapons on Sudeten. The second-line BattleMech was designed as a patrol and guard duty 'Mech, so it has modest speed coupled with good maneuverability thanks to its jump jet range of 150 meters. Additionally, the Pinion is meant to test the effectiveness and drawbacks of heavy lasers, as early reports from Clan Star Adder indicated heavy lasers are unreliable and possibly damaging to the MechWarrior. In order to properly judge the effect of this new weapon, the Falcons decided to use garrison MechWarriors as guinea pigs. Their vitals were carefully tracked and medical evaluations were administered weekly as part of these tests.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_victor",
-  "PrefabIdentifier": "chrPrfMech_victorBase-001",
-  "PrefabBase": "victor",
+  "HardpointDataDefID": "hardpointdatadef_thunder",
+  "PrefabIdentifier": "chrprfmech_thunderbase-001",
+  "PrefabBase": "thunder",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_pinion_PIN-3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_pinion_PIN-3.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ClanMech",
-      "mr-resize-0.65"
+      "mr-resize-0.93-0.83-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "The Pinion is part testbed, part leftovers. Developed by Clan Jade Falcon and introduced into service in 3065, the Pinion BattleMech is the second Clan 'Mech to be produced by Olivetti Weapons on Sudeten. The second-line BattleMech was designed as a patrol and guard duty 'Mech, so it has modest speed coupled with good maneuverability thanks to its jump jet range of 150 meters. Additionally, the Pinion is meant to test the effectiveness and drawbacks of heavy lasers, as early reports from Clan Star Adder indicated heavy lasers are unreliable and possibly damaging to the MechWarrior. In order to properly judge the effect of this new weapon, the Falcons decided to use garrison MechWarriors as guinea pigs. Their vitals were carefully tracked and medical evaluations were administered weekly as part of these tests.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_victor",
-  "PrefabIdentifier": "chrPrfMech_victorBase-001",
-  "PrefabBase": "victor",
+  "HardpointDataDefID": "hardpointdatadef_thunder",
+  "PrefabIdentifier": "chrprfmech_thunderbase-001",
+  "PrefabBase": "thunder",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_verfolger_VR6-C.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_verfolger_VR6-C.json
@@ -32,7 +32,7 @@
     "Id": "chassisdef_verfolger_VR6-C",
     "Name": "Verfolger",
     "Details": "This Verfolger variant removes the LB 10-X autocannon and anti-missile system of the original. In their place are two MML-9 missile launchers. The lasers are upgraded to extended range models.\n\n<b><color=#e62e00>Quirk: Hyper-Extending Actuators</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
-    "Icon": "uixTxrIcon_warhammer"
+    "Icon": "uixTxrIcon_sorcerer"
   },
   "VariantName": "VR6-C",
   "ChassisTags": {
@@ -45,9 +45,9 @@
   "YangsThoughts": "Designed to work with the lightweight Wolfhound BattleMech, the Verfolger (German for 'Pursuer') and Wolfhound together are capable of taking out much larger BattleMechs. The Verfolger is built on a lightweight Endo Steel chassis and is powered by a 325 XL engine that sacrifices durability for lighter weight and propels the 'Mech to a top speed of 86.4 km/h. The 'Mech uses its saved weight to carry an impressive twelve and a half tons of armor that allows the Verfolger to stand up to fire from most enemy units that it would encounter.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_bloodasp",
-  "PrefabIdentifier": "chrprfmech_bloodaspbase-001",
-  "PrefabBase": "bloodasp",
+  "HardpointDataDefID": "hardpointdatadef_sorcerer",
+  "PrefabIdentifier": "chrprfmech_sorcererbase-001",
+  "PrefabBase": "sorcerer",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_fennec_FEC-1CM.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_fennec_FEC-1CM.json
@@ -42,7 +42,7 @@
     "UIName": "Fennec FEC-1CM",
     "Id": "mechdef_fennec_FEC-1CM",
     "Name": "Fennec FEC-1CM",
-    "Details": "The Fennec 1CM is built on an endo steel chassis, clad in nine and a half tons of ferro-fibrous armor to protect the 'Mech's advanced systems and 330 XL engine. MechWarriors piloting the 'Mech must be mindful of the significant heat produced by its weapons and engine, as the design has only 10 double heat sinks. One of the primary features of the 'Mech, a C3 master computer allows it to coordinate with other C3 lancemates. The 'Mech's long range weaponry consists of a pair of arm-mounted PPCs, which are backed up by a pair of medium pulse lasers for close combat.\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Details": "The Fennec 1CM is built on an endo steel chassis, clad in nine and a half tons of ferro-fibrous armor to protect the 'Mech's advanced systems and 330 XL engine. MechWarriors piloting the 'Mech must be mindful of the significant heat produced by its weapons and engine, as the design has only 10 double heat sinks. One of the primary features of the 'Mech, a C3 master computer allows it to coordinate with other C3 lancemates. The 'Mech's long range weaponry consists of a pair of arm-mounted PPCs, which are backed up by a pair of medium pulse lasers for close combat.\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
     "Icon": "uixTxrIcon_fennec"
   },
   "simGameMechPartCost": 218948,

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_verfolger_VR6-C.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_verfolger_VR6-C.json
@@ -43,7 +43,7 @@
     "Id": "mechdef_verfolger_VR6-C",
     "Name": "Verfolger VR6-C",
     "Details": "This Verfolger variant removes the LB 10-X autocannon and anti-missile system of the original. In their place are two MML-9 missile launchers. The lasers are upgraded to extended range models.\n\n<b><color=#e62e00>Quirk: Hyper-Extending Actuators</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
-    "Icon": "uixTxrIcon_warhammer"
+    "Icon": "uixTxrIcon_sorcerer"
   },
   "simGameMechPartCost": 247573,
   "Locations": [

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_fennec_FEC-3C.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_fennec_FEC-3C.json
@@ -15,7 +15,7 @@
   "FixedEquipment": [
     {
       "MountedLocation": "CenterTorso",
-      "ComponentDefID": "Quirk_Rugged",
+      "ComponentDefID": "Quirk_NarrowLowProfile",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -30,7 +30,7 @@
     "UIName": "Fennec",
     "Id": "chassisdef_fennec_FEC-3C",
     "Name": "Fennec",
-    "Details": "This variant of the Fennec, developed in 3087, uses a C3 slave unit instead of employing a C3 master computer. Designed as a companion for the FEC-1CM variant, this 'Mech employs a pair of light PPCs in place of the medium pulse lasers. To help alleviate heat issues, two additional double heat sinks were mounted\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Details": "This variant of the Fennec, developed in 3087, uses a C3 slave unit instead of employing a C3 master computer. Designed as a companion for the FEC-1CM variant, this 'Mech employs a pair of light PPCs in place of the medium pulse lasers. To help alleviate heat issues, two additional double heat sinks were mounted\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
     "Icon": "uixTxrIcon_fennec"
   },
   "VariantName": "FEC-3C",
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-1.2"
+      "mr-resize-1.54-1.66-1.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_havoc_HVC-P6.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_havoc_HVC-P6.json
@@ -36,7 +36,7 @@
   "VariantName": "HVC-P6",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.55"
+      "mr-resize-0.73-0.73-0.7"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Designed by Adam Tech Industries and manufactured from their plant on Abadan, the Havoc was inspired by the JR7-K Jenner and managed to improve on many of the JR7-K's design features. The combination of almost double the Jenner's armor, a 10% increase in speed thanks to the 280 XL engine and a weapons loadout that allowed it to battle 'Mechs heavier than itself spurred the Adam Tech advertising campaign, which was geared exclusively towards pilots of light BattleMechs. The key to the Havoc's success was the Octagon Tartrac System E, considered the best short-range targeting and tracking system available on the market at the time and often compared to the highly successful and effective Garret D2j targeting system. The Octagon system identified threats faster than comparable systems, an invaluable aid to MechWarriors in the field. The Havoc also mounted five jump jets distributed throughout the Havoc's torso locations, allowing it to jump up to 150 meters.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kingcrab",
-  "PrefabIdentifier": "chrPrfMech_kingcrabBase-001",
-  "PrefabBase": "kingcrab",
+  "HardpointDataDefID": "hardpointdatadef_hammerhead",
+  "PrefabIdentifier": "chrprfmech_hammerheadbase-001",
+  "PrefabBase": "hammerhead",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_juliano_JLN-5A.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_juliano_JLN-5A.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-1-0.9-0.76"
+      "mr-resize-1.0"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "Originally developed by the defunct Marik-Stewart Commonwealth to produce a local Assault BattleMech, the Juliano would go on to serve in the ranks of the newly re-formed Free Worlds League. Produced on Angell II at Irian's Mech production facilities during the mid thirty-second century, this Assault BattleMech was named after the league's first Captain-General, Juliano Marik.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_pulverizer",
-  "PrefabIdentifier": "chrprfmech_pulverizerbase-001",
-  "PrefabBase": "pulverizer",
+  "HardpointDataDefID": "hardpointdatadef_hellbringer",
+  "PrefabIdentifier": "chrprfmech_hellbringerbase-001",
+  "PrefabBase": "hellbringer",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_shockwave_SKW-2F.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_shockwave_SKW-2F.json
@@ -36,7 +36,7 @@
   "VariantName": "SKW-2F",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-0.75-0.83-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "The Shockwave was created by the Marik-Stewart Commonwealth in the years after the Jihad. Its high top speed, strong armor, and powerful weapons make it a popular choice around the Inner Sphere. Mobile and heavily-armed for a 50-ton 'Mech, the Shockwave can deliver a withering barrage and has the heat-sinks to keep it up almost indefinitely. The use of standard armor and commonly employed weapons allows the Shockwave to be used on nearly any battlefield.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_firefly",
-  "PrefabIdentifier": "chrprfmech_fireflybase-001",
-  "PrefabBase": "firefly",
+  "HardpointDataDefID": "hardpointdatadef_pulverizer",
+  "PrefabIdentifier": "chrprfmech_pulverizerbase-001",
+  "PrefabBase": "pulverizer",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_shockwave_SKW-4G.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_shockwave_SKW-4G.json
@@ -36,7 +36,7 @@
   "VariantName": "SKW-4G",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-0.75-0.83-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "The Shockwave was created by the Marik-Stewart Commonwealth in the years after the Jihad. Its high top speed, strong armor, and powerful weapons make it a popular choice around the Inner Sphere. Mobile and heavily-armed for a 50-ton 'Mech, the Shockwave can deliver a withering barrage and has the heat-sinks to keep it up almost indefinitely. The use of standard armor and commonly employed weapons allows the Shockwave to be used on nearly any battlefield.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_firefly",
-  "PrefabIdentifier": "chrprfmech_fireflybase-001",
-  "PrefabBase": "firefly",
+  "HardpointDataDefID": "hardpointdatadef_pulverizer",
+  "PrefabIdentifier": "chrprfmech_pulverizerbase-001",
+  "PrefabBase": "pulverizer",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_shockwave_SKW-6H.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_shockwave_SKW-6H.json
@@ -36,7 +36,7 @@
   "VariantName": "SKW-6H",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-0.75-0.83-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "The Shockwave was created by the Marik-Stewart Commonwealth in the years after the Jihad. Its high top speed, strong armor, and powerful weapons make it a popular choice around the Inner Sphere. Mobile and heavily-armed for a 50-ton 'Mech, the Shockwave can deliver a withering barrage and has the heat-sinks to keep it up almost indefinitely. The use of standard armor and commonly employed weapons allows the Shockwave to be used on nearly any battlefield.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_firefly",
-  "PrefabIdentifier": "chrprfmech_fireflybase-001",
-  "PrefabBase": "firefly",
+  "HardpointDataDefID": "hardpointdatadef_pulverizer",
+  "PrefabIdentifier": "chrprfmech_pulverizerbase-001",
+  "PrefabBase": "pulverizer",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_verfolger_VR6-T.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_verfolger_VR6-T.json
@@ -32,7 +32,7 @@
     "Id": "chassisdef_verfolger_VR6-T",
     "Name": "Verfolger",
     "Details": "This version removes the standard weaponry and replaces it with a Large Pulse Laser, Snub Nose PPC, single ER Medium Laser, and a Medium Pulse Laser. These weapons are all tied into a Targeting Computer to improve accuracy. Mobility is improved by five Jump Jets, and to provide additional protection during landings the legs have received an extra half-ton of armor protection between them.\n\n<b><color=#e62e00>Quirk: Hyper-Extending Actuators</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
-    "Icon": "uixTxrIcon_warhammer"
+    "Icon": "uixTxrIcon_sorcerer"
   },
   "VariantName": "VR6-T",
   "ChassisTags": {
@@ -45,9 +45,9 @@
   "YangsThoughts": "Designed to work with the lightweight Wolfhound BattleMech, the Verfolger (German for 'Pursuer') and Wolfhound together are capable of taking out much larger BattleMechs. The Verfolger is built on a lightweight Endo Steel chassis and is powered by a 325 XL engine that sacrifices durability for lighter weight and propels the 'Mech to a top speed of 86.4 km/h. The 'Mech uses its saved weight to carry an impressive twelve and a half tons of armor that allows the Verfolger to stand up to fire from most enemy units that it would encounter.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_bloodasp",
-  "PrefabIdentifier": "chrprfmech_bloodaspbase-001",
-  "PrefabBase": "bloodasp",
+  "HardpointDataDefID": "hardpointdatadef_sorcerer",
+  "PrefabIdentifier": "chrprfmech_sorcererbase-001",
+  "PrefabBase": "sorcerer",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_fennec_FEC-3C.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_fennec_FEC-3C.json
@@ -40,7 +40,7 @@
     "UIName": "Fennec FEC-3C",
     "Id": "mechdef_fennec_FEC-3C",
     "Name": "Fennec FEC-3C",
-    "Details": "This variant of the Fennec, developed in 3087, uses a C3 slave unit instead of employing a C3 master computer. Designed as a companion for the FEC-1CM variant, this 'Mech employs a pair of light PPCs in place of the medium pulse lasers. To help alleviate heat issues, two additional double heat sinks were mounted\n\n<b><color=#e62e00>Quirk: Rugged</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Details": "This variant of the Fennec, developed in 3087, uses a C3 slave unit instead of employing a C3 master computer. Designed as a companion for the FEC-1CM variant, this 'Mech employs a pair of light PPCs in place of the medium pulse lasers. To help alleviate heat issues, two additional double heat sinks were mounted\n\n<b><color=#e62e00>Quirk: Narrow/Low Profile</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.05</color></b>\n\n<br><br><color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
     "Icon": "uixTxrIcon_fennec"
   },
   "simGameMechPartCost": 218948,

--- a/Eras/Republic3081-3130/Base/mech/mechdef_verfolger_VR6-T.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_verfolger_VR6-T.json
@@ -43,7 +43,7 @@
     "Id": "mechdef_verfolger_VR6-T",
     "Name": "Verfolger VR6-T",
     "Details": "This version removes the standard weaponry and replaces it with a Large Pulse Laser, Snub Nose PPC, single ER Medium Laser, and a Medium Pulse Laser. These weapons are all tied into a Targeting Computer to improve accuracy. Mobility is improved by five Jump Jets, and to provide additional protection during landings the legs have received an extra half-ton of armor protection between them.\n\n<b><color=#e62e00>Quirk: Hyper-Extending Actuators</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
-    "Icon": "uixTxrIcon_warhammer"
+    "Icon": "uixTxrIcon_sorcerer"
   },
   "simGameMechPartCost": 236848,
   "Locations": [


### PR DESCRIPTION
Juliano now using Hellbringer model
Havoc P6 now using Hammerhead model
Pinion now using Thunder model
Verfolger now using Sorcerer model, changed icon to Sorcerer
Shockwave now using Pulverizer model
Surtur now using Valkyrie II model
resized Fennec to fit in with 55-ton mechs, standardized its quirk to Narrow/Low Profile instead of two of them having Rugged