### PR TITLE
Airfield depends fix thanks to Transient74

### DIFF
--- a/Core/CustomMaps/mapGeneral_10_bluffs_vHigh/mod.json
+++ b/Core/CustomMaps/mapGeneral_10_bluffs_vHigh/mod.json
@@ -73,6 +73,7 @@
 {"Type": "Prefab", "Path": "Assets/Custom Assets/HBS Assets/envPrfSets_largeMilitaryOfficeBldgA_groupingA (1) 1.prefab", "AssetBundleName": "t74asset_largeofficea"},
 {"Type": "Prefab", "Path": "Assets/Custom Assets/HBS Assets/envPrfSets_largeMilitaryOfficeBldgA_groupingA (1).prefab", "AssetBundleName": "t74asset_largeofficea"},
 {"Type": "Prefab", "Path": "Assets/Custom Assets/HBS Assets/envPrfComp_largeRadar.prefab", "AssetBundleName": "t74asset_largeradara"},
+{"Type": "Prefab", "Path": "Assets/Custom Assets/Building Prefabs/envNstComp_smallMilitaryBarracksA.prefab", "AssetBundleName": "t74asset_milbarracks"},
 {"Type": "Prefab", "Path": "Assets/Custom Assets/HBS Assets/envPrfSets_mediumMilitaryBldgCGroupingA (1).prefab", "AssetBundleName": "t74asset_militaryc"},
 {"Type": "Prefab", "Path": "Assets/Custom Assets/HBS Assets/envPrfComp_miningShipping.prefab", "AssetBundleName": "t74asset_minishippinga"},
 {"Type": "Prefab", "Path": "Assets/Custom Assets/Building Prefabs/envPrfSets_industrialPump_groupingA (2).prefab", "AssetBundleName": "t74asset_pumpsetup"},


### PR DESCRIPTION
Map & Asset credit: **Transient74**
- Found prefab load failure for Airfield at `envNstComp_smallMilitaryBarracksA`
- Worked on Transient's setup due to existing map
- Add missing deps to manifest and relevant asset bundle
