### PR TITLE
Change proxy models; resize mechs; add extra text for LRM sensor mine…

### DIFF
--- a/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_DualSaw.json
+++ b/Core/RogueModuleTech/HandHeld/HandHeldMelee/HandHeld_Weapon_Industrial_DualSaw.json
@@ -39,7 +39,7 @@
       }
     },
     "IBLS": {
-      "StorageSize": 1
+      "StorageSize": 2
     },
     "CarryHandUsage": 3.5
   },
@@ -95,7 +95,7 @@
   "ComponentSubType": "Weapon",
   "PrefabIdentifier": "chainsaw",
   "BattleValue": 7,
-  "InventorySize": 1,
+  "InventorySize": 2,
   "Tonnage": 0,
   "AllowedLocations": "Arms",
   "DisallowedLocations": "All",

--- a/Core/RogueMunitions/LRM/Ammo_AmmunitionBox_LRM_Incendiary.json
+++ b/Core/RogueMunitions/LRM/Ammo_AmmunitionBox_LRM_Incendiary.json
@@ -7,7 +7,7 @@
     ],
     "BonusDescriptions": [
       "HeatDamage: +1",
-      "AmmoDamage: -25%",
+      "AmmoDamage: -20%",
       "MissileHP: 2",
       "AmmoCount: LRM, 120",
       "VolatileAmmo",

--- a/Core/RogueMunitions/LRM/Ammo_AmmunitionBox_LRM_Incendiary_Half.json
+++ b/Core/RogueMunitions/LRM/Ammo_AmmunitionBox_LRM_Incendiary_Half.json
@@ -7,7 +7,7 @@
     ],
     "BonusDescriptions": [
       "HeatDamage: +1",
-      "AmmoDamage: -33%",
+      "AmmoDamage: -20%",
       "MissileHP: 2",
       "AmmoCount: LRM, 60",
       "VolatileAmmo",

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -298,7 +298,7 @@
       "Bonus": "RemoteSensorLRM",
       "Short": "Remote Sensor Munition",
       "Long": "Remote Sensor Munition",
-      "Full": "Remote Sensor munitions leave a field of Sensors wherever a missile hits the ground; triggered like mines."
+      "Full": "Remote Sensor munitions leave a field of Sensors wherever a missile hits the ground; triggered like mines, increasing target's sensor signature and visibility. Effect stacks."
     },
     {
       "Bonus": "SensorMines",

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_koto_KT-3A.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_koto_KT-3A.json
@@ -36,7 +36,7 @@
   "VariantName": "KT-3A",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-1.07"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_snake_SNK-2B.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_snake_SNK-2B.json
@@ -36,7 +36,8 @@
   "VariantName": "SNK-2B",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.80-0.84-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +45,9 @@
   "YangsThoughts": "The 2B variant of the Snake is a modification of the 'Mech that uses Stealth Armor to make the 'Mech harder to target. In order to do this one of the Streak SRM-2 launchers has been removed from the 'Mech and an ECM Suite has been added to the 'Mech.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_spector",
+  "PrefabIdentifier": "chrprfmech_spectorbase-001",
+  "PrefabBase": "spector",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_blackjack_BJ-G.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_blackjack_BJ-G.json
@@ -47,7 +47,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "PrototypeMech",
-      "mr-resize-0.9"
+      "mr-resize-1.04-0.98-1.18"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3C.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3C.json
@@ -37,7 +37,7 @@
   "VariantName": "HMR-3C",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.65-0.5-0.5"
+      "mr-resize-0.51-0.54-0.47"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3M.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3M.json
@@ -37,7 +37,7 @@
   "VariantName": "HMR-3M",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.65-0.5-0.5"
+      "mr-resize-0.51-0.54-0.47"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3P.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3P.json
@@ -37,7 +37,7 @@
   "VariantName": "HMR-3P",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.65-0.5-0.5"
+      "mr-resize-0.51-0.54-0.47"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3S.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_hammer_HMR-3S.json
@@ -37,7 +37,7 @@
   "VariantName": "HMR-3S",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.65-0.5-0.5"
+      "mr-resize-0.51-0.54-0.47"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_koto_KT-2A.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_koto_KT-2A.json
@@ -36,7 +36,7 @@
   "VariantName": "KT-2A",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-1.07"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_koto_KT-P2.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_koto_KT-P2.json
@@ -36,7 +36,7 @@
   "VariantName": "KT-P2",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-1.07"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-0.75"
+      "mr-resize-0.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31B.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31B.json
@@ -36,7 +36,7 @@
   "VariantName": "JR7-31B",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31P.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31P.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-0.75"
+      "mr-resize-0.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31PX.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31PX.json
@@ -36,7 +36,7 @@
   "VariantName": "JR7-31PX",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31U.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_rattlesnake_JR7-31U.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-0.75"
+      "mr-resize-0.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_snake_SNK-1V.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_snake_SNK-1V.json
@@ -36,7 +36,8 @@
   "VariantName": "SNK-1V",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.80-0.84-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +45,9 @@
   "YangsThoughts": "The Snake's primary weapon is a Mydron Excel LB-X Autocannon/10 which can fire both standard rounds as well as firing cluster rounds which act like 'Mech sized shotgun shells. The 'Mech is also armed with three Hovertec Streak SRM-2s which are highly effective in finding weak spots in an enemy's armor or against Inner Sphere battle armor.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_spector",
+  "PrefabIdentifier": "chrprfmech_spectorbase-001",
+  "PrefabBase": "spector",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_wolf_trap_WFT-1.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_wolf_trap_WFT-1.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperRight",
-      "mr-resize-1.4-1.56-1.56"
+      "mr-resize-1.23-1.37-1.3"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_wolf_trap_WFT-C.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_wolf_trap_WFT-C.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperRight",
-      "mr-resize-1.4-1.56-1.56"
+      "mr-resize-1.23-1.37-1.3"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_snake_SNK-1V_alexi.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_snake_SNK-1V_alexi.json
@@ -40,7 +40,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",
-      "UniqueMech"
+      "UniqueMech",
+      "mr-resize-0.80-0.84-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -48,9 +49,9 @@
   "YangsThoughts": "A customized variant produced for House Marik MechWarrior Alexi Danisov. During Operation Guerrero, his Liao-built Snake was always running out of ammunition. With ammunition scarce, Alexi had his BattleMech's LB-X 10 Class Autocannon replaced with a pair of Large Lasers. The 'Mech performed well, and Alexi retained these weapons and upgraded the lasers to Extended Range Models.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_spector",
+  "PrefabIdentifier": "chrprfmech_spectorbase-001",
+  "PrefabBase": "spector",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_wolf_trap_WFT-1_daitama.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_wolf_trap_WFT-1_daitama.json
@@ -41,7 +41,7 @@
     "items": [
       "ArmLimitUpperRight",
       "UniqueMech",
-      "mr-resize-1.4-1.56-1.56"
+      "mr-resize-1.23-1.37-1.3"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_orochi_OR-3K.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_orochi_OR-3K.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperLeft",
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.42-1.26-1.46"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "Developed during the Draconis Combine's push into the Federated Suns during the 3140s. This variant swaps the Thunderbolt launchers for Silver Bullet Gauss Rifles and are excellent anti-aerospace platforms.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_stalker",
-  "PrefabIdentifier": "chrPrfMech_stalkerBase-001",
-  "PrefabBase": "stalker",
+  "HardpointDataDefID": "hardpointdatadef_cyclone",
+  "PrefabIdentifier": "chrprfmech_cyclonebase-001",
+  "PrefabBase": "cyclone",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_ii_RSN-1.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_ii_RSN-1.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-0.9"
+      "mr-resize-0.76"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_ii_RSN-2.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_rattlesnake_ii_RSN-2.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-0.9"
+      "mr-resize-0.76"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_koto_KT-4A.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_koto_KT-4A.json
@@ -36,7 +36,7 @@
   "VariantName": "KT-4A",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-1.07"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_mangonel_MNL-3L.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_mangonel_MNL-3L.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-0.8"
+      "mr-resize-1.01-0.84-0.84"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "Introduced in 3078, the controversial and quirky Mangonel was a Clan Wolf-in-Exile heavy cavalry BattleMech built using Inner Sphere rather than Clan technology. Facing increasing shortages of Clan-grade matériel during the Jihad, Khan Phelan Kell sponsored several programs to develop Inner Sphere equipment to pad out his forces, the Mangonel being one of the most visible outcomes of these initiatives.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_hauptmann",
-  "PrefabIdentifier": "chrPrfMech_hauptmannbase-001",
-  "PrefabBase": "hauptmann",
+  "HardpointDataDefID": "hardpointdatadef_thanatos",
+  "PrefabIdentifier": "chrprfmech_thanatosbase-001",
+  "PrefabBase": "thanatos",
   "Tonnage": 70.0,
   "InitialTonnage": 7.0,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_orochi_OR-2I.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_orochi_OR-2I.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperLeft",
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.42-1.26-1.46"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Orochi is a Post-Jihad Assault BattleMech built by Victory Industries on Marduk. This Mech was intended to be an upgrade of the ancient Longbow fire-support design, utilizing Advance Tech Missile launchers in place of the Longbow's traditional LRM launchers.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_stalker",
-  "PrefabIdentifier": "chrPrfMech_stalkerBase-001",
-  "PrefabBase": "stalker",
+  "HardpointDataDefID": "hardpointdatadef_cyclone",
+  "PrefabIdentifier": "chrprfmech_cyclonebase-001",
+  "PrefabBase": "cyclone",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_snake_SNK-2Br.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_snake_SNK-2Br.json
@@ -36,7 +36,8 @@
   "VariantName": "SNK-2Br",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.80-0.84-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +45,9 @@
   "YangsThoughts": "This refit of the 2B variant replaces the standard autocannon with a pair of Plasma Rifles. Though amazingly effective against battle armor, the Plasma Rifles can quickly run out of ammunition. Like many other newly manufactured machines the variant contains Stealth armor for better protection.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_spector",
+  "PrefabIdentifier": "chrprfmech_spectorbase-001",
+  "PrefabBase": "spector",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_valiant_V4-LNT-J3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_valiant_V4-LNT-J3.json
@@ -85,7 +85,9 @@
   },
   "VariantName": "V4-LNT-J3",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.70"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Light Skirmisher",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_valiant_V4-LNT-K7.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_valiant_V4-LNT-K7.json
@@ -62,7 +62,9 @@
   },
   "VariantName": "V4-LNT-K7",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.70"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Light Skirmisher",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_valiant_VLN-3T.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_valiant_VLN-3T.json
@@ -85,7 +85,9 @@
   },
   "VariantName": "VLN-3T",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.70"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Light Skirmisher",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wolf_trap_WFT-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wolf_trap_WFT-2.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperRight",
-      "mr-resize-1.4-1.56-1.56"
+      "mr-resize-1.23-1.37-1.3"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wolf_trap_WFT-2B.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wolf_trap_WFT-2B.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperRight",
-      "mr-resize-1.4-1.56-1.56"
+      "mr-resize-1.23-1.37-1.3"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wolf_trap_WFT-B.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wolf_trap_WFT-B.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperRight",
-      "mr-resize-1.4-1.56-1.56"
+      "mr-resize-1.23-1.37-1.3"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_snake_SNK-1V_arthur.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_snake_SNK-1V_arthur.json
@@ -40,7 +40,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",
-      "UniqueMech"
+      "UniqueMech",
+      "mr-resize-0.80-0.84-0.96"
     ],
     "tagSetSourceFile": ""
   },
@@ -48,9 +49,9 @@
   "YangsThoughts": "Used by the commander of Youling Zhanshi, the Snake Arthur is equipped with Stealth Armor and Guardian ECM Suite, while an Anti-Missile System destroys incoming fire. The standard weapons have been replaced by an ER PPC and LRM-5. Thirteen double heat sinks keep the Mech cool, while a MASC system allows Arthur to put on bursts of speed. The lack of weapons might be an issue for some pilots, but this Snake variant is used as a command 'Mech, so it's not a problem for Arthur.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_spector",
+  "PrefabIdentifier": "chrprfmech_spectorbase-001",
+  "PrefabBase": "spector",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_valiant_VAL-NT-JX.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_valiant_VAL-NT-JX.json
@@ -96,7 +96,8 @@
   "VariantName": "VAL-NT-JX",
   "ChassisTags": {
     "items": [
-      "UniqueMech"
+      "UniqueMech",
+      "mr-resize-0.70"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_wolf_trap_WFT-2X.json
+++ b/Eras/Jihad3068-3080/Uniques/chassis/chassisdef_wolf_trap_WFT-2X.json
@@ -41,7 +41,7 @@
     "items": [
       "ArmLimitUpperRight",
       "UniqueMech",
-      "mr-resize-1.4-1.56-1.56"
+      "mr-resize-1.23-1.37-1.3"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_mangonel_MNL-3W.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_mangonel_MNL-3W.json
@@ -39,7 +39,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "mr-resize-0.8"
+      "mr-resize-1.01-0.84-0.84"
     ],
     "tagSetSourceFile": ""
   },
@@ -47,9 +47,9 @@
   "YangsThoughts": "Introduced in 3078, the controversial and quirky Mangonel was a Clan Wolf-in-Exile heavy cavalry BattleMech built using Inner Sphere rather than Clan technology. Facing increasing shortages of Clan-grade matériel during the Jihad, Khan Phelan Kell sponsored several programs to develop Inner Sphere equipment to pad out his forces, the Mangonel being one of the most visible outcomes of these initiatives.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_hauptmann",
-  "PrefabIdentifier": "chrPrfMech_hauptmannbase-001",
-  "PrefabBase": "hauptmann",
+  "HardpointDataDefID": "hardpointdatadef_thanatos",
+  "PrefabIdentifier": "chrprfmech_thanatosbase-001",
+  "PrefabBase": "thanatos",
   "Tonnage": 70.0,
   "InitialTonnage": 7.0,
   "weightClass": "HEAVY",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_mangonel_MNL-4S.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_mangonel_MNL-4S.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-0.8"
+      "mr-resize-1.01-0.84-0.84"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "Introduced in 3078, the controversial and quirky Mangonel was a Clan Wolf-in-Exile heavy cavalry BattleMech built using Inner Sphere rather than Clan technology. Facing increasing shortages of Clan-grade matériel during the Jihad, Khan Phelan Kell sponsored several programs to develop Inner Sphere equipment to pad out his forces, the Mangonel being one of the most visible outcomes of these initiatives.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_hauptmann",
-  "PrefabIdentifier": "chrPrfMech_hauptmannbase-001",
-  "PrefabBase": "hauptmann",
+  "HardpointDataDefID": "hardpointdatadef_thanatos",
+  "PrefabIdentifier": "chrprfmech_thanatosbase-001",
+  "PrefabBase": "thanatos",
   "Tonnage": 70.0,
   "InitialTonnage": 7.0,
   "weightClass": "HEAVY",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_valiant_VLT-3E.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_valiant_VLT-3E.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-0.70"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Republic3081-3130/Uniques/chassis/chassisdef_rattlesnake_JR7-31R.json
+++ b/Eras/Republic3081-3130/Uniques/chassis/chassisdef_rattlesnake_JR7-31R.json
@@ -42,7 +42,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "UniqueMech",
-      "mr-resize-0.75"
+      "mr-resize-0.66"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/PirateTech/Base/chassis/chassisdef_valiant_V4-VAL-NT-P.json
+++ b/Optionals/PirateTech/Base/chassis/chassisdef_valiant_V4-VAL-NT-P.json
@@ -86,7 +86,8 @@
   "VariantName": "V4-VAL-NT-P",
   "ChassisTags": {
     "items": [
-      "PrototypeMech"
+      "PrototypeMech",
+      "mr-resize-0.70"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Quicsell/Weapons/Weapon_SRM_2_Streak_Quicsell.json
+++ b/Optionals/Quicsell/Weapons/Weapon_SRM_2_Streak_Quicsell.json
@@ -9,7 +9,6 @@
       "IsSRM",
       "AmmoPerShot: 2",
       "StreakMKII",
-      "WeaponAttachmentCompatible: Artemis IV or V",
       "WeaponShardsModRange: 0.5, 2"
     ],
     "Flags": [
@@ -89,8 +88,6 @@
       "component_type_stock",
       "range_standard",
       "BAIncompatible",
-      "ArtemisIVUnlockable",
-      "ArtemisVUnlockable",
       "SRM.{location}",
       "LootMagnetBlacklist"
     ],

--- a/Optionals/Quicsell/Weapons/Weapon_SRM_4_Streak_Quicsell.json
+++ b/Optionals/Quicsell/Weapons/Weapon_SRM_4_Streak_Quicsell.json
@@ -9,7 +9,6 @@
       "IsSRM",
       "AmmoPerShot: 2",
       "StreakMKII",
-      "WeaponAttachmentCompatible: Artemis IV or V",
       "WeaponShardsModRange: 0.5, 2"
     ],
     "Flags": [
@@ -89,8 +88,6 @@
       "component_type_stock",
       "range_standard",
       "BAIncompatible",
-      "ArtemisIVUnlockable",
-      "ArtemisVUnlockable",
       "SRM.{location}",
       "LootMagnetBlacklist"
     ],

--- a/Optionals/Quicsell/Weapons/Weapon_SRM_6_Streak_Quicsell.json
+++ b/Optionals/Quicsell/Weapons/Weapon_SRM_6_Streak_Quicsell.json
@@ -12,7 +12,6 @@
       "IsSRM",
       "AmmoPerShot: 2",
       "StreakMKII",
-      "WeaponAttachmentCompatible: Artemis IV or V",
       "WeaponShardsModRange: 0.5, 2"
     ],
     "Flags": [
@@ -92,8 +91,6 @@
       "component_type_stock",
       "range_standard",
       "BAIncompatible",
-      "ArtemisIVUnlockable",
-      "ArtemisVUnlockable",
       "SRM.{location}",
       "LootMagnetBlacklist"
     ],

--- a/Optionals/RISCtech/Base/chassis/chassisdef_hammer_HMR-RSC.json
+++ b/Optionals/RISCtech/Base/chassis/chassisdef_hammer_HMR-RSC.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "RISCBattleMech",
-      "mr-resize-0.65-0.5-0.5"
+      "mr-resize-0.51-0.54-0.47"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/RogueElites/Base/chassis/chassisdef_hammer_HMR-NI.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_hammer_HMR-NI.json
@@ -41,7 +41,7 @@
   "ChassisTags": {
     "items": [
       "EliteMech",
-      "mr-resize-0.65-0.5-0.5"
+      "mr-resize-0.51-0.54-0.47"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-FLORA.json
+++ b/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-FLORA.json
@@ -109,7 +109,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.09-1.05-1.09"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-O.json
+++ b/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-O.json
@@ -102,7 +102,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.09-1.05-1.09"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OA.json
+++ b/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OA.json
@@ -102,7 +102,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.09-1.05-1.09"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OB.json
+++ b/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OB.json
@@ -102,7 +102,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.09-1.05-1.09"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OC.json
+++ b/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OC.json
@@ -102,7 +102,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.09-1.05-1.09"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OD.json
+++ b/Optionals/Urbocalypse/Omnis/chassis/chassisdef_mobile_turret_MBT-OD.json
@@ -102,7 +102,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.09-1.05-1.09"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/Urbocalypse/Omnis_RISCtech/chassis/chassisdef_mobile_turret_MBT-OE.json
+++ b/Optionals/Urbocalypse/Omnis_RISCtech/chassis/chassisdef_mobile_turret_MBT-OE.json
@@ -102,7 +102,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.09-1.05-1.09"
     ],
     "tagSetSourceFile": ""
   },


### PR DESCRIPTION
…s bonusdescription indicating what they actually do; change number of slots for Dual Saw so you can't get free slots by using it; remove "Artemis-compatible" bonusdescription from QS streak SRMs

Snake now using Spector model
Orochi now using Cyclone model

resized Rattlesnake, Rattlesnake II, Hammer, Valiant, Blackjack -G 55-ton, Koto