### PR TITLE
Resize Falcon; Change proxy models for Hellion, Corvis, Omni-Corvis; …

### DIFF
--- a/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_Autocannon_AC_5_Light.json
+++ b/Core/RogueModuleTech/HandHeld/HandHelds/HandHeld_Weapon_Autocannon_AC_5_Light.json
@@ -51,7 +51,7 @@
   "HeatDamage": 0,
   "Instability": 5,
   "DamageVariance": 0,
-  "AccuracyModifier": 1,
+  "AccuracyModifier": -1,
   "EvasivePipsIgnored": 1,
   "RefireModifier": 0,
   "OverheatedDamageMultiplier": 0,

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Weapons.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Weapons.json
@@ -598,19 +598,38 @@
       "Bonus": "RISCMML",
       "Short": "RISC MML",
       "Long": "RISC Multi Missile Launcher",
-      "Full": "RISC Multi-Missile Launchers can fire both LRM and SRM ammo, with the normal range and damage for each. RISC MMLs roll to hit for each missile."
+      "Full": "RISC Multi-Missile Launchers can fire both LRM and SRM ammo, with the normal range and damage for each. RISC MMLs roll to hit individually for each missile."
     },
     {
       "Bonus": "MMLP",
       "Short": "MML",
       "Long": "Multi Missile Launcher",
-      "Full": "Jury Rigged Multi-Missile Launchers can fire SRM, LRM, MRM, HMRM ammo."
+      "Full": "Jury Rigged Multi-Missile Launchers can fire both LRM and SRM ammo. They roll to hit individually for each missile, and do not cluster."
     },
     {
       "Bonus": "PirateATM",
       "Short": "JR ATM",
       "Long": "Jury Rigged ATM",
-      "Full": "Jury-Rigged ATMs can fire MRM, LRM or SRM ammo."
+      "Full": "Jury-Rigged ATMs can fire MRM, LRM or SRM ammo. They roll to hit individually for each missile, and do not cluster."
+    },
+    {
+      "Bonus": "PirateLRM",
+      "Short": "JR LRM",
+      "Long": "Jury Rigged LRM",
+      "Full": "Jury-Rigged LRMs roll to hit individually for each missile, and do not cluster."
+    },
+    {
+      "Bonus": "PirateMRM",
+      "Short": "JR MRM",
+      "Long": "Jury Rigged MRM",
+      "Full": "Jury-Rigged MRMs roll to hit individually for each missile, and do not cluster."
+    },
+    
+    {
+      "Bonus": "PirateSRM",
+      "Short": "JR SRM",
+      "Long": "Jury Rigged SRM",
+      "Full": "Jury-Rigged SRMs roll to hit individually for each missile, and do not cluster."
     },
     {
       "Bonus": "BFG",

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Weapons.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Weapons.json
@@ -604,32 +604,32 @@
       "Bonus": "MMLP",
       "Short": "MML",
       "Long": "Multi Missile Launcher",
-      "Full": "Jury Rigged Multi-Missile Launchers can fire both LRM and SRM ammo. They roll to hit individually for each missile, and do not cluster."
+      "Full": "Jury Rigged Multi-Missile Launchers can fire both LRM and SRM ammo. They roll to hit individually for each missile, and do not group."
     },
     {
       "Bonus": "PirateATM",
       "Short": "JR ATM",
       "Long": "Jury Rigged ATM",
-      "Full": "Jury-Rigged ATMs can fire MRM, LRM or SRM ammo. They roll to hit individually for each missile, and do not cluster."
+      "Full": "Jury-Rigged ATMs can fire MRM, LRM or SRM ammo. They roll to hit individually for each missile, and do not group."
     },
     {
       "Bonus": "PirateLRM",
       "Short": "JR LRM",
       "Long": "Jury Rigged LRM",
-      "Full": "Jury-Rigged LRMs roll to hit individually for each missile, and do not cluster."
+      "Full": "Jury-Rigged LRMs roll to hit individually for each missile, and do not group."
     },
     {
       "Bonus": "PirateMRM",
       "Short": "JR MRM",
       "Long": "Jury Rigged MRM",
-      "Full": "Jury-Rigged MRMs roll to hit individually for each missile, and do not cluster."
+      "Full": "Jury-Rigged MRMs roll to hit individually for each missile, and do not group."
     },
     
     {
       "Bonus": "PirateSRM",
       "Short": "JR SRM",
       "Long": "Jury Rigged SRM",
-      "Full": "Jury-Rigged SRMs roll to hit individually for each missile, and do not cluster."
+      "Full": "Jury-Rigged SRMs roll to hit individually for each missile, and do not group."
     },
     {
       "Bonus": "BFG",

--- a/DLC/RogueFlashPointModule/Chassis/chassisdef_highlander_HGN-641-X-2.json
+++ b/DLC/RogueFlashPointModule/Chassis/chassisdef_highlander_HGN-641-X-2.json
@@ -49,7 +49,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_falcon_FLC-5P.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_falcon_FLC-5P.json
@@ -36,7 +36,7 @@
   "VariantName": "FLC-5P",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_falcon_FLC-6C.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_falcon_FLC-6C.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ClanMech",
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_highlander_HGN-694.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_highlander_HGN-694.json
@@ -46,7 +46,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_highlander_HGN-734.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_highlander_HGN-734.json
@@ -45,7 +45,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_corvis_CRV-1.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_corvis_CRV-1.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.9"
+      "mr-resize-0.87-0.78-0.83"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": " The Corvis was one of the predecessors to the OmniMech, utilizing the same semi-modular ports as the Star League Mercury BattleMech. Clan technicians eventually expanded upon this design to create the Stormcrow, and with the development of that front-line OmniMech, all of the Clans save the Horses lost interest in the Corvis, which was often derided as too slow for its weight class. In fact, the Corvis' only saving grace is its use of jump jets, because they allow the medium-range 'Mech to be useful when on restricting terrain, such as urban environments. The Corvis was often deployed as support for conventional troops, such as combat vehicles and infantry, so it only seems natural that the Horses would want to keep producing it.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_stormcrow",
-  "PrefabIdentifier": "chrprfmech_stormcrowbase-001",
-  "PrefabBase": "stormcrow",
+  "HardpointDataDefID": "hardpointdatadef_mushu",
+  "PrefabIdentifier": "chrprfmech_mushubase-001",
+  "PrefabBase": "mushu",
   "Tonnage": 40.0,
   "InitialTonnage": 4.0,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4N.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4N.json
@@ -36,7 +36,7 @@
   "VariantName": "FLC-4N",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4Nb-PP.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4Nb-PP.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "SLDFMech",
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4Nb-PP2.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4Nb-PP2.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "SLDFMech",
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4Nb.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4Nb.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "SLDFMech",
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4P.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-4P.json
@@ -36,7 +36,7 @@
   "VariantName": "FLC-4P",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-5P2.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-5P2.json
@@ -36,7 +36,7 @@
   "VariantName": "FLC-5P2",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-5PW.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_falcon_FLC-5PW.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.75"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-A.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-B.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persisent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-C.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-C.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-Prime.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hellion_HEN-Prime.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable scout unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_highlander_HGN-732.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_highlander_HGN-732.json
@@ -45,7 +45,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_highlander_HGN-732b.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_highlander_HGN-732b.json
@@ -46,7 +46,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_highlander_HGN-736.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_highlander_HGN-736.json
@@ -46,7 +46,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_omni-corvis_OCRV-A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_omni-corvis_OCRV-A.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.95-0.87-0.95"
     ],
     "tagSetSourceFile": ""
   },
@@ -75,9 +76,9 @@
   "YangsThoughts": "The Omni-Corvis is an early prototype of OmniMech technology that was developed by Clan Hell's Horses. Based on the Corvis BattleMech, it carries the modular systems first introduced in the Mercury to the logical extreme. After Clan Ghost Bear took control of Tokasha MechWorks in 2921 they released the plans for the Omni-Corvis on the Chatterweb to punish the Horses for the death of Khan Kilbourne Jorgensson. The only Clan to take advantage of the design was Clan Snow Raven, who used the plans to create the Stormcrow.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_stormcrow",
-  "PrefabIdentifier": "chrprfmech_stormcrowbase-001",
-  "PrefabBase": "stormcrow",
+  "HardpointDataDefID": "hardpointdatadef_mushu",
+  "PrefabIdentifier": "chrprfmech_mushubase-001",
+  "PrefabBase": "mushu",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_omni-corvis_OCRV-B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_omni-corvis_OCRV-B.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.95-0.87-0.95"
     ],
     "tagSetSourceFile": ""
   },
@@ -75,9 +76,9 @@
   "YangsThoughts": "The Omni-Corvis is an early prototype of OmniMech technology that was developed by Clan Hell's Horses. Based on the Corvis BattleMech, it carries the modular systems first introduced in the Mercury to the logical extreme. After Clan Ghost Bear took control of Tokasha MechWorks in 2921 they released the plans for the Omni-Corvis on the Chatterweb to punish the Horses for the death of Khan Kilbourne Jorgensson. The only Clan to take advantage of the design was Clan Snow Raven, who used the plans to create the Stormcrow.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_stormcrow",
-  "PrefabIdentifier": "chrprfmech_stormcrowbase-001",
-  "PrefabBase": "stormcrow",
+  "HardpointDataDefID": "hardpointdatadef_mushu",
+  "PrefabIdentifier": "chrprfmech_mushubase-001",
+  "PrefabBase": "mushu",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_omni-corvis_OCRV-Prime.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_omni-corvis_OCRV-Prime.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.95-0.87-0.95"
     ],
     "tagSetSourceFile": ""
   },
@@ -75,9 +76,9 @@
   "YangsThoughts": "The Omni-Corvis is an early prototype of OmniMech technology that was developed by Clan Hell's Horses. Based on the Corvis BattleMech, it carries the modular systems first introduced in the Mercury to the logical extreme. After Clan Ghost Bear took control of Tokasha MechWorks in 2921 they released the plans for the Omni-Corvis on the Chatterweb to punish the Horses for the death of Khan Kilbourne Jorgensson. The only Clan to take advantage of the design was Clan Snow Raven, who used the plans to create the Stormcrow.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_stormcrow",
-  "PrefabIdentifier": "chrprfmech_stormcrowbase-001",
-  "PrefabBase": "stormcrow",
+  "HardpointDataDefID": "hardpointdatadef_mushu",
+  "PrefabIdentifier": "chrprfmech_mushubase-001",
+  "PrefabBase": "mushu",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_highlander_HGN-732_colleen.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_highlander_HGN-732_colleen.json
@@ -49,7 +49,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_highlander_HGN-732_jorgensson.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_highlander_HGN-732_jorgensson.json
@@ -49,7 +49,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_gotterdammerung_GTD-20C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_gotterdammerung_GTD-20C.json
@@ -43,7 +43,7 @@
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_gotterdammerung_GTD-20S.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_gotterdammerung_GTD-20S.json
@@ -43,7 +43,7 @@
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_gotterdammerung_GTD-30S.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_gotterdammerung_GTD-30S.json
@@ -43,7 +43,7 @@
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_hellion_HEN-T.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_hellion_HEN-T.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persisent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_corvis_CRV-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_corvis_CRV-2.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.9"
+      "mr-resize-0.87-0.78-0.83"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": " The Corvis was one of the predecessors to the OmniMech, utilizing the same semi-modular ports as the Star League Mercury BattleMech. Clan technicians eventually expanded upon this design to create the Stormcrow, and with the development of that front-line OmniMech, all of the Clans save the Horses lost interest in the Corvis, which was often derided as too slow for its weight class. In fact, the Corvis' only saving grace is its use of jump jets, because they allow the medium-range 'Mech to be useful when on restricting terrain, such as urban environments. The Corvis was often deployed as support for conventional troops, such as combat vehicles and infantry, so it only seems natural that the Horses would want to keep producing it.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_stormcrow",
-  "PrefabIdentifier": "chrprfmech_stormcrowbase-001",
-  "PrefabBase": "stormcrow",
+  "HardpointDataDefID": "hardpointdatadef_mushu",
+  "PrefabIdentifier": "chrprfmech_mushubase-001",
+  "PrefabBase": "mushu",
   "Tonnage": 40.0,
   "InitialTonnage": 4.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellion_HEN-D.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellion_HEN-D.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellion_HEN-E.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellion_HEN-E.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellion_HEN-F.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_hellion_HEN-F.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_highlander_HGN-738.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_highlander_HGN-738.json
@@ -45,7 +45,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_hellion_HEN-G.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_hellion_HEN-G.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_hellion_HEN-P.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_hellion_HEN-P.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.62"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "A very formidable and mobile light unit, as most Clan designs tend to be. Enough armor so that a single alpha strike usually is not able to cripple it, and enough speed to get away from trouble, it can be as persistent as a cockroach at times. Oh, and it sports quite the bite too.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_kitfox",
-  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
-  "PrefabBase": "kitfox",
+  "HardpointDataDefID": "hardpointdatadef_griffin",
+  "PrefabIdentifier": "chrPrfMech_griffinBase-001",
+  "PrefabBase": "griffin",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_highlander_HGN-740.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_highlander_HGN-740.json
@@ -45,7 +45,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/ExperimentalWeapons/Superheavys/chassis/chassisdef_manx_MNX-1035.json
+++ b/Optionals/ExperimentalWeapons/Superheavys/chassis/chassisdef_manx_MNX-1035.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,

--- a/Optionals/ExperimentalWeapons/Superheavys/chassis/chassisdef_manx_MNX-1042.json
+++ b/Optionals/ExperimentalWeapons/Superheavys/chassis/chassisdef_manx_MNX-1042.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,

--- a/Optionals/ExperimentalWeapons/Superheavys/chassis/chassisdef_manx_MNX-1499.json
+++ b/Optionals/ExperimentalWeapons/Superheavys/chassis/chassisdef_manx_MNX-1499.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_10_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_10_Pirate.json
@@ -9,6 +9,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateLRM",
       "WpnAccuracy: -1",
       "OHDamage: 75%",
       "PipsIgnored: 1",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_15_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_15_Pirate.json
@@ -9,6 +9,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateLRM",
       "VariableDmg: 2",
       "WpnAccuracy: -1",
       "DmgFallOff: 35%",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_30_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_30_Pirate.json
@@ -9,6 +9,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateLRM",
       "WpnRecoil: 1",
       "VariableDmg: 2",
       "WeaponJAMFlat: 20%",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_5_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_LRM_5_Pirate.json
@@ -6,6 +6,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateLRM",
       "WpnCrits: x2",
       "VariableDmg: 2",
       "OHDamage: 50%",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_MML_20_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_MML_20_Pirate.json
@@ -9,11 +9,10 @@
       }
     ],
     "BonusDescriptions": [
-      "MML",
+      "MMLP",
       "VariableDmg: 2",
       "WeaponJAMFlat: 15%",
-      "IndirectMML",
-      "DoesCluster"
+      "IndirectMML"
     ],
     "Flags": [
       "not_broken",
@@ -93,6 +92,7 @@
       "Name": "LRM-Mode",
       "Description": "MML Fires LRM(Long Range Missiles)",
       "isBaseMode": true,
+      "HitGenerator": "Individual",
       "FlatJammingChance": 0.15,
       "AmmoCategory": "LRM",
       "AIHitChanceCap": 0.99
@@ -103,6 +103,7 @@
       "Name": "SRM-Mode",
       "Description": "MML Fires SRM(Short Range Missiles)",
       "isBaseMode": false,
+      "HitGenerator": "Individual",
       "DamagePerShot": 5,
       "Instability": 1,
       "DamageVariance": 2,

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_MRM_40_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_MRM_40_Pirate.json
@@ -9,6 +9,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateMRM",
       "WpnAccuracy: -1",
       "VariableDmg: 2",
       "ModesCanMisfire",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_MRM_5_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_MRM_5_Pirate.json
@@ -9,6 +9,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateMRM",
       "VariableDmg: 6",
       "WpnAccuracy: -1",
       "AMSChance: -20%",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_SRM_4_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_SRM_4_Pirate.json
@@ -9,6 +9,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateSRM",
       "Indirect",
       "OHDamage: 20%",
       "WpnCrits: +50%",

--- a/Optionals/PirateTech/Base/Items/Weapons/Weapon_SRM_6_Pirate.json
+++ b/Optionals/PirateTech/Base/Items/Weapons/Weapon_SRM_6_Pirate.json
@@ -9,6 +9,7 @@
       }
     ],
     "BonusDescriptions": [
+      "PirateSRM",
       "VariableDmg: 5",
       "WpnRecoil: 1",
       "WeaponJAMFlat: 15%",

--- a/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS1.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS1.json
@@ -80,7 +80,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS2.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS2.json
@@ -104,7 +104,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS3.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS3.json
@@ -94,7 +94,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS4.json
+++ b/Optionals/Quicsell/Chassis/chassisdef_highlander_HGN-QS4.json
@@ -94,7 +94,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/RogueElites/Base/chassis/chassisdef_highlander_HGN-732b_willie.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_highlander_HGN-732b_willie.json
@@ -59,7 +59,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/RogueElites/Base/chassis/chassisdef_highlander_HGN-EXb.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_highlander_HGN-EXb.json
@@ -50,7 +50,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 95.0,
   "InitialTonnage": 9.5,

--- a/Optionals/RogueElites/Experimental Weapons/chassis/chassisdef_highlander_HGN-732-BW.json
+++ b/Optionals/RogueElites/Experimental Weapons/chassis/chassisdef_highlander_HGN-732-BW.json
@@ -56,7 +56,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/RogueTribes/Base/chassis/chassisdef_highlander_HGN-751.json
+++ b/Optionals/RogueTribes/Base/chassis/chassisdef_highlander_HGN-751.json
@@ -46,7 +46,7 @@
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,

--- a/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-1142.json
+++ b/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-1142.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,

--- a/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-1145.json
+++ b/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-1145.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,

--- a/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-1320.json
+++ b/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-1320.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,

--- a/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-928.json
+++ b/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-928.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,

--- a/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-965.json
+++ b/Optionals/Superheavys/Base/chassis/chassisdef_manx_MNX-965.json
@@ -55,7 +55,7 @@
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
   "HardpointDataDefID": "hardpointdatadef_highlander",
-  "PrefabIdentifier": "chrPrfMech_highlanderBase-001",
+  "PrefabIdentifier": "chrPrfMech_highlander_SLDFBase-001",
   "PrefabBase": "highlander",
   "Tonnage": 170.0,
   "InitialTonnage": 34.0,


### PR DESCRIPTION
…Add bonus description for pirate missile launchers specifying that they roll to hit individually; 
Add Individual hit generator to pirate MMLs and remove bonus description from Pirate MML-20 saying it groups

Corvis and Omni-Corvis now using the Mushu model from the CAB

Hellion now using the Griffin model