### PR TITLE
change proxy models; change weapon prefabs for ATM and MML launchers

### DIFF
--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_12.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_12.json
@@ -84,7 +84,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm20",
+  "PrefabIdentifier": "lrm15",
   "BattleValue": 212,
   "InventorySize": 5,
   "Tonnage": 7,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_3.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_3.json
@@ -84,7 +84,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "srm4",
   "BattleValue": 53,
   "InventorySize": 2,
   "Tonnage": 1.5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_6.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_6.json
@@ -84,7 +84,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "srm6",
   "BattleValue": 105,
   "InventorySize": 3,
   "Tonnage": 3.5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_9.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_ATM_9.json
@@ -84,7 +84,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm15",
+  "PrefabIdentifier": "lrm10",
   "BattleValue": 147,
   "InventorySize": 4,
   "Tonnage": 5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_12.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_12.json
@@ -82,7 +82,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm20",
+  "PrefabIdentifier": "lrm15",
   "BattleValue": 333,
   "InventorySize": 5,
   "Tonnage": 7,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_3.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_3.json
@@ -82,7 +82,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "srm4",
   "BattleValue": 83,
   "InventorySize": 2,
   "Tonnage": 1.5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_6.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_6.json
@@ -82,7 +82,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "srm6",
   "BattleValue": 165,
   "InventorySize": 3,
   "Tonnage": 3.5,

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_9.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_iATM_9.json
@@ -82,7 +82,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm15",
+  "PrefabIdentifier": "lrm10",
   "BattleValue": 231,
   "InventorySize": 4,
   "Tonnage": 5,

--- a/Core/RogueModuleTech/Weapons/Weapon_MML_3.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_MML_3.json
@@ -73,7 +73,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "srm4",
   "BattleValue": 29,
   "InventorySize": 1,
   "Tonnage": 1.5,

--- a/Core/RogueModuleTech/Weapons/Weapon_MML_5.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_MML_5.json
@@ -76,7 +76,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "lrm5",
   "BattleValue": 45,
   "InventorySize": 2,
   "Tonnage": 3,

--- a/Core/RogueModuleTech/Weapons/Weapon_MML_7.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_MML_7.json
@@ -76,7 +76,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "mml7",
+  "PrefabIdentifier": "srm6",
   "BattleValue": 67,
   "InventorySize": 3,
   "Tonnage": 4.5,

--- a/Core/RogueModuleTech/Weapons/Weapon_MML_9.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_MML_9.json
@@ -76,7 +76,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "mml9",
+  "PrefabIdentifier": "lrm10",
   "BattleValue": 86,
   "InventorySize": 4,
   "Tonnage": 6,

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_bloodhound_B1-HND.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_bloodhound_B1-HND.json
@@ -36,7 +36,7 @@
   "VariantName": "B1-HND",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.7"
+      "mr-resize-0.9-0.95-1.15"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Built to operate in an counterinsurgency role, the Bloodhound is designed to engage enemy guerilla units. The Bloodhound is built on an Earthwerks PXH IV endo steel chassis that carries a lightweight Hermes 315 XL engine capable of pushing the Bloodhound up to speeds of 118.8 km/h. In addition to this speed, the Bloodhound is well armored for its mission, with nine and a half tons of Durallex Light armor with CASE to protect the 'Mech against complete destruction in the event of an ammunition explosion. The Bloodhound also carries a Beagle active probe which is capable of finding hidden enemy units.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_cyclone",
+  "PrefabIdentifier": "chrprfmech_cyclonebase-001",
+  "PrefabBase": "cyclone",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_bloodhound_B2-HND.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_bloodhound_B2-HND.json
@@ -36,7 +36,7 @@
   "VariantName": "B2-HND",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.7"
+      "mr-resize-0.9-0.95-1.15"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Built to operate in an counterinsurgency role, the Bloodhound is designed to engage enemy guerilla units. The Bloodhound is built on an Earthwerks PXH IV endo steel chassis that carries a lightweight Hermes 315 XL engine capable of pushing the Bloodhound up to speeds of 118.8 km/h. In addition to this speed, the Bloodhound is well armored for its mission, with nine and a half tons of Durallex Light armor with CASE to protect the 'Mech against complete destruction in the event of an ammunition explosion. The Bloodhound also carries a Beagle active probe which is capable of finding hidden enemy units.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_cyclone",
+  "PrefabIdentifier": "chrprfmech_cyclonebase-001",
+  "PrefabBase": "cyclone",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_ninja-to_NJT-2.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_ninja-to_NJT-2.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.87-0.84-0.89"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Ninja-To is intended to work with, and take advantage of, other units which carry a C3 Master Computer by carrying a C3 slave unit that allows it to share targeting data with other units in a C3 equipped unit. The Ninja-To is built on a lightweight Star League XT Light Endo Steel that cradles a powerful Magna 390 XL engine that gives the 'Mech a top speed of 97.2 km/h. While this combination of structure and engine saves weight, it also makes the Ninja-To susceptible to being a combat loss from side torso destruction. The Ninja-To carries twelve tons of Durallex Heavy with CASE to ensure that it will not be completely destroyed in the event of an ammunition explosion.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_emperor",
+  "PrefabIdentifier": "chrprfmech_emperorbase-001",
+  "PrefabBase": "emperor",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_lobo_LOB-1.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_lobo_LOB-1.json
@@ -39,7 +39,7 @@
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.65"
+      "mr-resize-0.8-0.69-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -47,9 +47,9 @@
   "YangsThoughts": "The Lobo was originally conceived as an inexpensive companion to the Timber Wolf. Khan Vladimir Ward's Clan Wolf was never fond of the Linebacker, the brain child of Khans Natasha Kerensky and Phelan Ward, so Khan Ward directed his scientists to design something smaller. Despite that, Ward was not happy with his options until Clan Coyote developed the Advanced Tactical Missile launcher, which Ward quickly secured the technology and had it incorporated into the Lobo. With that inclusion, the 'Mech ceased to be cheap, however, as the inclusion of endo steel and an extralight engine was necessary to free up space for the desired launchers. Able to out-pace the Timber Wolf, the Lobo is more in line with Clan Wolf's shift to faster, hard-hitting 'Mechs.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "PrefabIdentifier": "chrprfmech_avatarbase-001",
+  "PrefabBase": "avatar",
   "Tonnage": 40.0,
   "InitialTonnage": 4.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_lobo_LOB-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_lobo_LOB-2.json
@@ -39,7 +39,7 @@
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.65"
+      "mr-resize-0.8-0.69-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -47,9 +47,9 @@
   "YangsThoughts": "The Lobo was originally conceived as an inexpensive companion to the Timber Wolf. Khan Vladimir Ward's Clan Wolf was never fond of the Linebacker, the brain child of Khans Natasha Kerensky and Phelan Ward, so Khan Ward directed his scientists to design something smaller. Despite that, Ward was not happy with his options until Clan Coyote developed the Advanced Tactical Missile launcher, which Ward quickly secured the technology and had it incorporated into the Lobo. With that inclusion, the 'Mech ceased to be cheap, however, as the inclusion of endo steel and an extralight engine was necessary to free up space for the desired launchers. Able to out-pace the Timber Wolf, the Lobo is more in line with Clan Wolf's shift to faster, hard-hitting 'Mechs.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "PrefabIdentifier": "chrprfmech_avatarbase-001",
+  "PrefabBase": "avatar",
   "Tonnage": 40.0,
   "InitialTonnage": 4.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_lobo_LOB-3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_lobo_LOB-3.json
@@ -39,7 +39,7 @@
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.65"
+      "mr-resize-0.8-0.69-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -47,9 +47,9 @@
   "YangsThoughts": "The Lobo was originally conceived as an inexpensive companion to the Timber Wolf. Khan Vladimir Ward's Clan Wolf was never fond of the Linebacker, the brain child of Khans Natasha Kerensky and Phelan Ward, so Khan Ward directed his scientists to design something smaller. Despite that, Ward was not happy with his options until Clan Coyote developed the Advanced Tactical Missile launcher, which Ward quickly secured the technology and had it incorporated into the Lobo. With that inclusion, the 'Mech ceased to be cheap, however, as the inclusion of endo steel and an extralight engine was necessary to free up space for the desired launchers. Able to out-pace the Timber Wolf, the Lobo is more in line with Clan Wolf's shift to faster, hard-hitting 'Mechs.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "PrefabIdentifier": "chrprfmech_avatarbase-001",
+  "PrefabBase": "avatar",
   "Tonnage": 40.0,
   "InitialTonnage": 4.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_ninja-to_NJT-3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_ninja-to_NJT-3.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.87-0.84-0.89"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Ninja-To is intended to work with, and take advantage of, other units which carry a C3 Master Computer by carrying a C3 slave unit that allows it to share targeting data with other units in a C3 equipped unit. The Ninja-To is built on a lightweight Star League XT Light Endo Steel that cradles a powerful Magna 390 XL engine that gives the 'Mech a top speed of 97.2 km/h. While this combination of structure and engine saves weight, it also makes the Ninja-To susceptible to being a combat loss from side torso destruction. The Ninja-To carries twelve tons of Durallex Heavy with CASE to ensure that it will not be completely destroyed in the event of an ammunition explosion.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_emperor",
+  "PrefabIdentifier": "chrprfmech_emperorbase-001",
+  "PrefabBase": "emperor",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_ninja-to_NJT-4.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_ninja-to_NJT-4.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.87-0.84-0.89"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Ninja-To is intended to work with, and take advantage of, other units which carry a C3 Master Computer by carrying a C3 slave unit that allows it to share targeting data with other units in a C3 equipped unit. The Ninja-To is built on a lightweight Star League XT Light Endo Steel that cradles a powerful Magna 390 XL engine that gives the 'Mech a top speed of 97.2 km/h, more when TSM is activated. While this combination of structure and engine saves weight, it also makes the Ninja-To susceptible to being a combat loss from side torso destruction. This variant of the Ninja-To puts a Snub Nose PPC in each arm, removes a heat sink, and adds an advanced Targeting Computer. The standard armor plate of the original is replaced by Ferro-Fibrous Armor.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_emperor",
+  "PrefabIdentifier": "chrprfmech_emperorbase-001",
+  "PrefabBase": "emperor",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_ninja-to_NJT-EMP.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_ninja-to_NJT-EMP.json
@@ -41,7 +41,8 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "UniqueMech"
+      "UniqueMech",
+      "mr-resize-0.87-0.84-0.89"
     ],
     "tagSetSourceFile": ""
   },
@@ -49,9 +50,9 @@
   "YangsThoughts": "The Ninja-To is intended to work with, and take advantage of, other units which carry a C3 Master Computer by carrying a C3 slave unit that allows it to share targeting data with other units in a C3 equipped unit. The Ninja-To is built on a lightweight Star League XT Light Endo Steel that cradles a powerful Magna 390 XL engine that gives the 'Mech a top speed of 97.2 km/h. While this combination of structure and engine saves weight, it also makes the Ninja-To susceptible to being a combat loss from side torso destruction. The EMP Variant is a close range in-fighter packing dual Snub-Nose PPCs, ER Medium Lasers and Medium Pulse Lasers as well as TSM for that up close and personal touch.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_emperor",
+  "PrefabIdentifier": "chrprfmech_emperorbase-001",
+  "PrefabBase": "emperor",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_bloodhound_B3-HND.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_bloodhound_B3-HND.json
@@ -36,7 +36,7 @@
   "VariantName": "B3-HND",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.7"
+      "mr-resize-0.9-0.95-1.15"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Built to operate in an counterinsurgency role, the Bloodhound is designed to engage enemy guerilla units. The Bloodhound is built on an Earthwerks PXH IV endo steel chassis that carries a lightweight Hermes 315 XL engine capable of pushing the Bloodhound up to speeds of 118.8 km/h. In addition to this speed, the Bloodhound is well armored for its mission, with nine and a half tons of Durallex Light armor with CASE to protect the 'Mech against complete destruction in the event of an ammunition explosion. The Bloodhound also carries a Beagle active probe which is capable of finding hidden enemy units.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_marauder",
-  "PrefabIdentifier": "chrPrfMech_marauderBase-001",
-  "PrefabBase": "marauder",
+  "HardpointDataDefID": "hardpointdatadef_cyclone",
+  "PrefabIdentifier": "chrprfmech_cyclonebase-001",
+  "PrefabBase": "cyclone",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_12_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_12_Pirate.json
@@ -91,7 +91,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm20",
+  "PrefabIdentifier": "lrm15",
   "BattleValue": 128,
   "InventorySize": 5,
   "Tonnage": 7,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_12_Streak_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_12_Streak_Pirate.json
@@ -96,7 +96,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm20",
+  "PrefabIdentifier": "lrm15",
   "BattleValue": 128,
   "InventorySize": 6,
   "Tonnage": 8,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_3_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_3_Pirate.json
@@ -91,7 +91,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "srm4",
   "BattleValue": 37,
   "InventorySize": 2,
   "Tonnage": 1.5,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_3_Streak_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_3_Streak_Pirate.json
@@ -97,7 +97,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "srm4",
   "BattleValue": 37,
   "InventorySize": 3,
   "Tonnage": 2,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_6_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_6_Pirate.json
@@ -91,7 +91,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "srm6",
   "BattleValue": 65,
   "InventorySize": 3,
   "Tonnage": 3.5,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_6_Streak_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_6_Streak_Pirate.json
@@ -96,7 +96,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm10",
+  "PrefabIdentifier": "srm6",
   "BattleValue": 65,
   "InventorySize": 4,
   "Tonnage": 4,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_9_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_9_Pirate.json
@@ -91,7 +91,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm15",
+  "PrefabIdentifier": "lrm10",
   "BattleValue": 93,
   "InventorySize": 4,
   "Tonnage": 5,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_9_Streak_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_ATM_9_Streak_Pirate.json
@@ -96,7 +96,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm15",
+  "PrefabIdentifier": "lrm10",
   "BattleValue": 93,
   "InventorySize": 5,
   "Tonnage": 6,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_3_Streak.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_3_Streak.json
@@ -76,7 +76,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "lrm5",
+  "PrefabIdentifier": "srm4",
   "BattleValue": 0,
   "InventorySize": 1,
   "Tonnage": 2,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_5_Streak.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_5_Streak.json
@@ -79,7 +79,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "mml5",
+  "PrefabIdentifier": "lrm5",
   "BattleValue": 0,
   "InventorySize": 2,
   "Tonnage": 4,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_7_Streak.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_7_Streak.json
@@ -79,7 +79,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "mml7",
+  "PrefabIdentifier": "srm6",
   "BattleValue": 0,
   "InventorySize": 3,
   "Tonnage": 6,

--- a/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_9_Streak.json
+++ b/Optionals/RISCtech/Base/Items/Weapon/Weapon_MML_9_Streak.json
@@ -79,7 +79,7 @@
   "BonusValueB": "",
   "ComponentType": "Weapon",
   "ComponentSubType": "Weapon",
-  "PrefabIdentifier": "mml9",
+  "PrefabIdentifier": "lrm10",
   "BattleValue": 0,
   "InventorySize": 4,
   "Tonnage": 8,


### PR DESCRIPTION
Bloodhound using Cyclone model
Ninja-To using Emperor model
Lobo using Avatar model
The larger MML launchers were not displaying on models. I understand they were intended to pick a display proxy, but that wasn't happening, so I've swapped them to using regular srm/lrm prefabs, since that's pretty much all that the hardpoints defs look for anyway. And bumped the ATM launchers down to srm/lrm prefabs closer to their tube counts.