### PR TITLE
Pilot bio fixes vol. 1

### DIFF
--- a/Core/Vehicle Pilots/pilot/pilot_Big Tom.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Big Tom.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 44,
-    "Details": "",
+    "Details": "Big Tom is a grizzled veteran of the Free Worlds League militia, known more for his steady trigger finger than his tactful diplomacy. He's driven everything from hover tanks to heavy artillery haulers, and treats his crew like family. His loud, profane family. Rumor has it he once hotwired a Vedette during a live-fire exercise just to prove a point.",
     "Icon": "pilot_Big Tom"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Big Tom.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Big Tom.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 44,
-    "Details": "Big Tom is a grizzled veteran of the Free Worlds League militia, known more for his steady trigger finger than his tactful diplomacy. He's driven everything from hover tanks to heavy artillery haulers, and treats his crew like family. His loud, profane family. Rumor has it he once hotwired a Vedette during a live-fire exercise just to prove a point.",
+    "Details": "Big Tom is a grizzled veteran of the Free Worlds League militia, known more for his steady trigger finger than his tactful diplomacy. He's driven everything from hover tanks to heavy artillery haulers, and treats his crew like family. His loud, profane family. Rumor has it he once hotwired a Vedette during a live-fire exercise just to prove a point.\n\n",
     "Icon": "pilot_Big Tom"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Dark_Helmet.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Dark_Helmet.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 30,
-    "Details": "Some people say he is as much a machine as the vehicles he pilots.",
+    "Details": "Some people say he is as much a machine as the vehicles he pilots.\n\n",
     "Icon": "pilot_Dark_Helmet"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Dozer.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Dozer.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "When you live ona Rock in Aurigian space life is not exciting, then one day a whole war over who was in control changed that, one day he was driving a heavy dozer clearing ground the next he was driving a tank clearing enemy, being in a military after your side loses a war isn't much use so he put his talents up for sale. its funny he barely remembers his civilian life but he still has the Nickname Dozer.",
+    "Details": "When you live on a rock in Aurigan space, life is not exciting. Then, one day, a whole war over who is in control changed that. One day, he was driving a heavy dozer, clearing ground, the next he was driving a tank, clearing enemies. Being in the military after your side loses a war isn't much use though, so once the fighting was done, he put his talents up for sale. He barely remembers his civilian life any more, but he still holds the nickname 'Dozer'.",
     "Icon": "pilot_Dozer"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Dozer.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Dozer.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "When you live on a rock in Aurigan space, life is not exciting. Then, one day, a whole war over who is in control changed that. One day, he was driving a heavy dozer, clearing ground, the next he was driving a tank, clearing enemies. Being in the military after your side loses a war isn't much use though, so once the fighting was done, he put his talents up for sale. He barely remembers his civilian life any more, but he still holds the nickname 'Dozer'.",
+    "Details": "When you live on a rock in Aurigan space, life is not exciting. Then, one day, a whole war over who is in control changed that. One day, he was driving a heavy dozer, clearing ground, the next he was driving a tank, clearing enemies. Being in the military after your side loses a war isn't much use though, so once the fighting was done, he put his talents up for sale. He barely remembers his civilian life any more, but he still holds the nickname \"Dozer\".\n\n",
     "Icon": "pilot_Dozer"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Farmboy.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Farmboy.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 35,
-    "Details": "Farmboy started life on Karpathos out in New Delphi Compact space, what more can be said, farm life gets old and people move on",
+    "Details": "Farmboy started life on Karpathos, out in New Delphi Compact space. What more can be said - farm life gets old and people move on.",
     "Icon": "pilot_Farmboy"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Farmboy.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Farmboy.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 35,
-    "Details": "Farmboy started life on Karpathos, out in New Delphi Compact space. What more can be said - farm life gets old and people move on.",
+    "Details": "Farmboy started life on Karpathos, out in New Delphi Compact space. What more can be said - farm life gets old and people move on.\n\n",
     "Icon": "pilot_Farmboy"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_GeeGee.json
+++ b/Core/Vehicle Pilots/pilot/pilot_GeeGee.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 30,
-    "Details": "A former Capellan armored recon officer, GeeGee is sharp-eyed, sharp-tongued, and twice as fast as her callsign suggests. She has a knack for threading light vehicles through impossible terrain, and a reputation for getting out of tight spots with style.",
+    "Details": "A former Capellan armored recon officer, GeeGee is sharp-eyed, sharp-tongued, and twice as fast as her callsign suggests. She has a knack for threading light vehicles through impossible terrain, and a reputation for getting out of tight spots with style.\n\n",
     "Icon": "pilot_GeeGee"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_GeeGee.json
+++ b/Core/Vehicle Pilots/pilot/pilot_GeeGee.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 30,
-    "Details": "",
+    "Details": "A former Capellan armored recon officer, GeeGee is sharp-eyed, sharp-tongued, and twice as fast as her callsign suggests. She has a knack for threading light vehicles through impossible terrain, and a reputation for getting out of tight spots with style.",
     "Icon": "pilot_GeeGee"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Happy.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Happy.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "All people know about this man is that he always smiles.",
+    "Details": "All people know about this man is that he always smiles.\n\n",
     "Icon": "pilot_Happy"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Hardcase.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Hardcase.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "Jesse Link lost her job, her friends, and even her family.. casualties of raiders in this degrading hellscape of a world. Back on her home planet, she was the ace in the hole for the Main Force Patrol. Now she, along with her dog, cruise the wastelands, out for justice... in the last of the V8 Interceptors",
+    "Details": "Jesse Link lost her job, her friends, and even her family... casualties of raiders in this degrading hellscape of a world. Back on her home planet, she was the ace in the hole for the Main Force Patrol. Now she, along with her dog, cruise the wastelands, out for justice... in the last of the V8 Interceptors.",
     "Icon": "pilot_Hardcase"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Hardcase.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Hardcase.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "Jesse Link lost her job, her friends, and even her family... casualties of raiders in this degrading hellscape of a world. Back on her home planet, she was the ace in the hole for the Main Force Patrol. Now she, along with her dog, cruise the wastelands, out for justice... in the last of the V8 Interceptors.",
+    "Details": "Jesse Link lost her job, her friends, and even her family... casualties of raiders in this degrading hellscape of a world. Back on her home planet, she was the ace in the hole for the Main Force Patrol. Now she, along with her dog, cruise the wastelands, out for justice... in the last of the V8 Interceptors.\n\n",
     "Icon": "pilot_Hardcase"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Painless.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Painless.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 35,
-    "Details": "Painless got the callsign because she wont stop even when injured. She has been augmented with a bionic part every time she got hurt ",
+    "Details": "Painless got her callsign because she won't stop, even when injured. She has been augmented with a bionic part every time she has been hurt.",
     "Icon": "pilot_Painless"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Painless.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Painless.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 35,
-    "Details": "Painless got her callsign because she won't stop, even when injured. She has been augmented with a bionic part every time she has been hurt.",
+    "Details": "Painless got her callsign because she won't stop, even when injured. She has been augmented with a bionic part every time she has been hurt.\n\n",
     "Icon": "pilot_Painless"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Rafer.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Rafer.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 44,
-    "Details": "Rafer is a driver. He's a very good driver. On his home planet, it is a custom to have to drive around for a year at a minimum of 50 miles an hour in a vehicle. If the speed ever drops below that, the vehicle explodes. This leaves Rafer with a lot of experience, a lot of regret. Lost hopes and dreams. Before the race, he rode around for fun. Now, even after leaving his planet and searching for his destiny among the stars, he must drive. Drive to survive.",
+    "Details": "Rafer is a driver. He's a very good driver. On his home planet, it is a custom to have to drive around for a year at a minimum of 50 miles an hour in a vehicle. If the speed ever drops below that, the vehicle explodes. This leaves Rafer with a lot of experience, a lot of regret. Lost hopes and dreams. Before the race, he rode around for fun. Now, even after leaving his planet and searching for his destiny among the stars, he must drive. Drive to survive.\n\n",
     "Icon": "pilot_Rafer"
   },
   "BaseGunnery": 2,

--- a/Core/Vehicle Pilots/pilot/pilot_Rafer.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Rafer.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 44,
-    "Details": "Rafer is a driver. he`s a very good driver. on his home planet, it is custom to have to drive around for a year at a minimum of 50 miles an hour in a vehicle. if the speed drops below that, the vehicle explodes. This leaves Rafer with a lot of experience, a lot of regret. lost hopes and dreams.. before the race, he rode around for fun. Now, even after leaving his planet and searching for his destiny among the stars... he must drive. Drive to survive",
+    "Details": "Rafer is a driver. He's a very good driver. On his home planet, it is a custom to have to drive around for a year at a minimum of 50 miles an hour in a vehicle. If the speed ever drops below that, the vehicle explodes. This leaves Rafer with a lot of experience, a lot of regret. Lost hopes and dreams. Before the race, he rode around for fun. Now, even after leaving his planet and searching for his destiny among the stars, he must drive. Drive to survive.",
     "Icon": "pilot_Rafer"
   },
   "BaseGunnery": 2,

--- a/Core/Vehicle Pilots/pilot/pilot_Romeo.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Romeo.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "A good man to have on your side in a fight.",
+    "Details": "A good man to have on your side in a fight.\n\n",
     "Icon": "pilot_Romeo"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Saint.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Saint.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "A man that seems to be a rogue, but is always helping people out of bad situations.",
+    "Details": "A man that seems to be a rogue, but is always helping people out of bad situations.\n\n",
     "Icon": "pilot_Saint"
   },
   "BaseGunnery": 3,

--- a/Core/Vehicle Pilots/pilot/pilot_Saint.json
+++ b/Core/Vehicle Pilots/pilot/pilot_Saint.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "A man that seems to be a rogue but always helps people out of bad situations.",
+    "Details": "A man that seems to be a rogue, but is always helping people out of bad situations.",
     "Icon": "pilot_Saint"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aelle.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aelle.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 57,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Aelle"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aethelflaed.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aethelflaed.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 28,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Aethelflaed"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aethelwulf.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aethelwulf.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 35,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Aethelwulf"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aslaug.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Aslaug.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Aslaug"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Astrid.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Astrid.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 30,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Astrid"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Bjorn.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Bjorn.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 29,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Bjorn"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Bloodhair.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Bloodhair.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 47,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Bloodhair"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Brida.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Brida.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 33,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Brida"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Cnut.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Cnut.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 36,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Cnut"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ecbert.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ecbert.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 56,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ecbert"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ellsif.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ellsif.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 30,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ellsif"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Erik.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Erik.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 42,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Erik"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Eyvind.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Eyvind.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 46,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Eyvind"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Finan.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Finan.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 29,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Finan"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Floki.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Floki.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Floki"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Freydis.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Freydis.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 24,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and support units that survived a major battle.Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Freydis"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Gisela.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Gisela.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 33,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Gisela"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Gisla.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Gisla.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 26,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Gisla"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Gunnhild.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Gunnhild.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 33,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Gunnhild"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Haesten.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Haesten.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 44,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Haesten"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Halfdan .json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Halfdan .json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 37,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Halfdan "
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Harold.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Harold.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 45,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Harold"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Heahmund.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Heahmund.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Heahmund"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Helga.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Helga.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 29,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Helga"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Hild.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Hild.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 41,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Hild"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Hillborg.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Hillborg.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 36,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Hillborg"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Horik.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Horik.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 51,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Horik"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Hvitserk.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Hvitserk.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 25,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Hvitserk"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ingvild.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ingvild.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 41,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ingvild"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Iseult.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Iseult.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 30,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Iseult"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ivar.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ivar.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 23,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ivar"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Judith.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Judith.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 27,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Judith"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Kjetill.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Kjetill.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 43,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Kjetill"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Lagertha.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Lagertha.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Lagertha"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Porunn.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Porunn.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 31,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Porunn"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ragga.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ragga.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ragga"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ragnar.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ragnar.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ragnar"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ravn.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ravn.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 72,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ravn"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Rollo.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Rollo.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 38,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Rollo"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Siggy.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Siggy.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 29,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Siggy"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sigtryggr.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sigtryggr.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 33,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Sigtryggr"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sigurd.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sigurd.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 23,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Sigurd"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sihtric.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sihtric.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 28,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Sihtric"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sirgfrid.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Sirgfrid.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 53,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Sirgfrid"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Skade.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Skade.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 24,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Skade"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Skorpa.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Skorpa.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 46,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Skorpa"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Steapa.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Steapa.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 44,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Steapa"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Taetan.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Taetan.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 27,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Taetan"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Thorbjorn.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Thorbjorn.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 42,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Thorbjorn"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Thyra.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Thyra.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 32,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Thyra"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Torvi.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Torvi.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 24,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Torvi"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ubba.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ubba.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 50,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ubba"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ubbe.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Ubbe.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 30,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Ubbe"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Uhtred.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Uhtred.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "Faction": "NoFaction",
     "Age": 35,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Uhtred"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Vala.json
+++ b/InstallOptions/Pilots/JarnfolkPilots/pilot/pilot_Vala.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "Faction": "NoFaction",
     "Age": 36,
-    "Details": "One of the remaining pilots from a battalion of Mechwarriors and the garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold Lostech. Despite narrowly turning back the assault the base is held but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive. \n\n ",
+    "Details": "One of the remaining pilots from a battalion of MechWarriors and garrison vehicle crews that survived a major battle. Clan forces tried to seize a military base locked before the Exodus, rumoured to hold LosTech. Narrowly turning back the assault, the base is held, but contact is lost with the ship. In orbit, the expedition commander cowardly decides to nuke the site and claims the unit has defected. The few survivors, branded traitors, are forced to scatter to survive.\n\n",
     "Icon": "pilot_Vala"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Asmodeus.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Asmodeus.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 37,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Asmodeus"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Banshee.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Banshee.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 28,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Banshee"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Belphegor.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Belphegor.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 28,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Belphegor"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Dagon.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Dagon.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 28,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Dagon"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Djinn.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Djinn.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 30,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Djinn"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Gaki.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Gaki.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 27,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Gaki"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Harpy.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Harpy.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 32,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Harpy"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Hastur.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Hastur.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 29,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Hastur"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Huldra.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Huldra.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 39,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Huldra"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Jiangshi.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Jiangshi.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 33,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Jiangshi"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Kikimora.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Kikimora.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 34,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Kikimora"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Lamia.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Lamia.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 27,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Lamia"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Legion.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Legion.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 24,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Legion"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Loki.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Loki.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 31,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Loki"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Moloch.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Moloch.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 36,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Moloch"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Nixie.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Nixie.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 26,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Nixie"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Orcus.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Orcus.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 26,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Orcus"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Phenex.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Phenex.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 26,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Phenex"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Rusalka.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Rusalka.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 48,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Rusalka"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Tannin.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Tannin.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 26,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Tannin"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Valac.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Valac.json
@@ -8,7 +8,7 @@
     "Gender": "Male",
     "factionID": "Davion",
     "Age": 42,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Valac"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Wendigo.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Wendigo.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 30,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Wendigo"
   },
   "BaseGunnery": 2,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Wraith.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_Wraith.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 30,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_Wraith"
   },
   "BaseGunnery": 3,

--- a/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_YukiOnna.json
+++ b/InstallOptions/Pilots/OmegaSquadPilots/pilot/pilot_YukiOnna.json
@@ -8,7 +8,7 @@
     "Gender": "Female",
     "factionID": "Davion",
     "Age": 27,
-    "Details": "Classified - Commander Eyes Only",
+    "Details": "Classified - Commander Eyes Only\n\n",
     "Icon": "pilot_YukiOnna"
   },
   "BaseGunnery": 3,


### PR DESCRIPTION
Fixed formatting, typos and grammar, modified Battletech-specific terms to match the orthography used on Sarna. Added bios for two pilots who had none with permission from Werecat 101, the original creator.