### PR TITLE
Add unarmored handheld nlrm10 and axman to carry it

### DIFF
--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_LRM_10_Enhanced.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_LRM_10_Enhanced.json
@@ -22,7 +22,7 @@
       "AAFactor: 8",
       "EjectableWeapon",
       "WeaponShardsModRange: 0.06, 0.24",
-      "TACChanceLocation: +900%"
+      "TACChanceLocation: +3200%"
     ],
     "Flags": [
       "not_broken"
@@ -271,7 +271,7 @@
       "statisticData": {
         "statName": "CAC_APCritChance",
         "operation": "Float_Multiply",
-        "modValue": "10.0",
+        "modValue": "33.0",
         "modType": "System.Single",
         "Location": "{current}"
       }

--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_LRM_10_Enhanced.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_LRM_10_Enhanced.json
@@ -1,0 +1,291 @@
+{
+  "Custom": {
+    "Category": [
+      {
+        "CategoryID": "HandHeldNoArmMelee"
+      },
+      {
+        "CategoryID": "HandHeld"
+      },
+      {
+        "CategoryID": "w/s/h/HandHeld"
+      }
+    ],
+    "BonusDescriptions": [
+      "HandHeld: 6.5",
+      "ClusterWeapon",
+      "VariableDmg: 2",
+      "MissileHP: +1",
+      "Indirect",
+      "WeaponClustering: +1",
+      "HandHeldAmmo: 60",
+      "AAFactor: 8",
+      "EjectableWeapon",
+      "WeaponShardsModRange: 0.06, 0.24",
+      "TACChanceLocation: +900%"
+    ],
+    "Flags": [
+      "not_broken"
+    ],
+    "InternalAmmoTonnage": {
+      "InternalAmmoTons": 0.5
+    },
+    "IBLS": {
+      "StorageSize": 3
+    },
+    "CarryHandUsage": 6.5
+  },
+  "weaponCategoryID": "SpecialHandHeld",
+  "Type": "LRM",
+  "WeaponSubType": "LRM10",
+  "MinRange": 90,
+  "MaxRange": 900,
+  "RangeSplit": [
+    240,
+    450,
+    660
+  ],
+  "AmmoCategory": "LRMInternal",
+  "StartingAmmoCapacity": 60,
+  "HeatGenerated": 0,
+  "Damage": 5,
+  "HeatDamage": 0,
+  "Instability": 1,
+  "DamageVariance": 2,
+  "AccuracyModifier": 0,
+  "EvasivePipsIgnored": 0,
+  "RefireModifier": 0,
+  "OverheatedDamageMultiplier": 0,
+  "EvasiveDamageMultiplier": 0,
+  "CriticalChanceMultiplier": 0.12,
+  "APArmorShardsMod": 3,
+  "APCriticalChanceMultiplier": 0.006,
+  "ShotsWhenFired": 10,
+  "ProjectilesPerShot": 1,
+  "ImprovedBallistic": true,
+  "IndirectFireCapable": true,
+  "MissBehavior": "Unguided",
+  "StatusEffectsPerHit": true,
+  "HitGenerator": "Streak",
+  "ClusteringModifier": 1,
+  "GunneryJammingMult": 0.005,
+  "GunneryJammingBase": 1,
+  "MissileHealth": 1,
+  "MissileVolleySize": 10,
+  "MissileVolleyIntervalMultiplier": 0.01,
+  "MissileFiringIntervalMultiplier": 0.01,
+  "FireTerrainChance": 0.005,
+  "AttackRecoil": 1,
+  "ProjectileSpeedMultiplier": 1.3,
+  "ColorsTable": [
+    {
+      "C": "#7F1D37",
+      "I": 5
+    },
+    {
+      "C": "#FAF43C",
+      "I": 5
+    },
+    {
+      "C": "#F7FF00",
+      "I": 5
+    },
+    {
+      "C": "#BA55D3",
+      "I": 5
+    },
+    {
+      "C": "#8A2BE2",
+      "I": 5
+    },
+    {
+      "C": "#EC4794",
+      "I": 5
+    },
+    {
+      "C": "#7BD1A3",
+      "I": 5
+    },
+    {
+      "C": "#FF4500",
+      "I": 5
+    },
+    {
+      "C": "#00FFFF",
+      "I": 5
+    },
+    {
+      "C": "#00BFFF",
+      "I": 5
+    },
+    {
+      "C": "#1813B2",
+      "I": 5
+    },
+    {
+      "C": "#00FFFF",
+      "I": 5
+    },
+    {
+      "C": "#11FF00",
+      "I": 5
+    },
+    {
+      "C": "#00FFFF",
+      "I": 5
+    },
+    {
+      "C": "#DC143C",
+      "I": 5
+    },
+    {
+      "C": "#565B5B",
+      "I": 5
+    },
+    {
+      "C": "#8B0000",
+      "I": 5
+    },
+    {
+      "C": "#467674",
+      "I": 5
+    },
+    {
+      "C": "#1813B2",
+      "I": 5
+    },
+    {
+      "C": "#1813B2",
+      "I": 5
+    },
+    {
+      "C": "#1D7F23",
+      "I": 5
+    },
+    {
+      "C": "#7F1D37",
+      "I": 5
+    },
+    {
+      "C": "#00BFFF",
+      "I": 5
+    },
+    {
+      "C": "#EE82EE",
+      "I": 5
+    }
+  ],
+  "ColorSpeedChange": 5,
+  "WeaponEffectID": "WeaponEffect-Weapon_LRM10",
+  "Description": {
+    "Cost": 325000,
+    "Rarity": 9,
+    "Purchasable": true,
+    "Manufacturer": "Defiance",
+    "Model": "Long-Range Missile Launcher",
+    "UIName": "HH NLRM-10",
+    "Id": "HandHeld_Weapon_LRM_10_Enhanced",
+    "Name": "LRM-10",
+    "Details": "Enhanced Long Range Missiles were developed by the Federated Commonwealth in response to the superior performance of Clan weaponry. These new LRMs use a more sophisticated arming mechanism to increase their viability at close range. The result has been a much smaller blind spot compared to traditional LRMs while still retaining the same long-range functionality. This is packaged with half a ton of ammo in an unarmored handheld package, intended for firing and ejecting before getting into brawling range.\n\n <b><color=#ffcc00>60 rounds.</color></b>",
+    "Icon": "lrm"
+  },
+  "BonusValueA": "",
+  "BonusValueB": "",
+  "ComponentType": "Weapon",
+  "ComponentSubType": "Weapon",
+  "PrefabIdentifier": "lrm10",
+  "BattleValue": 104,
+  "InventorySize": 1,
+  "Tonnage": 0,
+  "AllowedLocations": "Arms",
+  "DisallowedLocations": "All",
+  "CriticalComponent": false,
+  "Modes": [
+    {
+      "Id": "STD",
+      "UIName": "STD",
+      "Name": "Standard",
+      "Description": "LRM Fires normally.",
+      "isBaseMode": true,
+      "AIHitChanceCap": 0.99
+    },
+    {
+      "Id": "Hotload",
+      "UIName": "HL",
+      "Name": "HotLoaded",
+      "Description": "HotLoaded LRM have no Minimum Range, -1 Accuracy, 15% Jam Chance.",
+      "isBaseMode": false,
+      "DamageMultiplier": 0.9,
+      "AccuracyModifier": 1,
+      "MinRange": -90,
+      "FlatJammingChance": 0.15,
+      "AIHitChanceCap": 0.99
+    }
+  ],
+  "statusEffects": [
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "AAAFactor",
+        "Name": "NLRM-10: Anti Air Factor",
+        "Details": "AA Factor",
+        "Icon": "uixSvgIcon_equipment_Gyro"
+      },
+      "statisticData": {
+        "statName": "AAAFactor",
+        "operation": "Float_Add",
+        "modValue": "8",
+        "modType": "System.Single"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "Unarmored_HH_1",
+        "Name": "Unarmored handheld: Increased Receive AP Crit Chance - {current}",
+        "Details": "This unit is very vulnerable to arm crits",
+        "Icon": "UixSvgIcon_specialEquip_System"
+      },
+      "statisticData": {
+        "statName": "CAC_APCritChance",
+        "operation": "Float_Multiply",
+        "modValue": "10.0",
+        "modType": "System.Single",
+        "Location": "{current}"
+      }
+    }
+  ],
+  "ComponentTags": {
+    "items": [
+      "HandHeld.{location}",
+      "HandHeld",
+      "component_type_stock",
+      "range_very-long",
+      "BAIncompatible",
+      "LRM.{location}"
+    ],
+    "tagSetSourceFile": ""
+  }
+}

--- a/Eras/Republic3081-3130/Base Flashpoint/chassis/chassisdef_axman_AXM-6T-N.json
+++ b/Eras/Republic3081-3130/Base Flashpoint/chassis/chassisdef_axman_AXM-6T-N.json
@@ -1,0 +1,252 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.09
+    },
+    "AssemblyVariant": {
+      "PrefabID": "axman",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_AccurateWeapon_HandHeld",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 1252205,
+    "Rarity": 1,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Axman",
+    "Id": "chassisdef_axman_AXM-6T-N",
+    "Name": "Axman",
+    "Details": "This is a production variant based on the AXM-6X. This version, introduced in 3083, uses an Inner Sphere–produced XL engine and lacks the supercharger of the 6X. The top speed of the 6T is 86 km/h. The armor protection and weapon configuration are identical to the Axman 6X, but the Thunderbolt launchers have two tons of ammunition each. It is also the only Axman to not carry its typical melee weapon. Instead, this carries a handheld unarmored NLRM-10 launcher.\n\n<b><color=#e62e00>Quirk: Accurate Weapon - HandHeld</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
+    "Icon": "axman6x"
+  },
+  "VariantName": "AXM-6T-N",
+  "ChassisTags": {
+    "items": [
+      "mr-resize-1.2"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Brawler & Skirmisher",
+  "YangsThoughts": "The cheaper production variant of the prototype AXM-6X, should be easier to maintain. Good pickup boss.",
+  "MovementCapDefID": "movedef_heavymech",
+  "PathingCapDefID": "pathingdef_heavy",
+  "HardpointDataDefID": "hardpointdatadef_hatchetman",
+  "PrefabIdentifier": "chrPrfMech_hatchetmanBase-001",
+  "PrefabBase": "hatchetman",
+  "Tonnage": 65.0,
+  "InitialTonnage": 6.5,
+  "weightClass": "HEAVY",
+  "BattleValue": 0,
+  "Heatsinks": 0,
+  "TopSpeed": 120,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 100,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 5,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 33,
+  "MeleeInstability": 17,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 65,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 65,
+  "DFAInstability": 33,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 100,
+      "MaxRearArmor": -1,
+      "InternalStructure": 50
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 150,
+      "MaxRearArmor": 75,
+      "InternalStructure": 75
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 210,
+      "MaxRearArmor": 105,
+      "InternalStructure": 105
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 150,
+      "MaxRearArmor": 75,
+      "InternalStructure": 75
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 100,
+      "MaxRearArmor": -1,
+      "InternalStructure": 50
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 150,
+      "MaxRearArmor": -1,
+      "InternalStructure": 75
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 150,
+      "MaxRearArmor": -1,
+      "InternalStructure": 75
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 14,
+      "z": 0
+    },
+    {
+      "x": 4,
+      "y": 14,
+      "z": 0
+    },
+    {
+      "x": -4,
+      "y": 14,
+      "z": 0
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 14,
+      "z": 0
+    },
+    {
+      "x": 4,
+      "y": 14,
+      "z": 0
+    },
+    {
+      "x": -4,
+      "y": 14,
+      "z": 0
+    },
+    {
+      "x": 2.5,
+      "y": 6,
+      "z": 2.5
+    },
+    {
+      "x": -2.5,
+      "y": 6,
+      "z": 2.5
+    }
+  ]
+}

--- a/Eras/Republic3081-3130/Base Flashpoint/mech/mechdef_axman_AXM-6T-N.json
+++ b/Eras/Republic3081-3130/Base Flashpoint/mech/mechdef_axman_AXM-6T-N.json
@@ -1,0 +1,305 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_heavy",
+      "unit_advanced",
+      "unit_bracket_med",
+      "unit_role_brawler",
+      "unit_lance_assassin",
+      "unit_lance_vanguard",
+      "unit_indirectFire",
+      "unit_melee",
+      "unit_dlc",
+      "unit_optional_era",
+      "unit_era_republic",
+      "unit_proxy_model",
+      "unit_ready",
+      "unit_release",
+      "unit_chassis_axman",
+      "unit_tonnage_65",
+      "unit_rarity_equipment_level_1",
+      "steiner",
+      "Steiner3150",
+      "TimbuktuCollective",
+      "VesperMarches",
+      "ai_heat_normal",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_normal",
+      "ai_lance_normal",
+      "ai_lethalself_normal",
+      "ai_move_normal",
+      "ai_priority_normal",
+      "ai_reserve_normal",
+      "ai_shooting_normal",
+      "ai_surrounded_high"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_axman_AXM-6T-N",
+  "Description": {
+    "Cost": 7927142,
+    "Rarity": 1,
+    "Purchasable": false,
+    "UIName": "Axman AXM-6T-N",
+    "Id": "mechdef_axman_AXM-6T-N",
+    "Name": "Axman AXM-6T-N",
+    "Details": "This is a production variant based on the AXM-6X. This version, introduced in 3083, uses an Inner Sphere–produced XL engine and lacks the supercharger of the 6X. The top speed of the 6T is 86 km/h. The armor protection and weapon configuration are identical to the Axman 6X, but the Thunderbolt launchers have two tons of ammunition each. It is also the only Axman to not carry its typical melee weapon. Instead, this carries a handheld unarmored NLRM-10 launcher.\n\n<b><color=#e62e00>Quirk: Accurate Weapon - HandHeld</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.09</color></b>",
+    "Icon": "axman6x"
+  },
+  "simGameMechPartCost": 250441,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 50,
+      "CurrentInternalStructure": 75,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 50,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 125,
+      "CurrentRearArmor": 55,
+      "CurrentInternalStructure": 105,
+      "AssignedArmor": 125,
+      "AssignedRearArmor": 55,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 50,
+      "CurrentInternalStructure": 75,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 50,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 100,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 100,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 125,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 75,
+      "AssignedArmor": 125,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 125,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 75,
+      "AssignedArmor": 125,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Armor_LightFerroFibrous",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Structure_EndoSteel",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_325",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": true,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": true,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "HandHeld_Weapon_LRM_10_Enhanced",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_CASE",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_CASE",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_CASE",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Thunderbolt_15",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Thunderbolt_15",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Weapon_Laser_ER_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Weapon_Laser_ER_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Weapon_Laser_ER_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Weapon_Laser_ER_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Thunderbolt_15",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ]
+}


### PR DESCRIPTION
Add unarmored handheld NLRM-10 launcher and an axman to carry it. Increased incoming TAC chance in the carried arm to simulate unarmored hh launcher that is destroyed on first hit - ref TacOps Advanced Units/Weapons page 128. (1 in 6 chance to hit the handheld weapon). Tested, works.