### PR TITLE
Fix Unique Gyro Dreadnought description

### DIFF
--- a/Core/RogueModuleTech/Unique/Gear/Unique_Gyro_Dreadnought.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Gyro_Dreadnought.json
@@ -9,7 +9,8 @@
       "Bulwark",
       "GyroStab: 75",
       "GyroStab2: +75",
-      "GyroWeight: -50%"
+      "GyroWeight: -50%",
+      "DamageTaken: -15%"
     ],
     "Flags": [
       "default",


### PR DESCRIPTION
It still has -15% damage.