### PR TITLE
Fix lam tag restrictions

### DIFF
--- a/Core/RogueTechCore/categories/Categories_LAM.json
+++ b/Core/RogueTechCore/categories/Categories_LAM.json
@@ -58,7 +58,12 @@
     },
     {
       "Name": "LAMBAWingmountBay",
-      "DisplayName": "BattleArmor Wingmount"
+      "DisplayName": "BattleArmor Wingmount",
+      "BaseLimits": [
+        {
+          "Max": 1
+        }
+      ]
     },
     {
       "Name": "LAMBattleArmorBay",

--- a/Core/RogueTechCore/tagRestrictions/TagRestrictions_LAM.json
+++ b/Core/RogueTechCore/tagRestrictions/TagRestrictions_LAM.json
@@ -81,6 +81,16 @@
       ]
     },
     {
+      "Tag": "LAMBAWingmountBay",
+      "RequiredTags": [
+        "LandAirMech",
+        "LAM-Structure",
+        "LAM-Armor",
+        "LAM-Engine",
+        "LAMFlightSystems"
+      ]
+    },
+    {
       "Tag": "LAMInfantryBay",
       "RequiredTags": [
         "LandAirMech",


### PR DESCRIPTION
1 of the 2 parts needed to make LAM carry battle armor was equipable on normal mechs. Which didn't do much on it's own but looks like a bug.

LAM BA Refit item now limited to 1 on mech because it's effect is binary.
Refit item Now limited to LAMs. A missing category created for this purpose
Note this probably didn't let normal mechs actually carry extra BA. The actual BA pods can only go on LAM i'm pretty sure.
This is just tidier.