### PR TITLE
Swap proxy model for Firestorm; add ER ammo tag restriction to N-LRMs

### DIFF
--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_10_Enhanced.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_10_Enhanced.json
@@ -240,6 +240,9 @@
       }
     }
   ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_ER"
+  ],
   "ComponentTags": {
     "items": [
       "ExRLM",

--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_15_Enhanced.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_15_Enhanced.json
@@ -212,6 +212,9 @@
       "AIHitChanceCap": 0.99
     }
   ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_ER"
+  ],
   "ComponentTags": {
     "items": [
       "ExRLM",

--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_20_Enhanced.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_20_Enhanced.json
@@ -242,6 +242,9 @@
       }
     }
   ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_ER"
+  ],
   "ComponentTags": {
     "items": [
       "ExRLM",

--- a/Core/RogueModuleTech/Weapons/Weapon_LRM_5_Enhanced.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_LRM_5_Enhanced.json
@@ -240,6 +240,9 @@
       }
     }
   ],
+  "RestrictedAmmo": [
+    "Ammunition_LRM_ER"
+  ],
   "ComponentTags": {
     "items": [
       "ExRLM",

--- a/Core/ShellShuffler/mod.json
+++ b/Core/ShellShuffler/mod.json
@@ -102,6 +102,9 @@
         "Ammunition_LRM_Thunder_Quicsell",
         "Ammunition_LRM_Quicsell"
       ],
+      "unit_noshuffle_lrm_enhanced": [
+        "Ammunition_LRM_ER"
+      ],
       "unit_noshuffle_artillery_cannon": [
         "Ammunition_Thumper_Fascam",
         "Ammunition_Thumper_Inferno",

--- a/Eras/ClanInvasion3061/Base/KillTeams/mech/mechdef_marauder_ii_MAD-WLF.json
+++ b/Eras/ClanInvasion3061/Base/KillTeams/mech/mechdef_marauder_ii_MAD-WLF.json
@@ -11,6 +11,7 @@
       "unit_release",
       "unit_chassis_marauderii",
       "unit_tonnage_100",
+      "unit_noshuffle_lrm_enhanced",
       "unit_nightmare",
       "unit_rogueteched",
       "unit_youchosethis",

--- a/Eras/ClanInvasion3061/Base/KillTeams/mech/mechdef_viking_VKG-BMN.json
+++ b/Eras/ClanInvasion3061/Base/KillTeams/mech/mechdef_viking_VKG-BMN.json
@@ -11,6 +11,7 @@
       "unit_release",
       "unit_chassis_viking",
       "unit_tonnage_90",
+      "unit_noshuffle_lrm_enhanced",
       "unit_nightmare",
       "unit_rogueteched",
       "unit_youchosethis",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-A.json
@@ -82,7 +82,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },
@@ -90,9 +91,9 @@
   "YangsThoughts": "The Naga II is a further continuation from Clan Wolf's first OmniMech, the Woodsman. What originally was a technical failure during the first batches of production of the Woodsman got converted into the Naga, later refined into the Naga II, but still suffering from bad reputation as a partial failure. The Naga II keeps much of of the core design the same as the original Naga; an Endo Steel internal structure, 9 tons of standard armor and a 400 XL engine.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_naga",
-  "PrefabIdentifier": "chrprfmech_nagabase-001",
-  "PrefabBase": "naga",
+  "HardpointDataDefID": "hardpointdatadef_woodsman",
+  "PrefabIdentifier": "chrprfmech_woodsmanbase-001",
+  "PrefabBase": "woodsman",
   "Tonnage": 80.0,
   "InitialTonnage": 8.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-B.json
@@ -82,7 +82,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },
@@ -90,9 +91,9 @@
   "YangsThoughts": "The Naga II is a further continuation from Clan Wolf's first OmniMech, the Woodsman. What originally was a technical failure during the first batches of production of the Woodsman got converted into the Naga, later refined into the Naga II, but still suffering from bad reputation as a partial failure. The Naga II keeps much of of the core design the same as the original Naga; an Endo Steel internal structure, 9 tons of standard armor and a 400 XL engine.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_naga",
-  "PrefabIdentifier": "chrprfmech_nagabase-001",
-  "PrefabBase": "naga",
+  "HardpointDataDefID": "hardpointdatadef_woodsman",
+  "PrefabIdentifier": "chrprfmech_woodsmanbase-001",
+  "PrefabBase": "woodsman",
   "Tonnage": 80.0,
   "InitialTonnage": 8.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-C.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-C.json
@@ -82,7 +82,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },
@@ -90,9 +91,9 @@
   "YangsThoughts": "The Naga II is a further continuation from Clan Wolf's first OmniMech, the Woodsman. What originally was a technical failure during the first batches of production of the Woodsman got converted into the Naga, later refined into the Naga II, but still suffering from bad reputation as a partial failure. The Naga II keeps much of of the core design the same as the original Naga; an Endo Steel internal structure, 9 tons of standard armor and a 400 XL engine.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_naga",
-  "PrefabIdentifier": "chrprfmech_nagabase-001",
-  "PrefabBase": "naga",
+  "HardpointDataDefID": "hardpointdatadef_woodsman",
+  "PrefabIdentifier": "chrprfmech_woodsmanbase-001",
+  "PrefabBase": "woodsman",
   "Tonnage": 80.0,
   "InitialTonnage": 8.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-H.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-H.json
@@ -82,7 +82,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },
@@ -90,9 +91,9 @@
   "YangsThoughts": "The Naga II is a further continuation from Clan Wolf's first OmniMech, the Woodsman. What originally was a technical failure during the first batches of production of the Woodsman got converted into the Naga, later refined into the Naga II, but still suffering from bad reputation as a partial failure. The Naga II keeps much of of the core design the same as the original Naga; an Endo Steel internal structure, 9 tons of standard armor and a 400 XL engine.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_naga",
-  "PrefabIdentifier": "chrprfmech_nagabase-001",
-  "PrefabBase": "naga",
+  "HardpointDataDefID": "hardpointdatadef_woodsman",
+  "PrefabIdentifier": "chrprfmech_woodsmanbase-001",
+  "PrefabBase": "woodsman",
   "Tonnage": 80.0,
   "InitialTonnage": 8.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-Prime.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_naga_ii_NGA2-Prime.json
@@ -82,7 +82,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },
@@ -90,9 +91,9 @@
   "YangsThoughts": "The Naga II is a further continuation from Clan Wolf's first OmniMech, the Woodsman. What originally was a technical failure during the first batches of production of the Woodsman got converted into the Naga, later refined into the Naga II, but still suffering from bad reputation as a partial failure. The Naga II keeps much of of the core design the same as the original Naga; an Endo Steel internal structure, 9 tons of standard armor and a 400 XL engine.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_naga",
-  "PrefabIdentifier": "chrprfmech_nagabase-001",
-  "PrefabBase": "naga",
+  "HardpointDataDefID": "hardpointdatadef_woodsman",
+  "PrefabIdentifier": "chrprfmech_woodsmanbase-001",
+  "PrefabBase": "woodsman",
   "Tonnage": 80.0,
   "InitialTonnage": 8.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_WMN-A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_WMN-A.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.97"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_WMN-B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_WMN-B.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.97"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_WMN-Prime.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_WMN-Prime.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.97"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_ii_WMN2-A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_ii_WMN2-A.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_ii_WMN2-B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_ii_WMN2-B.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_ii_WMN2-Prime.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_woodsman_ii_WMN2-Prime.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.03"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Uniques HeavyMetal/KillTeams/mech/mechdef_archer_ARC-JNT.json
+++ b/Eras/ClanInvasion3061/Uniques HeavyMetal/KillTeams/mech/mechdef_archer_ARC-JNT.json
@@ -12,6 +12,7 @@
       "unit_release",
       "unit_chassis_archer",
       "unit_tonnage_70",
+      "unit_noshuffle_lrm_enhanced",
       "unit_nightmare",
       "unit_rogueteched",
       "unit_youchosethis",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_firestorm_FSM-1.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_firestorm_FSM-1.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperRight",
-      "ClanMech"
+      "ClanMech",
+      "mr-resize-1.0-0.94-0.95"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Firestorm was created by a combined group of Spina Khanate and Wolf Empire warriors and technicians. Based on a new OmniMech derived from the Shadow Cat, this long term project wasn't ready for production; however, a BattleMech could be developed from a planned configuration, thus laying the groundwork for the Firestorm. With this in mind, the Clan Wolf warriors favored a weapons suite focused on incendiary operations. This allowed the Wolf touman to rapidly expand its second line and garrison forces without incurring the cost of expensive OmniMechs.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_incubus",
-  "PrefabIdentifier": "chrprfmech_incubusbase-001",
-  "PrefabBase": "incubus",
+  "HardpointDataDefID": "hardpointdatadef_shadowcat",
+  "PrefabIdentifier": "chrPrfMech_shadowcatbase-001",
+  "PrefabBase": "shadowcat",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-A.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-A.json
@@ -64,7 +64,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.10-1.13-1.10"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-B.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-B.json
@@ -64,7 +64,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.10-1.13-1.10"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-C.json
@@ -64,7 +64,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.10-1.13-1.10"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-D.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-D.json
@@ -64,7 +64,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.10-1.13-1.10"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-Prime.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_regent_RGT-Prime.json
@@ -64,7 +64,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.10-1.13-1.10"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_uraeus_UAE-7R.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_uraeus_UAE-7R.json
@@ -63,7 +63,8 @@
   "VariantName": "UAE-7R",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.84-0.91-0.86"
     ],
     "tagSetSourceFile": ""
   },
@@ -71,9 +72,9 @@
   "YangsThoughts": "Named for the symbol of the Egyptian goddess Wadjet, the Uraeus is a heavy BattleMech which first appeared during the Dark Age era in the hands of ComStar and the Republic of the Sphere. With the Malcolm Buhl-led splinter faction the Blessed Order seeking to secretly rebuild the Com Guards, in 3128 agents of the Blessed Order stole advanced Word of Blake technical data, including extensive specs on the Manei Domini's Celestial series OmniMechs, stored within a protected Republic of the Sphere data depot on Terra. Reengineering the secured schematics to develop the Uraeus BattleMech, Buhl commissioned the New Earth Trading Company - little more than a corporate front owned and operated by ComStar since the early Succession Wars - to secretly construct production lines for these new 'Mechs, hiding them among the massive volume of civilian manufacturing lines operated by NETC.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_talon",
-  "PrefabIdentifier": "chrprfmech_talonbase-001",
-  "PrefabBase": "talon",
+  "HardpointDataDefID": "hardpointdatadef_iondeva",
+  "PrefabIdentifier": "chrprfmech_iondevabase-001",
+  "PrefabBase": "iondeva",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,
   "weightClass": "HEAVY",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_woodsman_WMN-C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_woodsman_WMN-C.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.97"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_woodsman_WMN-D.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_woodsman_WMN-D.json
@@ -67,7 +67,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-0.97"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base Urban Warfare/vehicle/vehicledef_GALLANT_3080.json
+++ b/Eras/Jihad3068-3080/Base Urban Warfare/vehicle/vehicledef_GALLANT_3080.json
@@ -9,6 +9,7 @@
       "unit_lance_tank",
       "unit_wheels",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_2",
       "auriganpirates",
       "circinus",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OA_dominus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OA_dominus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OB_infernus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OB_infernus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OC_comminus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OC_comminus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OD_luminos.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OD_luminos.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OE_eminus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OE_eminus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OS_caelestis.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-OS_caelestis.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-O_invictus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_deva_C-DVA-O_invictus.json
@@ -115,7 +115,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OA_dominus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OA_dominus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OB_infernus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OB_infernus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OC_comminus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OC_comminus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OD_luminos.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OD_luminos.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OE_eminus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OE_eminus.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OS_caelestis.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-OS_caelestis.json
@@ -88,7 +88,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-O_invictus.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_grigori_C-GRG-O_invictus.json
@@ -115,7 +115,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-C22.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_catapult_CPLT-C22.json
@@ -14,6 +14,7 @@
       "unit_rt_custom",
       "unit_chassis_catapult",
       "unit_tonnage_65",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_2",
       "ArcRoyalLibertyCoalition",
       "comstar",

--- a/Eras/Jihad3068-3080/Base/mech/mechdef_sunder_SD1-OX.json
+++ b/Eras/Jihad3068-3080/Base/mech/mechdef_sunder_SD1-OX.json
@@ -16,6 +16,7 @@
       "unit_release",
       "unit_chassis_sunder",
       "unit_tonnage_90",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "ClanSeaFox3150",
       "Davion3150",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_CARRIER_HEAVY_NLRM.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_CARRIER_HEAVY_NLRM.json
@@ -10,6 +10,7 @@
       "unit_tracks",
       "unit_indirectFire",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "mr-resize-1.73",
       "davion",

--- a/Eras/Jihad3068-3080/Base/vehicle/vehicledef_CARRIER_LRM_ENHANCED.json
+++ b/Eras/Jihad3068-3080/Base/vehicle/vehicledef_CARRIER_LRM_ENHANCED.json
@@ -12,6 +12,7 @@
       "unit_totem",
       "unit_release",
       "unit_rt_custom",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "mr-resize-1.50",
       "davion",

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_deva_C-DVA-O_achilleus.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_deva_C-DVA-O_achilleus.json
@@ -92,7 +92,7 @@
       "ArmLimitUpperRight",
       "UniqueMech",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_grigori_C-GRG-O_rufus.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_grigori_C-GRG-O_rufus.json
@@ -92,7 +92,7 @@
       "ArmLimitUpperRight",
       "UniqueMech",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_grigori_C-GRG-O_tamiel.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_grigori_C-GRG-O_tamiel.json
@@ -92,7 +92,7 @@
       "ArmLimitUpperRight",
       "UniqueMech",
       "OmniMech",
-      "mr-resize-0.95"
+      "mr-resize-0.88"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_anubis_ABS-3MC.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_anubis_ABS-3MC.json
@@ -16,6 +16,7 @@
       "unit_release",
       "unit_chassis_anubis",
       "unit_tonnage_30",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_chassis_uncommon",
       "unit_rarity_equipment_level_2",
       "liao",

--- a/Eras/Jihad3068-3080/Uniques/mech/mechdef_temax_cat_ninjabolt_TMC-NB.json
+++ b/Eras/Jihad3068-3080/Uniques/mech/mechdef_temax_cat_ninjabolt_TMC-NB.json
@@ -20,6 +20,7 @@
       "unit_release",
       "unit_chassis_temax",
       "unit_tonnage_65",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_chassis_unique",
       "unit_rarity_equipment_level_1",
       "unit_unique_has_no_replacement",

--- a/Eras/Republic3081-3130/Base Flashpoint/mech/mechdef_axman_AXM-6T-N.json
+++ b/Eras/Republic3081-3130/Base Flashpoint/mech/mechdef_axman_AXM-6T-N.json
@@ -18,6 +18,7 @@
       "unit_release",
       "unit_chassis_axman",
       "unit_tonnage_65",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "steiner",
       "Steiner3150",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_griffin_GRF-3N.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_griffin_GRF-3N.json
@@ -16,6 +16,7 @@
       "unit_release",
       "unit_chassis_griffin",
       "unit_tonnage_55",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "CalderonProtectorate3150",
       "ClanProtectorate",

--- a/Eras/Republic3081-3130/Base/mech/mechdef_shadowhawk_SHD-7H.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_shadowhawk_SHD-7H.json
@@ -15,6 +15,7 @@
       "unit_release",
       "unit_chassis_shadowhawk",
       "unit_tonnage_55",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "auriganpirates",
       "calderonprotectorate",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_MANTICORE_2.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_MANTICORE_2.json
@@ -10,6 +10,7 @@
       "unit_indirectFire",
       "unit_solaris",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_2",
       "mr-resize-1.62",
       "GalateanLeague",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_MANTICORE_XL.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_MANTICORE_XL.json
@@ -9,6 +9,7 @@
       "unit_tracks",
       "unit_indirectFire",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "mr-resize-1.50",
       "AlyinaMercantileLeague",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_ONTOS_HEAT.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_ONTOS_HEAT.json
@@ -10,6 +10,7 @@
       "unit_tracks",
       "unit_vehicle_apc",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "skip_heatcheck",
       "mr-resize-1.63",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_PIXIU_2.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_PIXIU_2.json
@@ -10,6 +10,7 @@
       "unit_tracks",
       "unit_stealth",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "liao",
       "Liao3150",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_STURMFEUR_NLRM.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_STURMFEUR_NLRM.json
@@ -10,6 +10,7 @@
       "unit_tracks",
       "unit_indirectFire",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "mr-resize-1.2",
       "ArcRoyalLibertyCoalition",

--- a/Eras/Republic3081-3130/Base/vehicle/vehicledef_Warrior_S9B.json
+++ b/Eras/Republic3081-3130/Base/vehicle/vehicledef_Warrior_S9B.json
@@ -11,6 +11,7 @@
       "unit_stealth",
       "unit_noconvoy",
       "unit_release",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rt_custom",
       "unit_rarity_chassis_uncommon",
       "unit_rarity_equipment_level_2",

--- a/Optionals/ExperimentalWeapons/RISC/mech/mechdef_stalker_iv_STK-RM.json
+++ b/Optionals/ExperimentalWeapons/RISC/mech/mechdef_stalker_iv_STK-RM.json
@@ -14,6 +14,7 @@
       "unit_chassis_stalkeriv",
       "unit_tonnage_170",
       "unit_superheavy_hunt_target",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_chassis_uncommon",
       "unit_rarity_dangerous",
       "unit_rarity_equipment_level_3",

--- a/Optionals/ExperimentalWeapons/Superheavys/mech/mechdef_emperor_crab_ERC-001.json
+++ b/Optionals/ExperimentalWeapons/Superheavys/mech/mechdef_emperor_crab_ERC-001.json
@@ -11,6 +11,7 @@
       "unit_tonnage_150",
       "unit_superheavy_support",
       "unit_superheavy_tier2",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_2",
       "comstar",
       "kurita",

--- a/Optionals/RogueOmnis/Base/mech/mechdef_proteus_PT-OC.json
+++ b/Optionals/RogueOmnis/Base/mech/mechdef_proteus_PT-OC.json
@@ -15,6 +15,7 @@
       "unit_release",
       "unit_chassis_omnikgc",
       "unit_tonnage_100",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_chassis_uncommon",
       "unit_rarity_equipment_level_5",
       "unit_rarity_support",

--- a/Optionals/Superheavys/Base/mech/mechdef_narayana_NRY-OC.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_narayana_NRY-OC.json
@@ -14,6 +14,7 @@
       "unit_chassis_narayana",
       "unit_tonnage_140",
       "unit_superheavy_tier2",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_chassis_uncommon",
       "unit_rarity_equipment_level_2",
       "ClanProtectorate",

--- a/Optionals/Superheavys/Base/mech/mechdef_ophanim_C-OPM-OA.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_ophanim_C-OPM-OA.json
@@ -15,6 +15,7 @@
       "unit_chassis_ophanim",
       "unit_tonnage_150",
       "unit_superheavy_tier4",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_4",
       "ShadowDivisions",
       "wordofblake",

--- a/Optionals/Superheavys/Base/mech/mechdef_ostend_OSE-3C.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_ostend_OSE-3C.json
@@ -13,6 +13,7 @@
       "unit_tonnage_135",
       "unit_superheavy_support",
       "unit_superheavy_tier2",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "ClanProtectorate",
       "davion",

--- a/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-B.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-B.json
@@ -14,6 +14,7 @@
       "unit_chassis_stonegiant",
       "unit_tonnage_180",
       "unit_superheavy_tier2",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "davion",
       "Davion3150",

--- a/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-B2.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-B2.json
@@ -14,6 +14,7 @@
       "unit_chassis_stonegiant",
       "unit_tonnage_180",
       "unit_superheavy_tier2",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "davion",
       "Davion3150",

--- a/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-D-TC.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-D-TC.json
@@ -14,6 +14,7 @@
       "unit_chassis_stonegiant",
       "unit_tonnage_180",
       "unit_superheavy_tier3",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_1",
       "ArcRoyalLibertyCoalition",
       "davion",

--- a/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-D.json
+++ b/Optionals/Superheavys/Base/mech/mechdef_stone_giant_SG11-D.json
@@ -14,6 +14,7 @@
       "unit_chassis_stonegiant",
       "unit_tonnage_180",
       "unit_superheavy_tier3",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "ArcRoyalLibertyCoalition",
       "davion",

--- a/Optionals/Superheavys/Flashpoint/mech/mechdef_polyphemus_PPH-OC.json
+++ b/Optionals/Superheavys/Flashpoint/mech/mechdef_polyphemus_PPH-OC.json
@@ -17,6 +17,7 @@
       "unit_tonnage_180",
       "unit_superheavy_support",
       "unit_superheavy_tier5",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_command",
       "unit_rarity_equipment_level_3",
       "blackcalderadefense",

--- a/Optionals/Superheavys/Urbocalypse/mech/mechdef_urbiestator_UMS-R2001.json
+++ b/Optionals/Superheavys/Urbocalypse/mech/mechdef_urbiestator_UMS-R2001.json
@@ -10,6 +10,7 @@
       "unit_chassis_urbiestator",
       "unit_tonnage_200",
       "unit_superheavy_tier3",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "NoFaction",
       "aurigandirectorate",

--- a/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanmech_UM-R60LRM-EN.json
+++ b/Optionals/Urbocalypse/DarkAge/mech/mechdef_urbanmech_UM-R60LRM-EN.json
@@ -15,6 +15,7 @@
       "unit_release",
       "unit_chassis_urbanmech",
       "unit_tonnage_30",
+      "unit_noshuffle_lrm_enhanced",
       "unit_rarity_equipment_level_0",
       "auriganmercenaries",
       "auriganpirates",


### PR DESCRIPTION
Firestorm now using Shadow Cat model

Enhanced LRMs have had a tag restriction on installing ER ammo for years, but vehicle bay doesn't check for restricted tags, so I've added an ammo restriction onto the missile launchers so that vehicles won't be able to use ER ammo with them anymore