### PR TITLE
Clan shops: add magshot ammo, remove UAC20 ammo duplicate

### DIFF
--- a/Core/DynamicShops/data/RT_Ammo_Clan.csv
+++ b/Core/DynamicShops/data/RT_Ammo_Clan.csv
@@ -22,8 +22,8 @@ Ammo_AmmunitionBox_UAC_20_Half,AmmunitionBox,1,5
 Ammo_AmmunitionBox_Gauss_Rifle,AmmunitionBox,1,6
 Ammo_AmmunitionBox_Gauss_Rifle_Double,AmmunitionBox,1,9
 Ammo_AmmunitionBox_Gauss_Rifle_Half,AmmunitionBox,1,7
-Ammo_AmmunitionBox_UAC_20,AmmunitionBox,1,5
-Ammo_AmmunitionBox_UAC_20_Double,AmmunitionBox,1,7
+Ammo_AmmunitionBox_Magshot,AmmunitionBox,1,3
+Ammo_AmmunitionBox_Magshot_Half,AmmunitionBox,1,3
 Ammo_AmmunitionBox_Narc_Beacon,AmmunitionBox,1,5
 Ammo_AmmunitionBox_SRM_Streak_Clan,AmmunitionBox,1,6
 Ammo_AmmunitionBox_SRM_Streak_Clan_Half,AmmunitionBox,1,9


### PR DESCRIPTION
AP gauss is available in shops, feels silly that magshot ammo isn't.