### PR TITLE
Text corrections

### DIFF
--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -2332,7 +2332,7 @@
       "Bonus": "BraceToFireReductionWeaponType",
       "Short": "{0} BraceToFireReduction",
       "Long": "{0} Reduced Stab Dmg to Self",
-      "Full": "{0} stability damage to self when firing {0} weapons. Effect Stacks."
+      "Full": "{0} stability damage to self when firing {1} weapons. Effect Stacks."
     },
     {
       "Bonus": "BraceToFireIncrease",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_stormcrow_SCR-L.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_stormcrow_SCR-L.json
@@ -72,7 +72,7 @@
     "UIName": "Stormcrow",
     "Id": "chassisdef_stormcrow_SCR-L",
     "Name": "Stormcrow",
-    "Details": "A pair of LRM-15 launchers provide long range firepower while each arm carries an ER Large Laser and ER Medium Laser. \n\n<b><color=#e62e00>Quirk: Stable</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.06</color></b>\n\n<color=#FFEF00>Arm Actuator Limits: Omni</color>",
+    "Details": "A pair of Clan-tech ATM-6 launchers installed on this Mech is accompanied by small and medium ER Pulse Lasers carried in each arm. \n\n<b><color=#e62e00>Quirk: Stable</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.06</color></b>\n\n<color=#FFEF00>Arm Actuator Limits: Omni</color>",
     "Icon": "uixTxrIcon_stormcrow"
   },
   "VariantName": "SCR-L",
@@ -86,7 +86,7 @@
     "tagSetSourceFile": ""
   },
   "StockRole": "Scout & Disabler",
-  "YangsThoughts": "A pair of LRM-15 launchers provide long range firepower while each arm carries an ER Large Laser and ER Medium Laser. ",
+  "YangsThoughts": "A pair of Clan-tech ATM-6 launchers installed on this Mech is accompanied by small and medium ER Pulse Lasers carried in each arm. ",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
   "HardpointDataDefID": "hardpointdatadef_stormcrow",


### PR DESCRIPTION
- Fixed wrong description of weaponry on SCR-L mech

- Fixed description of 'brace to fire' gyro bonus: current text is shown on screenshot below;
I'm expecting that my correction should lead to proper text ("{-20} stability damage to self when firing {Artillery} weapons. Effect Stacks.") but I didn't test it.

![637090_1](https://github.com/user-attachments/assets/f9bb3578-b126-4b2b-bf07-28de15164ad3)

