### PR TITLE
Affinity defs proofread, edited & made more consistent

### DIFF
--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Agile.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Agile.json
@@ -131,7 +131,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Agile",
-        "decription": "+1 Defense & +1 Melee Defense",
+        "decription": "+1 Defense and +1 Melee Defense",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_All_Out.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_All_Out.json
@@ -26,7 +26,7 @@
       {
         "missionsRequired": 20,
         "levelName": "All Out",
-        "decription": "+1 ALL Torso Accuracy",
+        "decription": "+1 accuracy to all torso-mounted weapons",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Ambusher.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Ambusher.json
@@ -68,7 +68,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Ambusher",
-        "decription": "-15% Signature and Visibility and +1 Local ECM",
+        "decription": "+1 ECM shield, -15% visual & sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Anarchist.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Anarchist.json
@@ -24,7 +24,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Anarchist",
-        "decription": "+1 Flamer & MG Accuracy, -10% Flamer & MG Heat",
+        "decription": "Flamers & MGs: +1 accuracy and -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Ankle_biter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Ankle_biter.json
@@ -137,7 +137,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Ankle biter",
-        "decription": "-25% Signature and Visibility and +1 Local ECM, +10% Vision and Sensors, +1 Probe",
+        "decription": "+1 ECM shield, +10% sight & sensor range, +1 probe, -25% visual & sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_AriesInitiative.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_AriesInitiative.json
@@ -50,7 +50,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Aries Initiative",
-        "decription": "Accuracy +1, -5% Heat Generated, -5% Damage Taken",
+        "decription": "+1 accuracy, -5% weapon heat generation, +5% damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Armed_to_the_Teeth.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Armed_to_the_Teeth.json
@@ -36,7 +36,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Armed to the Teeth",
-        "decription": "+1 Evasion Ignore, -5% Heat Generated",
+        "decription": "+1 evasion ignored, -5% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Ballistic_Expertise.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Ballistic_Expertise.json
@@ -44,7 +44,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Ballistic Expertise",
-        "decription": "-5% Min Scatter and -10% Max Scatter Radius, +1 Ballistic Accuracy, -1 Ballistic Recoil",
+        "decription": "Ballistics: +1 accuracy, -1 recoil, -5% min & -10% max scatter radius",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Battlefield_Commander.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Battlefield_Commander.json
@@ -14,7 +14,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Battlefield Commander",
-        "decription": "+2 Initiative and +2 Tactics for all Company units. If Company already have Tacticon or CommGear effect, increases it by +1. Does not stack.",
+        "decription": "All company units gain +2 Initiative and +2 Tactics. If company already has a Tacticon or CommGear effect, increases it by +1. Does not stack",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Because_Science.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Because_Science.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Because \"Science\"",
-        "decription": "-20% Heat Generated, +10% Vision, +20% Sensors, +1 Probe",
+        "decription": "+10% sight range, +20% sensor range, +1 probe, -20% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Benedictio_Caelestis.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Benedictio_Caelestis.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Benedictio Caelestis",
-        "decription": "-10% Heat Generated, +10 Heat Sink Capacity, +1 Accuracy",
+        "decription": "+1 accuracy, -10% heat generation, +10 heat sinking",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Bombardier.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Bombardier.json
@@ -23,7 +23,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Bombardier",
-        "decription": "-10% Min Scatter and -15% Max Scatter Radius, -2 Artillery Recoil, Allows MultiTarget",
+        "decription": "-10% min & -15% max scatter radius, -2 artillery recoil, Multi-target",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Brawler.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Brawler.json
@@ -74,7 +74,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Brawler",
-        "decription": "+1 Short & Medium Range Accuracy, +2 Min Range Accuracy",
+        "decription": "+1 short & medium range accuracy, +2 minimum range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Brute.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Brute.json
@@ -54,7 +54,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Brute",
-        "decription": "+10% Punch & Kick Damage and +10% Stability Damage",
+        "decription": "Punch & kick: +10% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Cheaply_Made.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Cheaply_Made.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Cheaply Made",
-        "decription": "-10 Walk Speed, -1 Accuracy, +50% Run Speed",
+        "decription": "-10m walk distance, -1 accuracy, +50% run speed",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Close_Quarters_Specialist.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Close_Quarters_Specialist.json
@@ -20,7 +20,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Close Quarters Specialist",
-        "decription": "+1 Medium Range Accuracy, +2 Short Range Accuracy, +4 Minimum Range Accuracy",
+        "decription": "+1 medium range accuracy, +2 short range accuracy, +4 minimum range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Cooler_Master.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Cooler_Master.json
@@ -21,7 +21,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Cooler Master",
-        "decription": "-15% Heat Generated, +12 Heat Sinking",
+        "decription": "-15% heat generation, +12 heat sinking",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Death_From_Above.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Death_From_Above.json
@@ -15,7 +15,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Death From Above!",
-        "decription": "-25% DFA Self Damage and +25% DFA Damage Dealt",
+        "decription": "DFA: +25% damage and -25% self-damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Dreadnought.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Dreadnought.json
@@ -52,7 +52,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Dreadnought",
-        "decription": "-20% Stability Damage Taken and +5% Damage Resist",
+        "decription": "+5% damage resistance and +20% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Eagle_Eye.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Eagle_Eye.json
@@ -21,7 +21,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Eagle Eye",
-        "decription": "Gauss: +1 Accuracy, +1 Evasive Pips Ignored, +50% Critical Chance",
+        "decription": "Gauss: +1 accuracy, +1 evasion ignored, and +50% critical hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Electromagnetic_Proficiency.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Electromagnetic_Proficiency.json
@@ -14,7 +14,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Electromagnetic Proficiency",
-        "decription": "Railgun: +1 Evasion Pips Ignored, -2 Recoil, +100% Critical Chance",
+        "decription": "Railgun: +1 evasion ignored, -2 recoil, and +100% critical hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Energizer.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Energizer.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Energizer",
-        "decription": "Mauler Laser: +5% Damage, +100% Critical Chance, -10% Heat Generated",
+        "decription": "Mauler Laser: +5% damage, +100% critical hit chance, and -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Evasive.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Evasive.json
@@ -99,7 +99,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Evasive",
-        "decription": "+1 Increased Evasion Gain and +1 Max",
+        "decription": "+1 evasion from movement, +1 max evasion",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Field_Ionizer.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Field_Ionizer.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Field Ionizer",
-        "decription": "Ion Cannon: +1 Accuracy, -25% Heat Generated",
+        "decription": "Ion Cannon: +1 accuracy and -25% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Fighter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Fighter.json
@@ -44,7 +44,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Fighter",
-        "decription": "+10% Physical Weapon Damage&Stability, +1 Physical Weapon Accuracy",
+        "decription": "Physical weapon: +1 accuracy and +10% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Fire_For_Effect.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Fire_For_Effect.json
@@ -15,7 +15,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Fire For Effect",
-        "decription": "Missile Artillery: 15% Min & -25% Max Scatter Radius, +25% Missile HP, -10% AMS Intercept Chance",
+        "decription": "Missile artillery: -15% min & -25% max scatter radius, +25% missile HP, and -10% AMS intercept chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_FirstOfItsKind.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_FirstOfItsKind.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 20,
         "levelName": "First of its Kind",
-        "decription": "+1 Accuracy, -1 Recoil, -5% Heat Generated",
+        "decription": "+1 accuracy, -1 recoil, -5% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Focus_Fire.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Focus_Fire.json
@@ -63,7 +63,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Focus Fire",
-        "decription": "+1 Arm Mounted Accuracy.",
+        "decription": "+1 arm-mounted weapon accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Focus_Fire_Tank.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Focus_Fire_Tank.json
@@ -40,7 +40,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Focus Fire",
-        "decription": "+1 Tank-Turret Accuracy.",
+        "decription": "+1 turret accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Gunboat.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Gunboat.json
@@ -96,7 +96,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Gunboat",
-        "decription": "+1 Evasion Ignore & +1 Gunnery",
+        "decription": "+1 evasion ignored, +1 Gunnery",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Gunslinger.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Gunslinger.json
@@ -53,7 +53,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Gunslinger",
-        "decription": "+0.3 Cluster to Ballistic Weapons, +20% Called Shot Chance, +1 Offensive Push Accuracy",
+        "decription": "+20% Called Shot location hit chance, +1 Offensive Push accuracy, +0.3 grouping for ballistic weapons",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Hardened_Internals.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Hardened_Internals.json
@@ -33,7 +33,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Hardened Internals",
-        "decription": "-25% Through Armor Damage and 25% AP Crit resistance.",
+        "decription": "+25% through-armor damage resistance, +25% through-armor critical hit resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_Gunner_LT.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_Gunner_LT.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Heavy Gunner (LT)",
-        "decription": "+1 Left Torso Accuracy, -1 Recoil",
+        "decription": "+1 left torso-mounted accuracy, -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_Gunner_RT.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_Gunner_RT.json
@@ -24,7 +24,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Heavy Gunner (RT)",
-        "decription": "+1 Right Torso Accuracy, -1 Recoil",
+        "decription": "+1 right torso-mounted accuracy, -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_Gunner_Tank_Front.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_Gunner_Tank_Front.json
@@ -28,7 +28,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Heavy Gunner (Front)",
-        "decription": "+1 Front Accuracy, -1 Recoil",
+        "decription": "+1 front-mounted accuracy, -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_MRM_Wizard.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Heavy_MRM_Wizard.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Heavy MRM Wizard",
-        "decription": "Heavy MRM: +1 / +2 (Medium Range) Accuracy, +1 Evasion Pips Ignored, +10% Damage",
+        "decription": "Heavy MRM: +1 accuracy & additional +1 at medium range, +1 evasion ignored, and +10% damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_High-Pressure-Cooling.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_High-Pressure-Cooling.json
@@ -47,7 +47,7 @@
       {
         "missionsRequired": 20,
         "levelName": "High-Pressure-Cooling",
-        "decription": "-10% Weapon Heat Generated",
+        "decription": "-10% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Improved_Concealment.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Improved_Concealment.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Improved Concealment",
-        "decription": "+2 Local ECM, -20% Signature, -20% Visibility",
+        "decription": "+2 ECM shield, -20% visual and sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Industrial_Safety_Bypass.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Industrial_Safety_Bypass.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Industrial Safety Bypass",
-        "decription": "+5% weapon heat generated, +1 Walk MP",
+        "decription": "+5% weapon heat generation, +30m walk distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Infantry_Slayer.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Infantry_Slayer.json
@@ -18,7 +18,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Infantry Slayer",
-        "decription": "Anti-Personal Gauss / Magshot: +50% Critical Chance, +10% Damage",
+        "decription": "AP Gauss & MagShot: +50% critical hit chance and +10% damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Jack_of_all_Trades.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Jack_of_all_Trades.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Jack of all Trades",
-        "decription": "+1 Accuracy, -5% Heat Generated, +5% Called Shot Bonus, -1 Recoil",
+        "decription": "+1 accuracy, -1 recoil, -5% weapon heat generation, +5% Called Shot location hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Jump_Trooper.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Jump_Trooper.json
@@ -51,7 +51,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Jump Trooper",
-        "decription": "+10% Jump Attack Damage, +10% Jump Distance",
+        "decription": "+10% damage after jumping, +10% jump distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_LeftHanded_Specialist.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_LeftHanded_Specialist.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Left-handed Specialist",
-        "decription": "+1 Left Arm Mounted Accuracy, +1 Piloting, + 1 Gunnery",
+        "decription": "+1 left arm-mounted accuracy, +1 Piloting, + 1 Gunnery",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Machinist.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Machinist.json
@@ -21,7 +21,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Machinist",
-        "decription": "+1 Hex Walk Speed, +20% Run Speed, -10% Heat Generated",
+        "decription": "+30m walk distance, +20% run speed, -10% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Man-of-War.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Man-of-War.json
@@ -28,7 +28,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Man-of-War",
-        "decription": "+1 Gunnery. Autocannon: +1 Accuracy, -1 Recoil, +1 Evasion Pips Ignored",
+        "decription": "+1 Gunnery. Autocannon: +1 accuracy, -1 Recoil, and +1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Master_Gunner.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Master_Gunner.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Master Gunner",
-        "decription": "Helical Railgun: +1 Side Torso Accuracy, -2 Recoil",
+        "decription": "Helical Railgun: +1 side torso-mounted accuracy and -2 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Missile_Boat.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Missile_Boat.json
@@ -74,7 +74,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Missile Boat",
-        "decription": "+1 Missile Accuracy",
+        "decription": "+1 missile accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Missile_Swarm_Platform.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Missile_Swarm_Platform.json
@@ -24,7 +24,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Missile Swarm Platform",
-        "decription": "Missile Weapons: +1 Evasive Pips Ignored, +1 Accuracy, +10% Clustering",
+        "decription": "Missiles: +1 evasion ignored, +1 accuracy, and +0.1 grouping",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Particular_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Particular_Mastery.json
@@ -22,7 +22,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Particular Mastery",
-        "decription": "PPC: +1 Accuracy, +1 Evasive Pips Ignored, -10% Heat Generated",
+        "decription": "PPC: +1 accuracy, +1 evasion ignored, and -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Pedal_to_the_Metal.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Pedal_to_the_Metal.json
@@ -31,7 +31,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Pedal to the Metal",
-        "decription": "+10% Run Movement, +1 Guts",
+        "decription": "+10% run speed, +1 Guts",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Pit_Fighter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Pit_Fighter.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Pit Fighter",
-        "decription": "Punch Attack: +20% damage, +20 Instability Damage, +2 Accuracy, +1 Extra Punch, -10% Resolve Cost",
+        "decription": "-10% ability Resolve cost. Punch: +20% damage & stability damage, +2 accuracy, and +1 extra punch",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Plasma_Capacitors.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Plasma_Capacitors.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Plasma Capacitors",
-        "decription": "Plasma Weapons / Plasma Railgun: +30% Heat Damage, -10% Heat Generated",
+        "decription": "Plasma weapons & Plasma Railgun: +30% heat damage and -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_QSTank_Complete_Overhaul.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_QSTank_Complete_Overhaul.json
@@ -16,7 +16,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Complete Overhaul",
-        "decription": "+1 Adv Sensors, +1 Pilot Skills, 35% Panic Resist, 45% Crit Resist (More than canceling malus from quirk). 'Once you totally rebuild a Quikcell tank they aren't that bad.' - Anon",
+        "decription": "+1 Adv. sensors, +1 to all pilot skills, +35% panic resistance, +45% critical hit resistance (more than canceling malus from quirk). 'Once you totally rebuild a Quicksell tank, they aren't that bad.' - Anon",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Raxpert.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Raxpert.json
@@ -19,7 +19,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Raxpert",
-        "decription": "Rotary Autocannon: +1 Accuracy, -1 Recoil, -10% Jam Chance",
+        "decription": "Rotary autocannon: +1 accuracy, -1 recoil, and -10% jam chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Reactive_Plates.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Reactive_Plates.json
@@ -50,7 +50,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Reactive Plates",
-        "decription": "-10% Ballistic/Missile Damage Taken",
+        "decription": "+10% ballistic & missile damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Reflective_Coating.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Reflective_Coating.json
@@ -48,7 +48,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Reflective Coating",
-        "decription": "-10% Energy Damage Taken",
+        "decription": "+10% energy damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Robustness.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Robustness.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Robustness",
-        "decription": "-10% Damage Taken, -10% Crits Taken, -5% Heat Generated",
+        "decription": "+10% damage resistance, +10% critical hit resistance, -5% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Scout.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Scout.json
@@ -92,7 +92,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Scout",
-        "decription": "+1 Probe, +15% Visions&Sensors",
+        "decription": "+15% sight & sensor range, +1 probe",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Scrapper.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Scrapper.json
@@ -70,7 +70,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Scrapper",
-        "decription": "Ace Pilot & Multi-Tracker",
+        "decription": "Ace Pilot & Multi-target",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Section_8.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Section_8.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Section 8",
-        "decription": "+1 Guts, +20% Resolve Generation, +2 Defense. 'You have to be a little crazy to drive one of these in a combat zone'",
+        "decription": "+1 Guts, +20% Resolve generation, +2 Defense. 'You have to be a little crazy to drive one of these in a combat zone'",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Sharpshooter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Sharpshooter.json
@@ -21,7 +21,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Sharpshooter",
-        "decription": "+1 Extreme Range Accuracy, +1 Long Range Accuracy, +1 Medium Range Accuracy",
+        "decription": "+1 extreme range accuracy, +1 long range accuracy, +1 medium range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Shieldbearer.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Shieldbearer.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Shieldbearer",
-        "decription": "+20 Armor/+5 Structure Left Arm, +1 Accuracy Right Arm, +1 Accuracy Physical Melee",
+        "decription": "+20 armor & +5 structure in left arm, +1 right arm-mounted accuracy , +1 physical weapon accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Shocktrooper.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Shocktrooper.json
@@ -37,7 +37,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Shocktrooper",
-        "decription": "+1 Right Arm Mounted Accuracy, +1 Piloting, + 1 Gunnery",
+        "decription": "+1 right arm-mounted accuracy, +1 Piloting, +1 Gunnery",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Sniper.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Sniper.json
@@ -63,7 +63,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Sniper",
-        "decription": "+1 Long Range Accuracy, +1 Extreme Range Accuracy",
+        "decription": "+1 long range accuracy, +1 extreme range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_SpeedDemon.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_SpeedDemon.json
@@ -22,7 +22,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Speed Demon",
-        "decription": "+3 Maximum Evasion",
+        "decription": "+3 max evasion",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Stabilized_Weapons_Platform.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Stabilized_Weapons_Platform.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Stabilized Weapons Platform",
-        "decription": "-2 Recoil, -10% Stability Damage Taken",
+        "decription": "-2 recoil, +10% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Stabilzation_Guru.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Stabilzation_Guru.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Stabilzation Guru",
-        "decription": "Mass Driver: -20% Jam Chance, -2 Recoil",
+        "decription": "Mass Driver: -20% jam chance and -2 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Storm_Trooper.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Storm_Trooper.json
@@ -35,7 +35,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Storm Trooper",
-        "decription": "+1 Accuracy for HandHeld, BoltOn, Physical Weapon and Punch",
+        "decription": "Handheld, bolt-on, physical weapon, and punch: +1 accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Supercooled.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Supercooled.json
@@ -38,7 +38,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Supercooled",
-        "decription": "+10 Heat Sinking",
+        "decription": "+10 heat sinking",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Superheavy_Rotary_Autocannon_Virtuoso.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Superheavy_Rotary_Autocannon_Virtuoso.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Superheavy Rotary Autocannon Virtuoso",
-        "decription": "SHRAC: +1 Accuracy, -1 Evasion Pips Ignored, -2 Recoil, -10% Jam Chance ",
+        "decription": "SHRAC: +1 accuracy, -1 evasion ignored, -2 recoil, and -10% jam chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Test_Pilot.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Test_Pilot.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Test Pilot",
-        "decription": "+1 Hex Movement, +1 Evasion Gained, -10% Signature, +1 Guts",
+        "decription": "+30m walk distance, +1 Defense, -10% sensor signature, +1 Guts",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Twin_Minds.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Twin_Minds.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Twin Minds",
-        "decription": "+100% Resolve Generation, +100% Resolve cost, +50 Max Resolve, +3 Base Resolve per round",
+        "decription": "+100% Resolve generation, +100% ability Resolve cost, +50 max Resolve, +3 base Resolve per round",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Unassailable.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Unassailable.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Unassailable",
-        "decription": "-10% Damage Taken, -10% Crits Taken, -10% Stability Damage Taken, -10% Incoming Heat, +1 Guts",
+        "decription": "+10% physical, stability & heat damage resistance, +10% critical hit resistance, +1 Guts",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Unrelenting_Flanker.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_Unrelenting_Flanker.json
@@ -16,7 +16,7 @@
       {
         "missionsRequired": 20,
         "levelName": "Unrelenting Flanker",
-        "decription": "-10% Signature and Visibility. +5% Run Speed. +1 Probe.",
+        "decription": "+1 probe, -10% visibility & sensor signature, +5% run speed",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_iATM_Expert.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_chassis_iATM_Expert.json
@@ -19,7 +19,7 @@
       {
         "missionsRequired": 20,
         "levelName": "iATM Expert",
-        "decription": "Improved ATM: +2 Accuracy, +1 Evasion Pips Ignored, -20% Heat Generated",
+        "decription": "Improved ATM: +2 accuracy, +1 evasion ignored, and -20% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Advanced_Field_Command.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Advanced_Field_Command.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Advanced Field Command",
-        "decription": "Command Module provides additional non-stacking +5% Sight&Sensors, +1 Initiative, +1 Indirect Accuracy and +1 Tactics to all Company units",
+        "decription": "Command Module: all company units gain +5% sight & sensor range, +1 Initiative, +1 indirect accuracy and +1 Tactics. Does not stack",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Advanced_Tracking.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Advanced_Tracking.json
@@ -29,7 +29,7 @@
       {
         "missionsRequired": 150,
         "levelName": "Advanced Tracking",
-        "decription": "+1 Evasion Ignore",
+        "decription": "+1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Aerial_Acrobat.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Aerial_Acrobat.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 60,
         "levelName": "Aerial Acrobat",
-        "decription": "+1 Evasion Generated, +5 Max Evasion",
+        "decription": "+1 evasion from movement, +5 max evasion",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Afterburner.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Afterburner.json
@@ -41,7 +41,7 @@
       {
         "missionsRequired": 150,
         "levelName": "Afterburner",
-        "decription": "+5% Jump Distance",
+        "decription": "+5% jump distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Alacrity.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Alacrity.json
@@ -19,7 +19,7 @@
       {
         "missionsRequired": 90,
         "levelName": "Alacrity",
-        "decription": "+1 Evasion Generated",
+        "decription": "+1 evasion from movement",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Asskickah.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Asskickah.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Asskickah",
-        "decription": "+1 DFA/Kick Accuracy, +5% DFA/Kick Damage",
+        "decription": "DFA & kick: +1 accuracy and +5% damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_AutoCannon_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_AutoCannon_Mastery.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 120,
         "levelName": "AutoCannon Mastery",
-        "decription": "+1 Accuracy and -2 Recoil for AutoCannons",
+        "decription": "Autocannon: +1 accuracy and -2 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Ballistics_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Ballistics_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Ballistics Mastery",
-        "decription": "+1 Accuracy and -1 Recoil for Ballistics",
+        "decription": "Ballistics: +1 accuracy and -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Barbarian.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Barbarian.json
@@ -42,7 +42,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Barbarian",
-        "decription": "+10% Physical Weapon Damage and Stability dealt",
+        "decription": "Physical weapon: +10% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Black_Ops_Recon.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Black_Ops_Recon.json
@@ -25,7 +25,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Black Ops Recon",
-        "decription": "-15% Signature and Visibility and +1 Local ECM",
+        "decription": "+1 ECM shield, -15% visibility & sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Broadside.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Broadside.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Broadside",
-        "decription": "+30% Stability Damage Dealt",
+        "decription": "+30% stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_CHOMP.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_CHOMP.json
@@ -16,7 +16,7 @@
       {
         "missionsRequired": 140,
         "levelName": "CHOMP!",
-        "decription": "+10% Charge/Punch/Physical Damage",
+        "decription": "Charge, punch & physical weapon: +10% damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Calibrated_Weapons.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Calibrated_Weapons.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Calibrated Weapons",
-        "decription": "+1 Arm Mounted Accuracy",
+        "decription": "+1 arm-mounted accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Cool_Running.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Cool_Running.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 110,
         "levelName": "Cool Running",
-        "decription": "+6 Heat Sinking, -5% Weapon Heat Generated",
+        "decription": "+6 heat sinking, -5% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Cooled_Laser.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Cooled_Laser.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Cooled Laser",
-        "decription": "-5% Heat generated with Laser",
+        "decription": "Lasers: -5% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Coordination.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Coordination.json
@@ -23,7 +23,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Coordination",
-        "decription": "+1 Lance Tactics (Does Not Stack), +1 Lance Resolve Per Round (Maximum 3 stacks)",
+        "decription": "All company units: +1 Tactics (does not stack), +1 Resolve per round (maximum 3 stacks)",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Death_From_Above.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Death_From_Above.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Death From Above!",
-        "decription": "-25% DFA Self Damage and +25% DFA Damage Dealt",
+        "decription": "DFA: +25% damage and -25% self-damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Deep_Fried.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Deep_Fried.json
@@ -14,7 +14,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Deep Fried",
-        "decription": "+10% Heat Damage",
+        "decription": "+10% heat damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Defender_of_the_Word.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Defender_of_the_Word.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Defender of the Word",
-        "decription": "+20% Crit Resistance, -5% Damage Taken",
+        "decription": "+20% critical hit resistance, +5% damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Destroyer.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Destroyer.json
@@ -42,7 +42,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Destroyer",
-        "decription": "+5% Physical Weapon and +15% Stability Damage dealt",
+        "decription": "Physical weapon: +5% damage and +15% stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Durability.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Durability.json
@@ -16,7 +16,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Durability",
-        "decription": "-5% Damage Taken",
+        "decription": "+5% damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_ExpertRunner.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_ExpertRunner.json
@@ -26,7 +26,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Expert Runner",
-        "decription": "+2 Maximum Evasion, +1 Piloting",
+        "decription": "+2 max evasion, +1 Piloting",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Eye_of_Blake.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Eye_of_Blake.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 100,
         "levelName": "Eye of Blake",
-        "decription": "+25% Sensor Range",
+        "decription": "+25% sensor range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Faster_than_Wind.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Faster_than_Wind.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Faster than Wind",
-        "decription": "+20% Run Multiplier",
+        "decription": "+20% run speed",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Field_Command.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Field_Command.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Field Command",
-        "decription": "Command Console provides additional non-stacking +5% Sight&Sensors and +1 Initiative to all Company units",
+        "decription": "Command Console: all company units gain +5% sight & sensor range and +1 Initiative. Does not stack",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Firewalker.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Firewalker.json
@@ -19,7 +19,7 @@
       {
         "missionsRequired": 150,
         "levelName": "Firewalker",
-        "decription": "-10% Heat Damage Taken",
+        "decription": "+10% heat damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Fly_High.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Fly_High.json
@@ -14,7 +14,7 @@
       {
         "missionsRequired": 100,
         "levelName": "Fly High!",
-        "decription": "+15% Jump Distance",
+        "decription": "+15% jump distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Go_for_the_knees.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Go_for_the_knees.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 80,
         "levelName": "Go for the knees!",
-        "decription": "+1 Physical Accuracy, +10% Physical Weapon Damage and Stability",
+        "decription": "Physical weapon: +1 accuracy and +10% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Guardian.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Guardian.json
@@ -28,7 +28,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Guardian",
-        "decription": "-10% Stability Damage Taken and +10% Damage Resist",
+        "decription": "+10% damage & stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Hardened_Plates.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Hardened_Plates.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 110,
         "levelName": "Hardened Plates",
-        "decription": "-3% Damage Taken, -10% TAC chance, -20% through armor damage taken.",
+        "decription": "+3% damage resistance, +20% through-armor damage resistance, +10% through-armor critical hit resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Hardy.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Hardy.json
@@ -25,7 +25,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Hardy",
-        "decription": "-3% Damage Taken",
+        "decription": "+3% damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Headhunter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Headhunter.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 80,
         "levelName": "Pinpoint",
-        "decription": "+1 Called Shot Accuracy",
+        "decription": "+1 Called Shot accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Heavy_Gunner_CT.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Heavy_Gunner_CT.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 80,
         "levelName": "Heavy Gunner (CT)",
-        "decription": "+1 Center Torso Accuracy, -15% Stability Damage Taken",
+        "decription": "+1 center torso-mounted accuracy, +15% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_High-Pressure-Cooling.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_High-Pressure-Cooling.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 120,
         "levelName": "High-Pressure-Cooling",
-        "decription": "-10% Weapon Heat Generated",
+        "decription": "-10% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Hunter_Killer_Team_Training.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Hunter_Killer_Team_Training.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 60,
         "levelName": "Hunter/Killer Team Training",
-        "decription": "Multi-Target & Breaching Shot Ability",
+        "decription": "Multi-target & Breaching Shot",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_I_See_You.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_I_See_You.json
@@ -27,7 +27,7 @@
       {
         "missionsRequired": 140,
         "levelName": "I See You",
-        "decription": "+1 Sensors/Probe Detection, +10% Sensors Range",
+        "decription": "+1 probe & Adv. sensors, +10% sensor range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Imperceptible.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Imperceptible.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Imperceptible",
-        "decription": "-15% Signature and Visibility",
+        "decription": "-15% visibility & sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Improved_Blazer.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Improved_Blazer.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Improved Blazer",
-        "decription": "-15% Kinetic Damage Taken",
+        "decription": "+15% ballistic & missile damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Indomitable.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Indomitable.json
@@ -22,7 +22,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Indomitable",
-        "decription": "-5% Damage Taken",
+        "decription": "+5% damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Jumpy.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Jumpy.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Jumpy",
-        "decription": "+33% Jump Distance",
+        "decription": "+33% jump distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Leaf_on_the_Wind.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Leaf_on_the_Wind.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Leaf on the Wind!",
-        "decription": "+20% Stability Threshhold and Max",
+        "decription": "+20% unsteady threshold and max stability",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Marksman.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Marksman.json
@@ -19,7 +19,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Marksman",
-        "decription": "+1 HandHeld and BoltOn Accuracy",
+        "decription": "Handheld and bolt-on: +1 accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Missile_Defense.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Missile_Defense.json
@@ -18,7 +18,7 @@
       {
         "missionsRequired": 130,
         "levelName": "Missile Defense",
-        "decription": "-10% Missile Damage Taken",
+        "decription": "+10% missile damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_One_with_the_Machine.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_One_with_the_Machine.json
@@ -24,7 +24,7 @@
       {
         "missionsRequired": 140,
         "levelName": "One with the Machine",
-        "decription": "+1 All Pilot Skills",
+        "decription": "+1 to all pilot skills",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Overclocking.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Overclocking.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Overclocking",
-        "decription": "Headshot Enabled",
+        "decription": "Can target the head with Called Shot",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Pinpoint_Rockets.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Pinpoint_Rockets.json
@@ -21,7 +21,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Pinpoint Rockets",
-        "decription": "+1 Missile Evasion Ignore",
+        "decription": "Missiles: +1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Polly.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Polly.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Polly!",
-        "decription": "+10% Sensors/Sight",
+        "decription": "+10% sight & sensor range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Prototype_Weapons_Master.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Prototype_Weapons_Master.json
@@ -14,7 +14,7 @@
       {
         "missionsRequired": 100,
         "levelName": "Prototype Weapons Master",
-        "decription": "-5% Heat Generated",
+        "decription": "-5% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Push_the_Envelope.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Push_the_Envelope.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 80,
         "levelName": "Push the Envelope",
-        "decription": "-20% Jump Heat Generation",
+        "decription": "-20% jump heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Range_Tracking.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Range_Tracking.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 60,
         "levelName": "Range Tracking",
-        "decription": "+1 Long Range Accuracy, +1 Extreme Range Accuracy",
+        "decription": "+1 long range accuracy, +1 extreme range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Resilience.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Resilience.json
@@ -50,7 +50,7 @@
       {
         "missionsRequired": 145,
         "levelName": "Resilience",
-        "decription": "+5% Crit Resist",
+        "decription": "+5% critical hit resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Shielded.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Shielded.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Shielded",
-        "decription": "-10% Energy Damage Taken",
+        "decription": "+10% energy damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Sieged.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Sieged.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Sieged",
-        "decription": "-3 Recoil with Ranged weapons and -10% Stability Damage taken",
+        "decription": "-3 recoil with ranged weapons, +10% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Size_Does_Not_Matter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Size_Does_Not_Matter.json
@@ -11,7 +11,7 @@
     "affinityLevels": [
       {
         "missionsRequired": 60,
-        "levelName": "Persistance",
+        "levelName": "Persistence",
         "decription": "+1 Guts",
         "affinities": [],
         "effectData": [
@@ -30,7 +30,7 @@
             "nature": "Buff",
             "Description": {
               "Id": "StatusEffect_Cockpit_Skill_Guts",
-              "Name": "Fixed Affinity Size Does Not Matter 60 Persistance: Increased Guts",
+              "Name": "Fixed Affinity Size Does Not Matter 60 Persistence: Increased Guts",
               "Details": "+1 Guts",
               "Icon": "AdvancedTC"
             },

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Skeet_Shooter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Skeet_Shooter.json
@@ -12,7 +12,7 @@
       {
         "missionsRequired": 90,
         "levelName": "Skeet Shooter",
-        "decription": "+1 Evasion Ignore",
+        "decription": "+1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Skilled_Sensor_Operator.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Skilled_Sensor_Operator.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 50,
         "levelName": "Skilled Sensor Operator",
-        "decription": "+1 Probe, +1 Adv. Sensors, +10% Sight and Sensors",
+        "decription": "+1 probe, +1 Adv. sensors, +10% sight & sensor range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Stake_Out.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Stake_Out.json
@@ -15,7 +15,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Stake Out",
-        "decription": "+1 Tactics Skill",
+        "decription": "+1 Tactics",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Stalker.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Stalker.json
@@ -34,7 +34,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Stalker",
-        "decription": "+1 Probe, +1 Local ECM",
+        "decription": "+1 ECM shield, +1 probe",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Superheavy_Mover.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Superheavy_Mover.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Superheavy Mover",
-        "decription": "+25% Run Distance",
+        "decription": "+25% run speed",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Superior_Stabilisation.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Superior_Stabilisation.json
@@ -33,7 +33,7 @@
       {
         "missionsRequired": 150,
         "levelName": "Superior Stabilisation",
-        "decription": "-5% Stability Damage Taken",
+        "decription": "+5% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Swarm.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Swarm.json
@@ -13,7 +13,7 @@
       {
         "missionsRequired": 60,
         "levelName": "Swarm!",
-        "decription": "+1 to Swarm success roll, +1 Melee Accuracy, +10% Melee Damage",
+        "decription": "+1 to swarming rolls, +1 melee accuracy, +10% melee damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Swiss_Cheese.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Swiss_Cheese.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 160,
         "levelName": "Swiss Cheese",
-        "decription": "-2 AC Recoil",
+        "decription": "Autocannon: -2 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Swordmaster.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Swordmaster.json
@@ -75,7 +75,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Swordmaster",
-        "decription": "+1 Accuracy and +5% Physical Weapon Damage and Stability dealt",
+        "decription": "Physical weapon: +1 accuracy and +5% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_The_Large_Bore.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_The_Large_Bore.json
@@ -17,7 +17,7 @@
       {
         "missionsRequired": 160,
         "levelName": "The Large Bore",
-        "decription": "+75% Gauss Crit, +25% Gauss Stab Damage",
+        "decription": "Gauss: +75% critical hit chance and +25% stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Thrasher.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Thrasher.json
@@ -20,7 +20,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Thrasher",
-        "decription": "+1 Punch Accuracy and +5% Punch Damage and Stability dealt",
+        "decription": "Punch: +1 accuracy, +5% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Tuned_Actuators.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Tuned_Actuators.json
@@ -20,7 +20,7 @@
       {
         "missionsRequired": 140,
         "levelName": "Tuned Actuators",
-        "decription": "+1 Punch/Physical Accuracy, +5% Punch/Physical Damage, +1 Arm Mounted Accuracy",
+        "decription": "+1 arm-mounted accuracy. Punch & physical weapon: +1 accuracy and +5% damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Tuned_Battlecomputers.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Tuned_Battlecomputers.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Tuned Battlecomputers",
-        "decription": "+5% Called Shot Chance",
+        "decription": "+5% Called Shot location hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Tuned_Engine.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Tuned_Engine.json
@@ -37,7 +37,7 @@
       {
         "missionsRequired": 150,
         "levelName": "Tuned Engine",
-        "decription": "-5% Heat Generated",
+        "decription": "-5% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Unyielding.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_fixed_Unyielding.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 120,
         "levelName": "Unyielding",
-        "decription": "-20% Stability Damage Taken",
+        "decription": "+20% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_global_Elite.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_global_Elite.json
@@ -4,7 +4,7 @@
   "affinityData": {
     "missionsRequired": 100,
     "levelName": "Master",
-    "decription": "+1 All Pilot Skills (Ignores Bonus Caps.)",
+    "decription": "+1 to all pilot skills (ignores bonus caps)",
     "affinities": [
       {
         "type": "Gunnery",

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_global_Master.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_global_Master.json
@@ -4,7 +4,7 @@
   "affinityData": {
     "missionsRequired": 60,
     "levelName": "Professional",
-    "decription": "+1 Max Evasion",
+    "decription": "+1 max evasion",
     "affinities": [],
     "effectData": [
       {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_global_Veteran.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_global_Veteran.json
@@ -4,7 +4,7 @@
   "affinityData": {
     "missionsRequired": 15,
     "levelName": "Practiced",
-    "decription": "+1 Advanced Sensors, +1 Max Evasion",
+    "decription": "+1 Adv. sensors, +1 max evasion",
     "affinities": [],
     "effectData": [
       {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_global_Warrior.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_global_Warrior.json
@@ -4,7 +4,7 @@
   "affinityData": {
     "missionsRequired": 5,
     "levelName": "Familiar",
-    "decription": "+1 Advanced Sensors, +1 Max Evasion",
+    "decription": "+1 Adv. sensors, +1 max evasion",
     "affinities": [],
     "effectData": [
       {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Long_Range_Targeting.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Long_Range_Targeting.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Advanced Long Range Targeting",
-        "decription": "+1 Long Range Accuracy",
+        "decription": "+1 long range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Medium_Range_Targeting.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Medium_Range_Targeting.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Advanced Medium Range Targeting",
-        "decription": "+1 Medium Range Accuracy",
+        "decription": "+1 medium range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Network.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Network.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Advanced Network",
-        "decription": "All Company units with C3 Master/C3i gear receive non-stacking bonus of +1 Probe.",
+        "decription": "All company units with C3 Master/C3i gear: +1 probe (does not stack)",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Short_Range_Targeting.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Advanced_Short_Range_Targeting.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Advanced Short Range Targeting",
-        "decription": "+1 Short Range Accuracy",
+        "decription": "+1 short range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Airtrooper.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Airtrooper.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Airtrooper",
-        "decription": "+15% Jump Distance",
+        "decription": "+15% jump distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Alacrity.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Alacrity.json
@@ -15,7 +15,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Alacrity",
-        "decription": "+1 Evasion Generated",
+        "decription": "+1 evasion from movement",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_All_Range_Tracking.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_All_Range_Tracking.json
@@ -14,7 +14,7 @@
       {
         "missionsRequired": 40,
         "levelName": "All Range Tracking",
-        "decription": "+1 Accuracy",
+        "decription": "+1 accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_All_Seeing.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_All_Seeing.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "All Seeing",
-        "decription": "+25% Vision Range",
+        "decription": "+25% sight range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Alpha_Mike_Foxtrot.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Alpha_Mike_Foxtrot.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Alpha Mike Foxtrot",
-        "decription": "+20% Jump Attack Damage",
+        "decription": "+20% damage after jumping",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Anti_Mech_Tactics.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Anti_Mech_Tactics.json
@@ -16,8 +16,8 @@
     "affinityLevels": [
       {
         "missionsRequired": 40,
-        "levelName": "Anti Mech Tactics",
-        "decription": "-20% Damage Taken",
+        "levelName": "Anti-'Mech Tactics",
+        "decription": "+20% damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_AutoCannon_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_AutoCannon_Mastery.json
@@ -9,8 +9,8 @@
     "affinityLevels": [
       {
         "missionsRequired": 40,
-        "levelName": "AutoCannon Mastery",
-        "decription": "+1 Accuracy and -1 Recoil for AutoCannons",
+        "levelName": "Autocannon Mastery",
+        "decription": "Autocannon: +1 accuracy and -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Ballistics_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Ballistics_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Ballistics Mastery",
-        "decription": "+1 Accuracy and -1 Recoil for Ballistics",
+        "decription": "Ballistics: +1 accuracy and -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Big_Bad.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Big_Bad.json
@@ -14,7 +14,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Big Bad",
-        "decription": "-1 Lance Resolve Per Round for All Enemies",
+        "decription": "All enemies suffer -1 Resolve per round",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Black_Ops.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Black_Ops.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Black Ops",
-        "decription": "+1 Probe, +1 Local ECM",
+        "decription": "+1 ECM shield, +1 probe",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Black_Ops_Recon.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Black_Ops_Recon.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Black Ops Recon",
-        "decription": "-15% Signature and Visibility and +1 Local ECM",
+        "decription": "+1 ECM shield, -15% visibility & sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Camouflaged.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Camouflaged.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Camouflaged",
-        "decription": "-20% Visibility and Signature",
+        "decription": "-20% visibility & sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Cant_Touch_This.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Cant_Touch_This.json
@@ -14,7 +14,7 @@
     "affinityLevels": [
       {
         "missionsRequired": 40,
-        "levelName": "Cant Touch This",
+        "levelName": "Can't Touch This",
         "decription": "+1 Defense",
         "affinities": [],
         "effectData": [

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Careful_Aim.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Careful_Aim.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Careful Aim",
-        "decription": "+2 Offensive Push Accuracy",
+        "decription": "+2 Offensive Push accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Cased_Components.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Cased_Components.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Cased Components",
-        "decription": "+50% Crit Resistance",
+        "decription": "+50% critical hit resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Cool_Running.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Cool_Running.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Cool Running",
-        "decription": "+6 Heat Sinking, -5% Weapon Heat Generated",
+        "decription": "+6 heat sinking, -5% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Defensive_Duties.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Defensive_Duties.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Rock Solid",
-        "decription": "-15% Stability Damage Received, +5% Unsteady Threshold, 5% Damage Reduction",
+        "decription": "+5% damage resistance, +15% stability damage resistance, +5% unsteady threshold",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Energy_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Energy_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Energy Mastery",
-        "decription": "+1 Accuracy and -1 Recoil for Energy",
+        "decription": "Energy weapons: +1 accuracy and -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_FEAR_ME.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_FEAR_ME.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "FEAR ME!",
-        "decription": "+25% Resolve Gain",
+        "decription": "+25% Resolve generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Facefull_of_Fist.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Facefull_of_Fist.json
@@ -8,8 +8,8 @@
     "affinityLevels": [
       {
         "missionsRequired": 40,
-        "levelName": "Facefull of Fist",
-        "decription": "+1 Punch Accuracy, +5% Punch Damage, +20% Punch Instability",
+        "levelName": "Faceful of Fist",
+        "decription": "Punch: +1 accuracy, +5% damage, and +20% stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Firestarter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Firestarter.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Firestarter",
-        "decription": "+10% Heat Damage",
+        "decription": "+10% heat damage",
         "affinities": [],
         "effectData": [
           {
@@ -44,7 +44,7 @@
       {
         "missionsRequired": 150,
         "levelName": "Firestarter",
-        "decription": "+5% Heat Damage",
+        "decription": "+5% heat damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Fisticuffs.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Fisticuffs.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Fisticuffs",
-        "decription": "+1 Punch Accuracy, +10% Punch Damage, +5% Punch Instability",
+        "decription": "Punch: +1 accuracy, +10% damage, and +5% stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Flexible_Internals.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Flexible_Internals.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Flexible Internals",
-        "decription": "+3 Heat Sinking, -6% Weapon Heat Generated",
+        "decription": "+3 heat sinking, -6% weapon heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_GERONIMO.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_GERONIMO.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "GERONIMO!",
-        "decription": "+15% DFA Damage and Stability, -50% DFA Stability Self Damage ",
+        "decription": "DFA: +15% damage & stability damage and -50% stability self-damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_GO_FASTAH.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_GO_FASTAH.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 40,
         "levelName": "GO FASTAH",
-        "decription": "+1 Walk Move Point",
+        "decription": "+30m walk distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Gauss_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Gauss_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Gauss Mastery",
-        "decription": "+1 Accuracy and +100% Crit for Gauss",
+        "decription": "Gauss: +1 accuracy and +100% critical hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_HandHeld_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_HandHeld_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "HandHeld Mastery",
-        "decription": "+1 Accuracy for HandHelds and Physical Melee",
+        "decription": "Handheld and physical weapons: +1 accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Heavy_Gunner_CT.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Heavy_Gunner_CT.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Heavy Gunner (CT)",
-        "decription": "+1 Center Torso Accuracy, -15% Stability Damage Taken",
+        "decription": "+1 center torso-mounted accuracy, +15% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_High_Command.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_High_Command.json
@@ -15,7 +15,7 @@
       {
         "missionsRequired": 40,
         "levelName": "High Command",
-        "decription": "Company Coordinator: -10% Company Ability Resolve Cost (Stacks up to 3 times)",
+        "decription": "Company Coordinator: -10% ability Resolve cost for all company unit (stacks up to 3 times)",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Hull_Down.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Hull_Down.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Hull Down",
-        "decription": "+1 Defense, -5% Visibility",
+        "decription": "+1 Defense, -5% visibility",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Hunter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Hunter.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Hunter",
-        "decription": "+1 Adv. Sensors, +10% Sight, +5% Sensors",
+        "decription": "+1 Adv. sensors, +10% sight range, +5% sensor range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_I_See_You.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_I_See_You.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "I See You",
-        "decription": "+1 Adv. Sensors, +10% Sensors Range",
+        "decription": "+1 Adv. sensors, +10% sensor range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Im_a_Leaf_on_the_Wind.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Im_a_Leaf_on_the_Wind.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Im a Leaf on the Wind",
-        "decription": "+1 DFA Accuracy, -25% DFA Stability and Damage Taken",
+        "decription": "DFA: +1 accuracy and -25% self-damage & stability self-damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Indomitable.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Indomitable.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Indomitable",
-        "decription": "-5% Damage Taken",
+        "decription": "+5% damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Juggernaut.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Juggernaut.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Juggernaut",
-        "decription": "10% Crit Resistance, -5% Damage Taken",
+        "decription": "+5% damage resistance, +10% critical hit resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Just_a_Flesh_Wound.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Just_a_Flesh_Wound.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Just a Flesh Wound",
-        "decription": "+1 Pilot Bonus Health",
+        "decription": "+1 pilot health",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_LAM_like.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_LAM_like.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "LAM-like",
-        "decription": "+10% JumpDistance, +1 DFA Accuracy, +1 Defense",
+        "decription": "+1 Defense, +1 DFA accuracy, +10% jump distance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Laser_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Laser_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Laser Mastery",
-        "decription": "+1 Accuracy and +100% Crit Laser",
+        "decription": "Lasers: +1 accuracy and +100% critical hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Lifeboat.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Lifeboat.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Lifeboat",
-        "decription": "+1 Guts, +1 Piloting, +1 Pilot Bonus Health",
+        "decription": "+1 Guts, +1 Piloting, +1 pilot health",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_MachineGun_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_MachineGun_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "MachineGun Mastery",
-        "decription": "+1 Accuracy and 1 Evasion ignore for MachineGuns",
+        "decription": "Machine guns: +1 accuracy and 1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Melee_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Melee_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Melee Mastery",
-        "decription": "+1 Accuracy, +10% Damage and Stability dealt for Physical Weapons, Punch and Kick",
+        "decription": "Physical weapons, punch, and kick: +1 accuracy, +10% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Defender.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Missile Defender",
-        "decription": "+25% AMS Accuracy, -10% Missile Damage Taken",
+        "decription": "+10% missile damage resistance, +25% AMS accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Missile_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Missile Mastery",
-        "decription": "+1 Accuracy and -1 Recoil for Missiles",
+        "decription": "Missiles: +1 accuracy and -1 recoil",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Nothing_to_See_Here.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Nothing_to_See_Here.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Nothing to See Here",
-        "decription": "+2 Local ECM, -10% Signature",
+        "decription": "+2 ECM shield, -10% sensor signature",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Obvious_Controls.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Obvious_Controls.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Obvious Controls",
-        "decription": "+1 All Pilot Skills",
+        "decription": "+1 to all pilot skills",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_PPC_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_PPC_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "PPC Mastery",
-        "decription": "+1 Evasion Ignored for PPC",
+        "decription": "PPC: +1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Physical_Weapon_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Physical_Weapon_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Physical Weapon Mastery",
-        "decription": "+1 Accuracy and +15% Physical Weapon Damage and Stability dealt",
+        "decription": "Physical weapons: +1 accuracy and +15% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Pinpoint_Rockets.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Pinpoint_Rockets.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Pinpoint Rockets",
-        "decription": "+1 Missile Evasion Ignore",
+        "decription": "Missiles: +1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Resilience.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Resilience.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Resilience",
-        "decription": "40% Crit Resistance",
+        "decription": "+40% critical hit resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Ronin.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Ronin.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Ronin",
-        "decription": "+1 Physical Weapon Attacks, +10% Physical Weapon Damage and Stability",
+        "decription": "Physical weapons: +1 extra attack, +10% damage & stability damage",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Sharpshooter.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Sharpshooter.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Sharpshooter",
-        "decription": "+1 Long Range Accuracy, +1 Extreme Range Accuracy",
+        "decription": "+1 long range accuracy, +1 extreme range accuracy",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Smart_Warheads.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Smart_Warheads.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Smart Warheads",
-        "decription": "+1 Missile Evasion Ignore, +25% Missile Crits",
+        "decription": "Missiles: +1 evasion ignored and +25% critical hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Steady_Aim.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Steady_Aim.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Steady Aim",
-        "decription": "+1 Gunnery, +1 Offensive Push Accuracy, +10% Called Shot Chance",
+        "decription": "+1 Gunnery, +1 Offensive Push accuracy, +10% Called Shot location hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Strength_of_the_Faithful.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Strength_of_the_Faithful.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Strength of the Faithful",
-        "decription": "+1 Guts, +2 Pilot Bonus Health",
+        "decription": "+1 Guts, +2 pilot health",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_AutoCannons.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_AutoCannons.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Supercooled AutoCannons",
-        "decription": "-10% Heat generated with AutoCannons",
+        "decription": "Autocannon: -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_Laser.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_Laser.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Supercooled Laser",
-        "decription": "-10% Heat generated with Laser",
+        "decription": "Lasers: -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_Missiles.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_Missiles.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Supercooled Missiles",
-        "decription": "-10% Heat generated with Missiles",
+        "decription": "Missiles: -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_PPC.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Supercooled_PPC.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Supercooled PPC",
-        "decription": "-10% Heat generated with PPC",
+        "decription": "PPC: -10% heat generation",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_The_One_Truth.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_The_One_Truth.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "The One Truth",
-        "decription": "+2 Offensive Push Accuracy, +5% Called Shot Bonus",
+        "decription": "+2 Offensive Push accuracy, +5% Called Shot location hit chance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Unyielding.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Unyielding.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Unyielding",
-        "decription": "-20% Stability Damage Taken",
+        "decription": "+20% stability damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Vector_Plotting.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Vector_Plotting.json
@@ -11,7 +11,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Vector Plotting",
-        "decription": "+1 Evasion Ignore",
+        "decription": "+1 evasion ignored",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_WITNESS_ME.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_WITNESS_ME.json
@@ -10,7 +10,7 @@
       {
         "missionsRequired": 40,
         "levelName": "WITNESS ME!",
-        "decription": "+1 All Pilot Skills",
+        "decription": "+1 to all pilot skills",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Weapons_Bay_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Weapons_Bay_Mastery.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Weapons Bay Mastery",
-        "decription": "+1 Accuracy and -25% Minimum Range for [Bay] Weapons",
+        "decription": "Bay weapons: +1 accuracy and -25% minimum range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Well_Built.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Well_Built.json
@@ -9,8 +9,8 @@
     "affinityLevels": [
       {
         "missionsRequired": 40,
-        "levelName": "Well-Built",
-        "decription": "-3% Damage Taken, +25% TAD Resist",
+        "levelName": "Well-built",
+        "decription": "+3% damage resistance, +25% through-armor damage resistance",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Wing_Mounted_Mastery.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Wing_Mounted_Mastery.json
@@ -8,8 +8,8 @@
     "affinityLevels": [
       {
         "missionsRequired": 40,
-        "levelName": "Wing Mounted Mastery",
-        "decription": "-25% Minimum Range and +25% Critical Hit chance for Wing Mounted Weapons",
+        "levelName": "Wing-mounted Mastery",
+        "decription": "Wing-mounted weapons: +25% critical hit chance and -25% minimum range",
         "affinities": [],
         "effectData": [
           {

--- a/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Zeroed_In.json
+++ b/Core/MechAffinity/AffinityDefs/AffinityDef_quirk_Zeroed_In.json
@@ -9,7 +9,7 @@
       {
         "missionsRequired": 40,
         "levelName": "Zeroed In",
-        "decription": "+0.15 Clustering, +10% Called Shot Chance, +1 Offensive Push Accuracy",
+        "decription": "+10% Called Shot location hit chance, +1 Offensive Push accuracy, +0.15 grouping",
         "affinities": [],
         "effectData": [
           {


### PR DESCRIPTION
Edited almost all of the Affinity defs to make them more internally consistent and easier to read. 


All affinities now consistently use the terms:

- walk distance (instead of MP, movement point, hex moved and other variants)
- run speed (instead of run multiplier etc.)
- Multi-target (i.e. referring to the ability, instead of Multi-Tracker)
- max evasion (it was variably max or maximum)
- evasion from movement (instead of evasion generated etc.)
- grouping (instead of clustering)
- damage resistance (instead of damage taken)
- critical hit resistance
- through-armor damage & through-armor critical hit
- heat generation (instead of Heat Generated)
- heat sinking (instead of Heat Sink Capacity etc.)
- sight range (instead of Vision etc.)
- sensor range (instead of just Sensors)
- ECM shield (instead of Local ECM)
and so on.


All affinities that provide bonuses for given weapon or attack types have been formatted into 

`Weapon type: bonus, bonus, bonus, and bonus`
to improve their readability and avoid repeating the type for each bonus separately.

Also fixed a couple of errors where the description was incorrect compared to the effect listed below.