### PR TITLE
Artillery "Cannon" Changes

### DIFF
--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_LongTom_Cannon.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_LongTom_Cannon.json
@@ -12,14 +12,13 @@
       }
     ],
     "BonusDescriptions": [
-      "IsArtillery",
+      "IsArtilleryCannon",
+      "IsArtilleryCannonAoE: 33%",
       "NoBonusesArtillery",
       "Indirect",
-      "DirectMode: -4",
       "FlakMode",
-      "ArtilleryMode",
       "WpnRecoil: 4",
-      "BraceToFireMode: 80, Direct & Flak",
+      "BraceToFire: 60",
       "WeaponShardsModRange: 1, 4"
     ],
     "Flags": [
@@ -90,17 +89,15 @@
   "CriticalComponent": false,
   "Modes": [
     {
-      "Id": "directfire",
-      "UIName": "Direct",
-      "isBaseMode": false,
-      "MinRange": -60,
-      "ShortRange": -30,
-      "MediumRange": -145,
-      "LongRange": -260,
-      "MaxRange": -355,
-      "IndirectFireCapable": false,
+      "Id": "STD",
+      "UIName": "STD",
+      "isBaseMode": true,
+      "IndirectFireCapable": true,
       "CantHitUnaffecedByPathing": true,
       "AlwaysIndirectVisuals": false,
+      "AOERange": 105,
+      "MinMissRadius": 5,
+      "MaxMissRadius": 60,
       "statusEffects": [
         {
           "durationData": {
@@ -123,13 +120,17 @@
           "statisticData": {
             "statName": "SelfInstability_OnFire",
             "operation": "Float_Add",
-            "modValue": "80",
+            "modValue": "60",
             "modType": "System.Single"
           }
         }
       ],
       "RestrictedAmmo": [
-        "Ammunition_LongTom_FAE"
+        "Ammunition_LongTom_SolidSlug",
+        "Ammunition_LongTom_FAE",
+        "Ammunition_LongTom_Nuke",
+        "Ammunition_LongTom_Copperhead",
+        "Ammunition_LongTom_Inferno"
       ]
     },
     {
@@ -175,7 +176,7 @@
           "statisticData": {
             "statName": "SelfInstability_OnFire",
             "operation": "Float_Add",
-            "modValue": "80",
+            "modValue": "60",
             "modType": "System.Single"
           }
         }
@@ -184,28 +185,8 @@
         "Ammunition_LongTom_SolidSlug",
         "Ammunition_LongTom_FAE",
         "Ammunition_LongTom_Nuke",
+        "Ammunition_LongTom_Copperhead",
         "Ammunition_LongTom_Inferno"
-      ]
-    },
-    {
-      "Id": "indirectfire",
-      "UIName": "Indirect",
-      "isBaseMode": true,
-      "ForbiddenRange": 120,
-      "MinMissRadius": 5,
-      "MaxMissRadius": 75,
-      "IndirectFireCapable": true,
-      "CantHitUnaffecedByPathing": true,
-      "AlwaysIndirectVisuals": true,
-      "IsArtillery": true,
-      "ArtilleryReticleColor": {
-        "C": "#FF0000",
-        "I": 1.5
-      },
-      "ArtilleryReticleRadius": 160,
-      "ArtilleryReticleText": "Long Tom Artillery",
-      "RestrictedAmmo": [
-        "Ammunition_LongTom_SolidSlug"
       ]
     }
   ],
@@ -217,9 +198,7 @@
       "TurretRestriction.{location}",
       "component_type_stock",
       "range_very-long",
-      "BAIncompatible",
-      "IgnoreSizeMatters",
-      "VehicleComponentFamily-Artillery"
+      "BAIncompatible"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_LongTom_Cannon.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_LongTom_Cannon.json
@@ -95,7 +95,11 @@
       "IndirectFireCapable": true,
       "CantHitUnaffecedByPathing": true,
       "AlwaysIndirectVisuals": false,
+      "AOECapable": true,
       "AOERange": 105,
+      "AOEDamage": 150,
+      "AOEHeatDamage": 0.01,
+      "AOEInstability": 35,
       "MinMissRadius": 5,
       "MaxMissRadius": 60,
       "statusEffects": [

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_Sniper_Cannon.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_Sniper_Cannon.json
@@ -95,7 +95,11 @@
       "IndirectFireCapable": true,
       "CantHitUnaffecedByPathing": true,
       "AlwaysIndirectVisuals": false,
+      "AOECapable": true,
       "AOERange": 80,
+      "AOEDamage": 100,
+      "AOEHeatDamage": 0.01,
+      "AOEInstability": 25,
       "MinMissRadius": 5,
       "MaxMissRadius": 50,
       "statusEffects": [

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_Sniper_Cannon.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_Sniper_Cannon.json
@@ -12,14 +12,13 @@
       }
     ],
     "BonusDescriptions": [
-      "IsArtillery",
+      "IsArtilleryCannon",
+      "IsArtilleryCannonAoE: 33%",
       "NoBonusesArtillery",
       "Indirect",
-      "ArtilleryMode",
       "FlakMode",
-      "DirectMode: -4",
       "WpnRecoil: 3",
-      "BraceToFireMode: 64, Direct & Flak",
+      "BraceToFire: 48",
       "WeaponShardsModRange: 1, 4"
     ],
     "Flags": [
@@ -90,17 +89,15 @@
   "CriticalComponent": false,
   "Modes": [
     {
-      "Id": "directfire",
-      "UIName": "Direct",
-      "isBaseMode": false,
-      "MinRange": -45,
-      "ShortRange": -25,
-      "MediumRange": -95,
-      "LongRange": -170,
-      "MaxRange": -235,
-      "IndirectFireCapable": false,
+      "Id": "STD",
+      "UIName": "STD",
+      "isBaseMode": true,
+      "IndirectFireCapable": true,
       "CantHitUnaffecedByPathing": true,
       "AlwaysIndirectVisuals": false,
+      "AOERange": 80,
+      "MinMissRadius": 5,
+      "MaxMissRadius": 50,
       "statusEffects": [
         {
           "durationData": {
@@ -123,10 +120,17 @@
           "statisticData": {
             "statName": "SelfInstability_OnFire",
             "operation": "Float_Add",
-            "modValue": "64",
+            "modValue": "48",
             "modType": "System.Single"
           }
         }
+      ],
+      "RestrictedAmmo": [
+        "Ammunition_Sniper_Inferno",
+        "Ammunition_Sniper_Nuke",
+        "Ammunition_Sniper_SolidSlug",
+        "Ammunition_Sniper_Copperhead",
+        "Ammunition_Sniper_Shaped"
       ]
     },
     {
@@ -172,7 +176,7 @@
           "statisticData": {
             "statName": "SelfInstability_OnFire",
             "operation": "Float_Add",
-            "modValue": "64",
+            "modValue": "48",
             "modType": "System.Single"
           }
         }
@@ -181,28 +185,7 @@
         "Ammunition_Sniper_Inferno",
         "Ammunition_Sniper_Nuke",
         "Ammunition_Sniper_SolidSlug",
-        "Ammunition_Sniper_Shaped"
-      ]
-    },
-    {
-      "Id": "indirectfire",
-      "UIName": "Indirect",
-      "isBaseMode": true,
-      "ForbiddenRange": 120,
-      "MinMissRadius": 5,
-      "MaxMissRadius": 60,
-      "IndirectFireCapable": true,
-      "CantHitUnaffecedByPathing": true,
-      "AlwaysIndirectVisuals": true,
-      "IsArtillery": true,
-      "ArtilleryReticleColor": {
-        "C": "#FF0000",
-        "I": 1.5
-      },
-      "ArtilleryReticleRadius": 120,
-      "ArtilleryReticleText": "Sniper Artillery",
-      "RestrictedAmmo": [
-        "Ammunition_Sniper_SolidSlug",
+        "Ammunition_Sniper_Copperhead",
         "Ammunition_Sniper_Shaped"
       ]
     }
@@ -215,9 +198,7 @@
       "TurretRestriction.{location}",
       "component_type_stock",
       "range_long",
-      "BAIncompatible",
-      "IgnoreSizeMatters",
-      "VehicleComponentFamily-Artillery"
+      "BAIncompatible"
     ],
     "tagSetSourceFile": ""
   }

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_Thumper_Cannon.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_Thumper_Cannon.json
@@ -96,7 +96,11 @@
       "IndirectFireCapable": true,
       "CantHitUnaffecedByPathing": true,
       "AlwaysIndirectVisuals": false,
+      "AOECapable": true,
       "AOERange": 60,
+      "AOEDamage": 75,
+      "AOEHeatDamage": 0.01,
+      "AOEInstability": 15,
       "MinMissRadius": 5,
       "MaxMissRadius": 40,
       "statusEffects": [

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_Thumper_Cannon.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_Thumper_Cannon.json
@@ -12,12 +12,13 @@
       }
     ],
     "BonusDescriptions": [
-      "IsArtillery",
+      "IsArtilleryCannon",
+      "IsArtilleryCannonAoE: 33%",
       "NoBonusesArtillery",
       "Indirect",
       "FlakMode",
       "WpnRecoil: 2",
-      "BraceToFireMode: 48, Direct & Flak",
+      "BraceToFire: 36",
       "WeaponShardsModRange: 1, 4"
     ],
     "Flags": [
@@ -89,17 +90,15 @@
   "CriticalComponent": false,
   "Modes": [
     {
-      "Id": "directfire",
-      "UIName": "Direct",
-      "isBaseMode": false,
-      "MinRange": -45,
-      "ShortRange": -5,
-      "MediumRange": -45,
-      "LongRange": -85,
-      "MaxRange": -115,
-      "IndirectFireCapable": false,
+      "Id": "STD",
+      "UIName": "STD",
+      "isBaseMode": true,
+      "IndirectFireCapable": true,
       "CantHitUnaffecedByPathing": true,
       "AlwaysIndirectVisuals": false,
+      "AOERange": 60,
+      "MinMissRadius": 5,
+      "MaxMissRadius": 40,
       "statusEffects": [
         {
           "durationData": {
@@ -122,13 +121,18 @@
           "statisticData": {
             "statName": "SelfInstability_OnFire",
             "operation": "Float_Add",
-            "modValue": "48",
+            "modValue": "36",
             "modType": "System.Single"
           }
         }
       ],
       "RestrictedAmmo": [
-        "Ammunition_Thumper_Fascam"
+        "Ammunition_Thumper_Fascam",
+        "Ammunition_Thumper_Inferno",
+        "Ammunition_Thumper_Nuke",
+        "Ammunition_Thumper_Shaped",
+        "Ammunition_Thumper_Copperhead",
+        "Ammunition_Thumper_SolidSlug"
       ]
     },
     {
@@ -174,7 +178,7 @@
           "statisticData": {
             "statName": "SelfInstability_OnFire",
             "operation": "Float_Add",
-            "modValue": "48",
+            "modValue": "36",
             "modType": "System.Single"
           }
         }
@@ -184,28 +188,7 @@
         "Ammunition_Thumper_Inferno",
         "Ammunition_Thumper_Nuke",
         "Ammunition_Thumper_Shaped",
-        "Ammunition_Thumper_SolidSlug"
-      ]
-    },
-    {
-      "Id": "indirectfire",
-      "UIName": "Indirect",
-      "isBaseMode": true,
-      "ForbiddenRange": 120,
-      "MinMissRadius": 5,
-      "MaxMissRadius": 45,
-      "IndirectFireCapable": true,
-      "CantHitUnaffecedByPathing": true,
-      "AlwaysIndirectVisuals": true,
-      "IsArtillery": true,
-      "ArtilleryReticleColor": {
-        "C": "#FF0000",
-        "I": 1.5
-      },
-      "ArtilleryReticleRadius": 90,
-      "ArtilleryReticleText": "Thumper Artillery",
-      "RestrictedAmmo": [
-        "Ammunition_Thumper_Shaped",
+        "Ammunition_Thumper_Copperhead",
         "Ammunition_Thumper_SolidSlug"
       ]
     }
@@ -214,13 +197,11 @@
     "items": [
       "LootMagnetBlacklist",
       "Artillery",
-      "component_type_stock",
       "OmniRestriction.{location}",
       "TurretRestriction.{location}",
+      "component_type_stock",
       "range_long",
-      "BAIncompatible",
-      "IgnoreSizeMatters",
-      "VehicleComponentFamily-Artillery"
+      "BAIncompatible"
     ],
     "tagSetSourceFile": ""
   }


### PR DESCRIPTION
Cannons were somewhat orphaned by the artillery rework. The following changes are an attempt to make them more distinct from their larger cousins. Changes are partially inspired by TT sources, where they function more like short range siege guns or heavy mortars rather than artillery pieces.

- Cannons no longer require a setup turn, Direct/Artillery modes have been condensed into a single indirect enabled mode.
- Cannon "AoERange" reduced by 33% compared to their full-sized counterparts
- Cannon "SelfInstability" reduced by 25% compared to their full-sized counterparts
- Cannons may only fire "Standard" high explosive ammunition, there are no exceptions as of this changelog.
- Cannons retain the "NoBonusesArtillery*" tag.
- Cannons no longer ignore "SizeMatters", unlike their full counterparts.
- Cannons are no longer classed as "Artillery" weapons for vehicle refitting purposes.

*"Most accuracy and evasion ignore modifiers from other equipment, affinities and skills do not apply to this weapon."

Changes are highly subject to feedback and testing, expect anything from adjustments to a full rollback should they not work out as intended, but I am hopeful this is a step in the right direction.