### PR TITLE
Ability text edits

### DIFF
--- a/Core/Abilifier/TagAbilities/AbilityDefCMD_MechDrop_Liquidforce.json
+++ b/Core/Abilifier/TagAbilities/AbilityDefCMD_MechDrop_Liquidforce.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_MechDrop_Liquidforce",
     "Name": "BATTLEMECH AIRDROP",
-    "Details": "DEPLOYS A BATTLEMECH FROM THE ARGO'S STORAGE BAYS UNDER ALLIED CONTROL.\r\n\r\n <b><color=#8080ff>Resolve Cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 50 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call upto three BattleMechs per contract!</color></b>",
+    "Details": "Deploys a 'Mech from the Argo's storage bays under allied control.\r\n\r\n <b><color=#8080ff>Resolve Cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 50 000 C-bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call up to three 'Mechs per contract!</color></b>",
     "Icon": "mounted-knight"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/Abilifier/TagAbilities/AbilityDefCMD_MechDrop_Narf.json
+++ b/Core/Abilifier/TagAbilities/AbilityDefCMD_MechDrop_Narf.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_MechDrop_Narf",
     "Name": "BATTLEMECH AIRDROP",
-    "Details": "DEPLOYS A BATTLEMECH FROM THE ARGO'S STORAGE BAYS UNDER ALLIED CONTROL.\r\n\r\n <b><color=#8080ff>Resolve Cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 100 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in one BattleMech per contract!</color></b>",
+    "Details": "Deploys a 'Mech from the Argo's storage bays under allied control.\r\n\r\n <b><color=#8080ff>Resolve cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 100 000 C-bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in one 'Mech per contract!</color></b>",
     "Icon": "mounted-knight"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Alekto.json
+++ b/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Alekto.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_Strafe_Alekto",
     "Name": "STRAFE",
-    "Details": "CALLS IN A STRAFING RUN.\r\n\r\n <b><color=#099ff2>Has a 3 turn cooldown!\r\n\r\n <b><color=#8080ff>Resolve Cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 15 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in two strafes per contract! The fighter attacks in two waves, 30 Initiative Phases apart!</color></b>\r\n\r\n ",
+    "Details": "Calls in a strafing run.\r\n\r\n <b><color=#099ff2>Has a 3 turn cooldown!\r\n\r\n <b><color=#8080ff>Resolve cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 15 000 C-bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in two strafes per contract! The fighter attacks in two waves, 30 Initiative Phases apart!</color></b>\r\n\r\n ",
     "Icon": "strafe"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Fiona.json
+++ b/Core/Abilifier/TagAbilities/AbilityDefCMD_Strafe_Fiona.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_Strafe_Fiona",
     "Name": "STRAFE",
-    "Details": "CALLS IN A STRAFING RUN.\r\n\r\n <b><color=#099ff2>Has a 3 turn cooldown!\r\n\r\n <b><color=#8080ff>Resolve Cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 15 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in two strafes per contract! The fighter attacks in two waves, 30 Initiative Phases apart!</color></b>\r\n\r\n ",
+    "Details": "Calls in a strafing run.\r\n\r\n <b><color=#099ff2>Has a 3 turn cooldown!\r\n\r\n <b><color=#8080ff>Resolve Cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 15 000 C-bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in two strafes per contract! The fighter attacks in two waves, 30 Initiative Phases apart!</color></b>\r\n\r\n ",
     "Icon": "strafe"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/Abilifier/TagAbilities/AbilityDefCMD_TankDrop_Cargo.json
+++ b/Core/Abilifier/TagAbilities/AbilityDefCMD_TankDrop_Cargo.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_TankDrop_Cargo",
     "Name": "TANK AIRDROP",
-    "Details": "DEPLOYS A TANK FROM THE ARGO'S STORAGE BAYS UNDER YOUR CONTROL.\r\n\r\n <b><color=#8080ff>Resolve Cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 100 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in one Tank per contract!</color></b>",
+    "Details": "Deploys a tank from the Argo's storage bays under your control.\r\n\r\n <b><color=#8080ff>Resolve cost: {10}</color></b>\r\n\r\n <b><color=#e11919>Costs 100 000 C-bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in one tank per contract!</color></b>",
     "Icon": "mounted-knight"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/Abilifier/TagAbilities/AbilityDef_AAStance.json
+++ b/Core/Abilifier/TagAbilities/AbilityDef_AAStance.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_AAStance",
     "Name": "AA Stance",
-    "Details": "Use this Ability disrupt incoming enemy airstrikes.",
+    "Details": "ACTION: Use this ability disrupt incoming enemy airstrikes.\n\nThis brings all the unit's weapons with an Anti-Air Factor to bear against the strafing fighter in order to try and stop the attack run.\n\nCovers units up to 900 meters away.",
     "Icon": "targeting"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/Abilifier/TagAbilities/AbilityDef_AAStance.json
+++ b/Core/Abilifier/TagAbilities/AbilityDef_AAStance.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_AAStance",
     "Name": "AA Stance",
-    "Details": "ACTION: Use this ability disrupt incoming enemy airstrikes.\n\nThis brings all the unit's weapons with an Anti-Air Factor to bear against the strafing fighter in order to try and stop the attack run.\n\nCovers units up to 900 meters away.",
+    "Details": "ACTION: Attempt to disrupt incoming enemy airstrikes.\n\nThis brings all the unit's weapons with an Anti-Air Factor to bear against the strafing fighter in order to try and stop the attack run.\n\nCovers friendly units up to 900 meters away.",
     "Icon": "targeting"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/Abilifier/TagAbilities/AbilityDef_CarefulManeuvers.json
+++ b/Core/Abilifier/TagAbilities/AbilityDef_CarefulManeuvers.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_CarefulManeuvers",
     "Name": "CAREFUL MANEUVERS",
-    "Details": "ACTION: Reduces movement extremely heavily, bringing it to a crawl, but allows the unit to ignore all pathing and terrain restrictions for the turn in order to unstick itself from bad terrain.",
+    "Details": "ACTION: Reduce movement to a crawl, but allow the unit to ignore all pathing and terrain restrictions for the turn in order to unstick from bad terrain.",
     "Icon": "journey"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/Abilifier/TagAbilities/AbilityDef_CarefulManeuvers.json
+++ b/Core/Abilifier/TagAbilities/AbilityDef_CarefulManeuvers.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_CarefulManeuvers",
     "Name": "CAREFUL MANEUVERS",
-    "Details": "ACTION: Reduce movement to a crawl, but allow the unit to ignore all pathing and terrain restrictions for the turn in order to unstick from bad terrain.",
+    "Details": "ACTION: Reduce movement to a crawl, but allow the unit to ignore all pathing and terrain restrictions for the turn in order to get unstuck.",
     "Icon": "journey"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/Abilifier/TagAbilities/AbilityDef_Command.json
+++ b/Core/Abilifier/TagAbilities/AbilityDef_Command.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_Command",
     "Name": "COMMANDER",
-    "Details": "+1 Ini, +1 Resolve per round, +1 Tactics, +25% Panic Saves to allies within 5 hex radius. Does not stack.",
+    "Details": "+1 Initiative, +1 Resolve per round, +1 Tactics, and +25% to panic saves to allies within 5 hex radius. Does not stack.",
     "Icon": "uixSvgIcon_ability_mastertactician"
   },
   "ShortDesc": "Command",
@@ -117,7 +117,7 @@
           "nature": "Buff",
           "Description": {
             "Id": "Pilot_Command_Panic",
-            "Name": "COMMANDER Aura: Decreased Allies Panic Chance",
+            "Name": "COMMANDER Aura: Decreased Allies panic chance",
             "Details": "Pilot_Command_Panic",
             "Icon": "uixSvgIcon_status_ECM-missileDef"
           },

--- a/Core/Abilifier/TagAbilities/AbilityDef_FirstAid.json
+++ b/Core/Abilifier/TagAbilities/AbilityDef_FirstAid.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_FirstAid",
     "Name": "FIRST AID",
-    "Details": "ACTION: Use this ability to recover 2 points of lost blood and improve panic rolls for 1 turn.\nCan only be used as the first action and ends turn.",
+    "Details": "ACTION: Administer first aid to recover 2 points of lost blood and improve panic rolls for 1 turn.\r\n\r\n<color=#F79B26>Can only be used as the first action and ends your turn.</color>",
     "Icon": "blood"
   },
   "ActivationTime": "ConsumedByMovement",
@@ -53,7 +53,7 @@
       "Description": {
         "Id": "FirstAidCalm",
         "Name": "Ability First Aid: Decreased panic chance",
-        "Details": "Pilot has administered First Aid and is feeling warm and fuzzy. (+50% to panic saves)",
+        "Details": "Pilot has administered first aid and is feeling warm and fuzzy (+50% to panic saves)",
         "Icon": "uixSvgIcon_equipment_Cockpit"
       },
       "statisticData": {

--- a/Core/Abilifier/TagAbilities/AbilityDef_FirstAid.json
+++ b/Core/Abilifier/TagAbilities/AbilityDef_FirstAid.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_FirstAid",
     "Name": "FIRST AID",
-    "Details": "Use this Ability to recover 2 points of lost blood and improve panic rolls for 1 turn.",
+    "Details": "ACTION: Use this ability to recover 2 points of lost blood and improve panic rolls for 1 turn.\nCan only be used as the first action and ends turn.",
     "Icon": "blood"
   },
   "ActivationTime": "ConsumedByMovement",
@@ -52,7 +52,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "FirstAidCalm",
-        "Name": "Ability First Aid: Decreased Panic Chance",
+        "Name": "Ability First Aid: Decreased panic chance",
         "Details": "Pilot has administered First Aid and is feeling warm and fuzzy. (+50% to panic saves)",
         "Icon": "uixSvgIcon_equipment_Cockpit"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG5Bandit.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG5Bandit.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityG5Bandit",
     "Name": "BANDIT",
-    "Details": "PASSIVE: +25% critical hit chance. +0.5 to clustering modifiers",
+    "Details": "PASSIVE: +25% critical hit chance, +0.5 to grouping modifiers",
     "Icon": "bandit"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -24,7 +24,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BanditCrits",
-        "Name": "Ability Bandit: Increased critical hit chance",
+        "Name": "Ability Bandit: Increased Critical Hit Chance",
         "Details": "Missile weapon attacks have their hit improved by 3.",
         "Icon": "AdvancedTC"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG5Bandit.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG5Bandit.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityG5Bandit",
     "Name": "BANDIT",
-    "Details": "PASSIVE: +25% Critical Hit Chance. +0.5 to Clustering Roll modifiers.",
+    "Details": "PASSIVE: +25% critical hit chance. +0.5 to clustering modifiers",
     "Icon": "bandit"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -24,7 +24,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BanditCrits",
-        "Name": "Ability Bandit: Increased Critical Hit Chance",
+        "Name": "Ability Bandit: Increased critical hit chance",
         "Details": "Missile weapon attacks have their hit improved by 3.",
         "Icon": "AdvancedTC"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG5FocusFire.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG5FocusFire.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityG5FocusFire",
     "Name": "FOCUS FIRE",
-    "Details": "PASSIVE: +6% Called Shot Multiplier. -1 Recoil.",
+    "Details": "PASSIVE: +6% Called Shot location hit chance. -1 recoil",
     "Icon": "focusfire"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -24,7 +24,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "FocusFireRecoil",
-        "Name": "Ability Focus Fire: Decreased Recoil",
+        "Name": "Ability Focus Fire: Decreased recoil",
         "Details": "Ballistic recoil penalties reduced by 1",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },
@@ -48,7 +48,7 @@
       "effectType": "StatisticEffect",
       "Description": {
         "Id": "BanditCalledShot",
-        "Name": "Ability Focus Fire: Increased Called Shot Targeted Location Hit Chance",
+        "Name": "Ability Focus Fire: Increased Called Shot targeted location hit chance",
         "Details": "Called Shots twice as reliable",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG5FocusFire.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG5FocusFire.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityG5FocusFire",
     "Name": "FOCUS FIRE",
-    "Details": "PASSIVE: +6% Called Shot location hit chance. -1 recoil",
+    "Details": "PASSIVE: +6% Called Shot location hit chance, -1 recoil",
     "Icon": "focusfire"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -24,7 +24,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "FocusFireRecoil",
-        "Name": "Ability Focus Fire: Decreased recoil",
+        "Name": "Ability Focus Fire: Decreased Recoil",
         "Details": "Ballistic recoil penalties reduced by 1",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },
@@ -48,7 +48,7 @@
       "effectType": "StatisticEffect",
       "Description": {
         "Id": "BanditCalledShot",
-        "Name": "Ability Focus Fire: Increased Called Shot targeted location hit chance",
+        "Name": "Ability Focus Fire: Increased Called Shot Targeted Location Hit Chance",
         "Details": "Called Shots twice as reliable",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG8ControlledBursts.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG8ControlledBursts.json
@@ -54,7 +54,7 @@
       "effectType": "StatisticEffect",
       "Description": {
         "Id": "FocusFireRecoil",
-        "Name": "Ability Controlled Bursts: Decreased recoil",
+        "Name": "Ability Controlled Bursts: Decreased Recoil",
         "Details": "Ballistic recoil penalties reduced by 1",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },
@@ -81,7 +81,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Warlord-Heat2",
-        "Name": "Ability Controlled Bursts: Decreased heat generation",
+        "Name": "Ability Controlled Bursts: Decreased Heat Generated",
         "Details": "-50 Heat",
         "Icon": "uixSvgIcon_skullAtlas"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG8ControlledBursts.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG8ControlledBursts.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityG8ControlledBursts",
     "Name": "CONTROLLED BURSTS",
-    "Details": "ACTION: Gain -10% Heat Generated, -1 Recoil, -20% Jam Chance Multiplier for 2 Turns. 3 Turn Cooldown.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: Gain -10% heat generation, -1 recoil, and -20% jam chance multiplier for 2 turns. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "controlledbursts"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -54,7 +54,7 @@
       "effectType": "StatisticEffect",
       "Description": {
         "Id": "FocusFireRecoil",
-        "Name": "Ability Controlled Bursts: Decreased Recoil",
+        "Name": "Ability Controlled Bursts: Decreased recoil",
         "Details": "Ballistic recoil penalties reduced by 1",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },
@@ -81,7 +81,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Warlord-Heat2",
-        "Name": "Ability Controlled Bursts: Decreased Heat Generated",
+        "Name": "Ability Controlled Bursts: Decreased heat generation",
         "Details": "-50 Heat",
         "Icon": "uixSvgIcon_skullAtlas"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG8Warlord.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG8Warlord.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityG8Warlord",
     "Name": "WARLORD",
-    "Details": "ACTION: Gain +1 Accuracy, +1 to Clustering Roll modifiers, +10% to Called Shot Multiplier. 3 Turn Cooldown.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: Gain +1 accuracy, +1 to clustering modifiers, +10% to Called Shot location hit chance. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_skullAtlas"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -27,8 +27,8 @@
       "nature": "Buff",
       "Description": {
         "Id": "Warlord-TO-HIT",
-        "Name": "Ability Warlord: Improved Accuracy",
-        "Details": "+1 Accuracy",
+        "Name": "Ability Warlord: Improved accuracy",
+        "Details": "+1 accuracy",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {
@@ -53,7 +53,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "WarlordCalledShot",
-        "Name": "Ability Warlord: Increased Called Shot Targeted Location Hit Chance",
+        "Name": "Ability Warlord: Increased Called Shot targeted location hit chance",
         "Details": "Called Shots twice as reliable",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityG8Warlord.json
+++ b/Core/Abilifier/TreeAbilities/AbilityG8Warlord.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityG8Warlord",
     "Name": "WARLORD",
-    "Details": "ACTION: Gain +1 accuracy, +1 to clustering modifiers, +10% to Called Shot location hit chance. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: Gain +1 accuracy, +1 to grouping modifiers, +10% to Called Shot location hit chance. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_skullAtlas"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -27,8 +27,8 @@
       "nature": "Buff",
       "Description": {
         "Id": "Warlord-TO-HIT",
-        "Name": "Ability Warlord: Improved accuracy",
-        "Details": "+1 accuracy",
+        "Name": "Ability Warlord: Improved Accuracy",
+        "Details": "+1 Accuracy",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {
@@ -53,7 +53,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "WarlordCalledShot",
-        "Name": "Ability Warlord: Increased Called Shot targeted location hit chance",
+        "Name": "Ability Warlord: Increased Called Shot Targeted Location Hit Chance",
         "Details": "Called Shots twice as reliable",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityGu5Hardcase.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu5Hardcase.json
@@ -26,7 +26,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "StatusEffect-Defense_StabilityAll-T1",
-        "Name": "Ability Hardcase: Decreased Stability damage Taken",
+        "Name": "Ability Hardcase: Decreased Stability Damage Taken",
         "Details": "Incoming stability damage reduced by 10%.",
         "Icon": "uixSvgIcon_equipment_Gyro"
       },
@@ -52,7 +52,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "HardCaseCalm",
-        "Name": "Ability Hardcase: Decreased panic Chance",
+        "Name": "Ability Hardcase: Decreased Panic Chance",
         "Details": "Pilot has nerves of steel",
         "Icon": "uixSvgIcon_equipment_Cockpit"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityGu5Hardcase.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu5Hardcase.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu5Hardcase",
     "Name": "HARDCASE",
-    "Details": "PASSIVE: -15% Stability Damage Taken, +25% Panic Saves",
+    "Details": "PASSIVE: +15% stability damage resistance, +25% to panic save rolls",
     "Icon": "hardcase"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -26,7 +26,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "StatusEffect-Defense_StabilityAll-T1",
-        "Name": "Ability Hardcase: Decreased Stability Damage Taken",
+        "Name": "Ability Hardcase: Decreased Stability damage Taken",
         "Details": "Incoming stability damage reduced by 10%.",
         "Icon": "uixSvgIcon_equipment_Gyro"
       },
@@ -52,7 +52,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "HardCaseCalm",
-        "Name": "Ability Hardcase: Decreased Panic Chance",
+        "Name": "Ability Hardcase: Decreased panic Chance",
         "Details": "Pilot has nerves of steel",
         "Icon": "uixSvgIcon_equipment_Cockpit"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityGu5Juggernaut.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu5Juggernaut.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu5Juggernaut",
     "Name": "JUGGERNAUT",
-    "Details": "PASSIVE: Braces after melee and DFA. +1 Initiative, +1 injury & melee resist.",
+    "Details": "PASSIVE: Braces after melee and DFA. -1 to Ini penalty resulting from being injured or hit with melee",
     "Icon": "uixSvgIcon_juggernaut"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityGu5Juggernaut.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu5Juggernaut.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu5Juggernaut",
     "Name": "JUGGERNAUT",
-    "Details": "PASSIVE: Braces after Melee and DFA. +1 Ini Injury&Melee Resist.",
+    "Details": "PASSIVE: Braces after melee and DFA. +1 Initiative, +1 injury & melee resist.",
     "Icon": "uixSvgIcon_juggernaut"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityGu5Leadfoot.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu5Leadfoot.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu5Leadfoot",
     "Name": "LEADFOOT",
-    "Details": "PASSIVE (VEHICLE ONLY): +10% movement speed. +30m sprint distance. <color=#ff0000>(Does NOT apply to 'Mechs or BA).</color>",
+    "Details": "PASSIVE (VEHICLES ONLY): +10% movement speed, +30m sprint distance. <color=#ffcc00>(Does NOT apply to 'Mechs or BA)</color>",
     "Icon": "leadfoot"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityGu5Leadfoot.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu5Leadfoot.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu5Leadfoot",
     "Name": "LEADFOOT",
-    "Details": "PASSIVE (VEHICLE): +10% Movement Distance. +1 Hex Sprint distance. <color=#ff0000>(Does NOT apply to mechs or BA).</color>",
+    "Details": "PASSIVE (VEHICLE ONLY): +10% movement speed. +30m sprint distance. <color=#ff0000>(Does NOT apply to 'Mechs or BA).</color>",
     "Icon": "leadfoot"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityGu8Berserker.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu8Berserker.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu8Berserker",
     "Name": "BERSERKER",
-    "Details": "ACTION: For ALL Melee Attacks, +1 Accuracy, +20% Damage, -10% Charge Self Damage, -15% DFA Self Damage. 3 turn cooldown.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: All melee attacks gain +1 accuracy and +20% damage. -10% charge self-damage, -15% DFA self-damage. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "berserker"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -27,7 +27,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyPunch",
-        "Name": "Ability Berserker: Improved Punch Hit Chance",
+        "Name": "Ability Berserker: Improved punch hit chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -51,7 +51,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyKick",
-        "Name": "Ability Berserker: Improved Kick Hit Chance",
+        "Name": "Ability Berserker: Improved kick hit chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -75,7 +75,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyPhys",
-        "Name": "Ability Berserker: Improved Physical Weapon Hit Chance",
+        "Name": "Ability Berserker: Improved Physical Weapon hit chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -99,7 +99,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyDFA",
-        "Name": "Ability Berserker: Improved DFA Hit Chance",
+        "Name": "Ability Berserker: Improved DFA hit chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -123,7 +123,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyCharge",
-        "Name": "Ability Berserker: Improved Charge Hit Chance",
+        "Name": "Ability Berserker: Improved charge hit chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -147,7 +147,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerSelfDamageCharge",
-        "Name": "Ability Berserker: Decreased Charge Self Damage",
+        "Name": "Ability Berserker: Decreased charge self-damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -171,7 +171,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerSelfDamageDFA",
-        "Name": "Ability Berserker: Decreased DFA Self Damage",
+        "Name": "Ability Berserker: Decreased DFA self-damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -195,7 +195,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamageCharge",
-        "Name": "Ability Berserker: Increased Charge Damage",
+        "Name": "Ability Berserker: Increased charge damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -219,7 +219,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamageDFA",
-        "Name": "Ability Berserker: Increased DFA Damage",
+        "Name": "Ability Berserker: Increased DFA damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -243,7 +243,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamageKick",
-        "Name": "Ability Berserker: Increased Kick Damage",
+        "Name": "Ability Berserker: Increased kick damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -267,7 +267,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamagePunch",
-        "Name": "Ability Berserker: Increased Punch Damage",
+        "Name": "Ability Berserker: Increased punch damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -291,7 +291,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamagePhys",
-        "Name": "Ability Berserker: Increased Physical Weapon Damage",
+        "Name": "Ability Berserker: Increased Physical Weapon damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -315,7 +315,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamageCharge",
-        "Name": "Ability Berserker: Increased Charge Stability Damage",
+        "Name": "Ability Berserker: Increased charge Stability damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -339,7 +339,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamageDFA",
-        "Name": "Ability Berserker: Increased DFA Stability Damage",
+        "Name": "Ability Berserker: Increased DFA Stability damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -363,7 +363,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamageKick",
-        "Name": "Ability Berserker: Increased Kick Stability Damage",
+        "Name": "Ability Berserker: Increased kick Stability damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -387,7 +387,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamagePunch",
-        "Name": "Ability Berserker: Increased Punch Stability Damage",
+        "Name": "Ability Berserker: Increased punch Stability damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -411,7 +411,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamagePhys",
-        "Name": "Ability Berserker: Increased Physical Weapon Stability Damage",
+        "Name": "Ability Berserker: Increased Physical Weapon Stability damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityGu8Berserker.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu8Berserker.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu8Berserker",
     "Name": "BERSERKER",
-    "Details": "ACTION: All melee attacks gain +1 accuracy and +20% damage. -10% charge self-damage, -15% DFA self-damage. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: All melee attacks gain +1 accuracy and +20% damage. -10% to charge self-damage, -15% to DFA self-damage. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "berserker"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -27,7 +27,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyPunch",
-        "Name": "Ability Berserker: Improved punch hit chance",
+        "Name": "Ability Berserker: Improved Punch Hit Chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -51,7 +51,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyKick",
-        "Name": "Ability Berserker: Improved kick hit chance",
+        "Name": "Ability Berserker: Improved Kick Hit Chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -75,7 +75,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyPhys",
-        "Name": "Ability Berserker: Improved Physical Weapon hit chance",
+        "Name": "Ability Berserker: Improved Physical Weapon Hit Chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -99,7 +99,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyDFA",
-        "Name": "Ability Berserker: Improved DFA hit chance",
+        "Name": "Ability Berserker: Improved DFA Hit Chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -123,7 +123,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerAccuracyCharge",
-        "Name": "Ability Berserker: Improved charge hit chance",
+        "Name": "Ability Berserker: Improved Charge Hit Chance",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -147,7 +147,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerSelfDamageCharge",
-        "Name": "Ability Berserker: Decreased charge self-damage",
+        "Name": "Ability Berserker: Decreased Charge Self Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -171,7 +171,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerSelfDamageDFA",
-        "Name": "Ability Berserker: Decreased DFA self-damage",
+        "Name": "Ability Berserker: Decreased DFA Self Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -195,7 +195,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamageCharge",
-        "Name": "Ability Berserker: Increased charge damage",
+        "Name": "Ability Berserker: Increased Charge Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -219,7 +219,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamageDFA",
-        "Name": "Ability Berserker: Increased DFA damage",
+        "Name": "Ability Berserker: Increased DFA Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -243,7 +243,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamageKick",
-        "Name": "Ability Berserker: Increased kick damage",
+        "Name": "Ability Berserker: Increased Kick Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -267,7 +267,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamagePunch",
-        "Name": "Ability Berserker: Increased punch damage",
+        "Name": "Ability Berserker: Increased Punch Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -291,7 +291,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerDamagePhys",
-        "Name": "Ability Berserker: Increased Physical Weapon damage",
+        "Name": "Ability Berserker: Increased Physical Weapon Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -315,7 +315,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamageCharge",
-        "Name": "Ability Berserker: Increased charge Stability damage",
+        "Name": "Ability Berserker: Increased Charge Stability Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -339,7 +339,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamageDFA",
-        "Name": "Ability Berserker: Increased DFA Stability damage",
+        "Name": "Ability Berserker: Increased DFA Stability Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -363,7 +363,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamageKick",
-        "Name": "Ability Berserker: Increased kick Stability damage",
+        "Name": "Ability Berserker: Increased Kick Stability Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -387,7 +387,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamagePunch",
-        "Name": "Ability Berserker: Increased punch Stability damage",
+        "Name": "Ability Berserker: Increased Punch Stability Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },
@@ -411,7 +411,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "BerserkerStabDamagePhys",
-        "Name": "Ability Berserker: Increased Physical Weapon Stability damage",
+        "Name": "Ability Berserker: Increased Physical Weapon Stability Damage",
         "Details": "Random babble what this does",
         "Icon": "uixSvgIcon_equipment_ActuatorLeg"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityGu8CoolVent.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu8CoolVent.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu8CoolVent",
     "Name": "COOLANT VENT",
-    "Details": "ACTION: Vent Coolant to gain +60 HeatSinkCapacity. Afterwards Cooling is reduced by 30 for 3 Turns, recovering 10 per turn. 4 Turn Cooldown.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: Vent coolant to gain sink 60 heat. Afterwards, cooling is reduced by 30, and recovers 10 per turn. 4 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_ability_coolantVent"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -58,7 +58,7 @@
       "Description": {
         "Id": "CoolantVentPenalty3",
         "Name": "Ability Coolant Vent: Decreased Cooling 3",
-        "Details": "+10 Heat Generated",
+        "Details": "+10 heat generation",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {
@@ -87,7 +87,7 @@
       "Description": {
         "Id": "CoolantVentPenalty2",
         "Name": "Ability Coolant Vent: Decreased Cooling",
-        "Details": "+10 Heat Generated",
+        "Details": "+10 heat generation",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {
@@ -116,7 +116,7 @@
       "Description": {
         "Id": "CoolantVentPenalty3",
         "Name": "Ability Coolant Vent: Decreased Cooling 3 3",
-        "Details": "+10 Heat Generated",
+        "Details": "+10 heat generation",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {

--- a/Core/Abilifier/TreeAbilities/AbilityGu8CoolVent.json
+++ b/Core/Abilifier/TreeAbilities/AbilityGu8CoolVent.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityGu8CoolVent",
     "Name": "COOLANT VENT",
-    "Details": "ACTION: Vent coolant to gain sink 60 heat. Afterwards, cooling is reduced by 30, and recovers 10 per turn. 4 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: Vent coolant to sink 60 heat. Afterwards, cooling is reduced by 30 for 3 turns, recovering 10 per turn. 4 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_ability_coolantVent"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -58,7 +58,7 @@
       "Description": {
         "Id": "CoolantVentPenalty3",
         "Name": "Ability Coolant Vent: Decreased Cooling 3",
-        "Details": "+10 heat generation",
+        "Details": "+10 Heat Generated",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {
@@ -87,7 +87,7 @@
       "Description": {
         "Id": "CoolantVentPenalty2",
         "Name": "Ability Coolant Vent: Decreased Cooling",
-        "Details": "+10 heat generation",
+        "Details": "+10 Heat Generated",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {
@@ -116,7 +116,7 @@
       "Description": {
         "Id": "CoolantVentPenalty3",
         "Name": "Ability Coolant Vent: Decreased Cooling 3 3",
-        "Details": "+10 heat generation",
+        "Details": "+10 Heat Generated",
         "Icon": "uixSvgIcon_skullAtlas"
       },
       "statisticData": {

--- a/Core/Abilifier/TreeAbilities/AbilityP5Awareness.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP5Awareness.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP5Awareness",
     "Name": "AWARENESS",
-    "Details": "PASSIVE: Evasive Pips are Immune to Sensor Lock. +1 Initiative",
+    "Details": "PASSIVE: Evasive Pips are immune to Sensor Lock. +1 Initiative",
     "Icon": "awareness"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityP5Escapist.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP5Escapist.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP5Escapist",
     "Name": "ESCAPIST",
-    "Details": "PASSIVE: +1 evasion from movement. +1 max evasion",
+    "Details": "PASSIVE: +1 evasion from movement, +1 max evasion",
     "Icon": "escapist"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityP5Escapist.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP5Escapist.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP5Escapist",
     "Name": "ESCAPIST",
-    "Details": "PASSIVE: +1 Evasion generated from movement. +1 Max Evasision",
+    "Details": "PASSIVE: +1 evasion from movement. +1 max evasion",
     "Icon": "escapist"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityP88HullAngle.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP88HullAngle.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP88HullAngle",
     "Name": "HULL DOWN",
-    "Details": "ACTION: Cannot be used if you have moved this turn. Set movement to 0 this turn. Reduce all incoming damage by 75% for 1 turn and 25% on the second turn.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: Remain where you are, but angle yourself to glance off incoming attacks. Reduces all incoming damage by 50% for the first and 25% for the second turn.\n<b><color=#8080ff>Resolve cost: {10}</color></b>\nCan only be used before moving.",
     "Icon": "shield-reflect"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -86,7 +86,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "StatusEffect-AbilityGu8-DamageReduction50",
-        "Name": "Ability Hull Down: Decreased Damage Taken 50",
+        "Name": "Ability Hull Down: Decreased damage taken 50",
         "Details": "",
         "Icon": "shield-reflect"
       },
@@ -113,7 +113,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "StatusEffect-AbilityGu8-DamageReduction25",
-        "Name": "Ability Hull Down: Decreased Damage Taken",
+        "Name": "Ability Hull Down: Decreased damage taken",
         "Details": "",
         "Icon": "shield-reflect"
       },
@@ -140,7 +140,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "StatusEffect-AbilityGu8-AoEDamageReduction50",
-        "Name": "Ability Hull Down: Decreased AoE Damage Taken 50",
+        "Name": "Ability Hull Down: Decreased AoE damage taken 50",
         "Details": "",
         "Icon": "shield-reflect"
       },
@@ -167,7 +167,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "StatusEffect-AbilityGu8-AoEDamageReduction25",
-        "Name": "Ability Hull Down: Decreased AoE Damage Taken",
+        "Name": "Ability Hull Down: Decreased AoE damage taken",
         "Details": "",
         "Icon": "shield-reflect"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityP8Mobility.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP8Mobility.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP8Mobility",
     "Name": "MOBILITY EXPERT",
-    "Details": "ACTION: Push your engine to the limit. Gain +30m move speed and avoid mines for 1 turn. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: Push your engine to the limit. Gain +30m movement speed and avoid mines for 1 turn. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_action_evasivemove"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityP8Mobility.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP8Mobility.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP8Mobility",
     "Name": "MOBILITY EXPERT",
-    "Details": "ACTION: Push your Engine to the Limit. +1 Hex Move and avoid mines for 1 turn. 3 turn cooldown.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: Push your engine to the limit. Gain +30m move speed and avoid mines for 1 turn. 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_action_evasivemove"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityP8PhantomMech.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP8PhantomMech.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP8PhantomMech",
     "Name": "PHANTOM",
-    "Details": "ACTION: Gain +2 ECM shield and -50% visibility & sensor signature, and become immune to indirect attacks for 2 turns. Has a 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: Gain +2 ECM shield, -50% visibility & sensor signature, and immunity to indirect attacks for 2 turns. Has a 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "phantommech"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -55,7 +55,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "TraitEliteFerret",
-        "Name": "Ability Phantom: Is Immune to Indirect attacks",
+        "Name": "Ability Phantom: Is Immune to Indirect Attacks",
         "Details": "This unit can not be targeted by indirect attacks",
         "Icon": "uixSvgIcon_action_evasivemove"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityP8PhantomMech.json
+++ b/Core/Abilifier/TreeAbilities/AbilityP8PhantomMech.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityP8PhantomMech",
     "Name": "PHANTOM",
-    "Details": "ACTION: Gain +2 Local ECM, -50% Visibility/SensorSignature and Immune to Indirect Attacks for 2 Turns. Has a 3 turn cooldown.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: Gain +2 ECM shield and -50% visibility & sensor signature, and become immune to indirect attacks for 2 turns. Has a 3 turn cooldown.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "phantommech"
   },
   "DisplayParams": "ShowInMWTRay",
@@ -55,7 +55,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "TraitEliteFerret",
-        "Name": "Ability Phantom: Is Immune to Indirect Attacks",
+        "Name": "Ability Phantom: Is Immune to Indirect attacks",
         "Details": "This unit can not be targeted by indirect attacks",
         "Icon": "uixSvgIcon_action_evasivemove"
       },

--- a/Core/Abilifier/TreeAbilities/AbilityT5Cautious.json
+++ b/Core/Abilifier/TreeAbilities/AbilityT5Cautious.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityT5Cautious",
     "Name": "CAUTIOUS",
-    "Details": "PASSIVE: Remove one bar of stability damage when Reserving. +1 Adv. Sensors, +1 Initiative.",
+    "Details": "PASSIVE: Removes one bar of stability damage when reserving. +1 Adv. sensors, +1 Initiative",
     "Icon": "cautious"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityT5Tactician.json
+++ b/Core/Abilifier/TreeAbilities/AbilityT5Tactician.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityT5Tactician",
     "Name": "TACTICIAN",
-    "Details": "PASSIVE: +15% Max Sight/Sensor Range, +1 Adv. Sensors, +1 Initiative.",
+    "Details": "PASSIVE: +15% sight & sensor range, +1 Adv. sensors, +1 Initiative",
     "Icon": "uixSvgIcon_ability_mastertactician"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityT8FieldCommand.json
+++ b/Core/Abilifier/TreeAbilities/AbilityT8FieldCommand.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityT8FieldCommand",
     "Name": "FIELD COMMAND",
-    "Details": "ACTION: For 2 Turns, Company units gain +2 Sensors Check, +20% Sensors/Sight, +2 to Initiative. Has a 3 turn cooldown. Stack 2 times. Stacks with other effects granting same bonuses.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: For 2 turns,  all company units gain +2 Adv. sensors, +20% sight & sensor range, and +2 Initiative. Has a 3 turn cooldown. Stacks 2 times and with other effects granting same bonuses.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "fieldcommand"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityT8FieldCommand.json
+++ b/Core/Abilifier/TreeAbilities/AbilityT8FieldCommand.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityT8FieldCommand",
     "Name": "FIELD COMMAND",
-    "Details": "ACTION: For 2 turns,  all company units gain +2 Adv. sensors, +20% sight & sensor range, and +2 Initiative. Has a 3 turn cooldown. Stacks 2 times and with other effects granting same bonuses.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: For 2 turns, all company units gain +2 Adv. sensors, +20% sight & sensor range, and +2 Initiative. Has a 3 turn cooldown. Stacks 2 times, and with other effects granting the same bonuses.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "fieldcommand"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityT8SensorLock.json
+++ b/Core/Abilifier/TreeAbilities/AbilityT8SensorLock.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityT8SensorLock",
     "Name": "SENSOR LOCK",
-    "Details": "ACTION: Select a target within sensor range to remove 2 of its EVASIVE charges, Double its Signature & Visibility and disable its Stealth; Effects decrease with target movement. Does not End Your Turn.\n<b><color=#8080ff>Resolve Cost: {10}</color></b>",
+    "Details": "ACTION: Select a target within sensor range to remove 2 of its Evasive Pips, double its visibility & sensor signature, and disable its stealth. The effects decrease with target movement.\nDoes not end your turn.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_action_sensorlock"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityT8SensorLock.json
+++ b/Core/Abilifier/TreeAbilities/AbilityT8SensorLock.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityT8SensorLock",
     "Name": "SENSOR LOCK",
-    "Details": "ACTION: Select a target within sensor range to remove 2 of its Evasive Pips, double its visibility & sensor signature, and disable its stealth. The effects decrease with target movement.\nDoes not end your turn.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: Select a target within sensor range to remove 2 of its Evasive Pips, double its visibility & sensor signature, and disable its stealth. Effects decrease with target movement\nDoes not end your turn\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_action_sensorlock"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/Abilifier/TreeAbilities/AbilityT8SensorLock.json
+++ b/Core/Abilifier/TreeAbilities/AbilityT8SensorLock.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityT8SensorLock",
     "Name": "SENSOR LOCK",
-    "Details": "ACTION: Select a target within sensor range to remove 2 of its Evasive Pips, double its visibility & sensor signature, and disable its stealth. Effects decrease with target movement\nDoes not end your turn\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
+    "Details": "ACTION: Select a target within sensor range to remove 2 of its Evasive Pips, double its visibility & sensor signature, and disable its stealth. Effects decrease with target movement.\nDoes not end your turn.\n<b><color=#8080ff>Resolve cost: {10}</color></b>",
     "Icon": "uixSvgIcon_action_sensorlock"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/CBTBehaviorsEnhanced/mod_localized_text.json
+++ b/Core/CBTBehaviorsEnhanced/mod_localized_text.json
@@ -1,57 +1,57 @@
 {
     "Floaties" : {
-        "SHUTDOWN_OVERRIDE_SUCCESS" : "Passed Shutdown Override",
-        "SHUTDOWN_OVERRIDE_FAILED" : "Failed Shutdown Override",
-        "SHUTDOWN_FALL" : "Falling from Shutdown",
+        "SHUTDOWN_OVERRIDE_SUCCESS" : "Passed shutdown override",
+        "SHUTDOWN_OVERRIDE_FAILED" : "Failed shutdown override",
+        "SHUTDOWN_FALL" : "Falling from shutdown",
 
-        "EXPLOSION_CHECK" : "Ammo Explosion Check",
-        "VOLATILE_EXPLOSION_CHECK" : "Volatile Ammo Explosion Check",
-        "SHUTDOWN_CHECK" : "Shutdown Check",
-        "STARTUP_CHECK" : "Startup Check",
-        "INJURY_CHECK" : "Pilot Injury Check",
-        "SYSTEM_FAILURE_CHECK": "System Failure Check",
-        "FALLING_CHECK" : "Falling Check",
+        "EXPLOSION_CHECK" : "Ammo explosion check",
+        "VOLATILE_EXPLOSION_CHECK" : "Volatile ammo explosion check",
+        "SHUTDOWN_CHECK" : "Shutdown check",
+        "STARTUP_CHECK" : "Startup check",
+        "INJURY_CHECK" : "Pilot injury check",
+        "SYSTEM_FAILURE_CHECK": "System failure check",
+        "FALLING_CHECK" : "Falling check",
 
-        "PILOT_DEATH_OVERHEAT" : "Overheat Death",
-        "PILOT_DEATH_FALLING" : "Falling Death",
+        "PILOT_DEATH_OVERHEAT" : "Overheat death",
+        "PILOT_DEATH_FALLING" : "Falling death",
 
-        "MELEE_KICK" : "Kick Falling Check",
-        "MELEE_CHARGE" : "Charge Falling Check",
-        "MELEE_DFA" : "DFA Falling Check",
+        "MELEE_KICK" : "Kick falling check",
+        "MELEE_CHARGE" : "Charge falling check",
+        "MELEE_DFA" : "DFA falling check",
 
-        "RUN_AND_FALL" : "Sprinted with Damage",
-        "JUMP_AND_FALL" : "Jumped with Damage",
+        "RUN_AND_FALL" : "Sprinted with damage",
+        "JUMP_AND_FALL" : "Jumped with damage",
 
-        "AUTO_FAIL" : "Automatic Failure",
-        "HULL_BREACH" : "Hull Breach Check",
+        "AUTO_FAIL" : "Automatic failure",
+        "HULL_BREACH" : "Hull breach check",
 		
 		"SWARM_ATTACK" : "Swarm attack!"
     },
 
     "Tooltips" : {
         "TITLE" : "HEAT LEVEL",
-        "END_OF_TURN_HEAT" : "Projected Heat: {0} of {1}",
-        "HEAT_AND_SINKING" : "\n  Heat: {0} of {1}  Will Sink: {2} of {3} (<color=#{4}>x{5:#.#}</color>)",
-        "AMMO_EXP_CHANCE" : "\nAmmo Explosion on (d100+{0}) < {1}",
-        "AMMO_EXP_WARNING" : "Guaranteed Ammo Explosion!",
-        "PILOT_INJURY_CHANCE" : "\nPilot Injury on (d100+{0}) < {1}",
-        "SYSTEM_FAILURE_CHANCE" : "\nSystem Failure on (d100+{0}) < {1}",
+        "END_OF_TURN_HEAT" : "Projected heat: {0} of {1}",
+        "HEAT_AND_SINKING" : "\n  Heat: {0} of {1}, will sink: {2} of {3} (<color=#{4}>x{5:#.#}</color>)",
+        "AMMO_EXP_CHANCE" : "\nAmmo explosion on (d100+{0}) < {1}",
+        "AMMO_EXP_WARNING" : "Guaranteed ammo explosion!",
+        "PILOT_INJURY_CHANCE" : "\nPilot injury on (d100+{0}) < {1}",
+        "SYSTEM_FAILURE_CHANCE" : "\nSystem failure on (d100+{0}) < {1}",
         "SHUTDOWN_CHANCE" : "\nShutdown on (d100+{0}) < {1}",
-        "SHUTDOWN_WARNING" : "\nGuaranteed Shutdown!",
-        "ATTACK_PENALTY" : "\nAttack Penalty: +{0}",
-        "MOVEMENT_PENALTY" : "\nMovement Penalty: -{0}m",
+        "SHUTDOWN_WARNING" : "\nGuaranteed shutdown!",
+        "ATTACK_PENALTY" : "\nAttack penalty: +{0}",
+        "MOVEMENT_PENALTY" : "\nMovement penalty: -{0}m",
 
         "SHUTDOWN_ICON_TITLE" : "SHUT DOWN",
-        "SHUTDOWN_ICON_TEXT" : "This target is easier to hit, and Called Shots can be made against this target. When clicking the restart button, a piloting check will if the BattleMech restarts.",
+        "SHUTDOWN_ICON_TEXT" : "This target is easier to hit, and Called Shots can be made against this target. When clicking the Restart button, a piloting check will decide if the unit restarts.",
         "OVERHEAT_ICON_TITLE" : "OVERHEATING",
-        "OVERHEAT_ICON_TEXT" : "This unit will suffer penalties, may shutdown or even explode unless heat is reduced past critical levels.\n<i>Hover over the heat bar to see a detailed breakdown.</i>"
+        "OVERHEAT_ICON_TEXT" : "This unit will suffer penalties, may shut down or even explode unless heat is reduced past critical levels.\n<i>Hover over the heat bar to see a detailed breakdown.</i>"
     },
 
     "AttackDescriptions" : {
         "CHARGE_DESC" : 
-            "<align=\"left\"><b>CHARGE</b> Damages both the attacker and target.\n<color=#00ff00>Target    DMG: {0} STAB: {1}  {2}</color>\n<color=#ff0000>Attacker  DMG: {3} STAB: {4}  {5}</color>\n" ,
+            "<align=\"left\"><b>CHARGE</b> damages both the attacker and target.\n<color=#00ff00>Target    DMG: {0} STAB: {1}  {2}</color>\n<color=#ff0000>Attacker  DMG: {3} STAB: {4}  {5}</color>\n" ,
         "DFA_DESC" : 
-            "<align=\"left\"><b>DFA</b> Damages both the attacker and target.\n<color=#00ff00>Target    DMG: {0} STAB: {1}  {2}</color>\n<color=#ff0000>Attacker  DMG: {3} STAB: {4}  {5}</color>\n",
+            "<align=\"left\"><b>DFA</b> damages both the attacker and target.\n<color=#00ff00>Target    DMG: {0} STAB: {1}  {2}</color>\n<color=#ff0000>Attacker  DMG: {3} STAB: {4}  {5}</color>\n",
         "KICK_DESC" :
             "<align=\"left\"></b>KICK</b>\n<color=#00ff00>Target    DMG: {0} STAB: {1}  {2}</color>",
         "PHYSICAL_WEAPON_DESC" :

--- a/Core/RogueTechCore/CombatGame/CombatGameConstants.json
+++ b/Core/RogueTechCore/CombatGame/CombatGameConstants.json
@@ -1247,39 +1247,39 @@
     ],
     "MoveDescription": {
       "Name": "MOVE",
-      "Details": "Execute a normal move, gaining EVASIVE charges based on distance. -1 Accuracy. May also use to initiate a Melee attack on nearby enemies."
+      "Details": "Execute a normal move, gaining EVASIVE Pips based on distance. Can also be used to initiate a melee attack on nearby enemies.\r\n\n-1 accuracy"
     },
     "SprintDescription": {
       "Name": "SPRINT",
-      "Details": "Use this 'Mech's entire turn to move farther, gaining EVASIVE charges based on distance. -2 Accuracy. Cannot Sprint if UNSTEADY, or if a leg is destroyed."
+      "Details": "Execute a sprint to move farther, gaining EVASIVE Pips based on distance. Cannot sprint if UNSTEADY, or if a leg is destroyed.\r\n\n-2 accuracy"
     },
     "BackwardDescription": {
       "Name": "REVERSE",
-      "Details": "Reverse-move at a slower speed to a nearby location, and set a new facing for this 'Mech."
+      "Details": "Reverse-move at a slower speed to a nearby location, and set a new facing for this unit."
     },
     "JumpDescription": {
       "Name": "JUMP",
-      "Details": "Execute a jump move, gaining EVASIVE charges based on distance. -3 Accuracy .You may also use Jump to initiate a 'Death from Above' attack on nearby enemies."
+      "Details": "Execute a jump, gaining EVASIVE Pips based on distance. Can also be used to initiate a 'Death from Above' attack on nearby enemies.\r\n\n-3 accuracy"
     },
     "FireDescription": {
       "Name": "FIRE",
-      "Details": "Fire selected weapons at any target within this 'Mech's current firing arc."
+      "Details": "Fire selected weapons at any target within this unit's current firing arc."
     },
     "MoraleBarDescription": {
       "Name": "Resolve",
-      "Details": "The MechWarrior gains <color=#F79B26>{0}</color> base resolve each round of combat, increased by guts.\n When a MechWarrior become Inspired at 50 resolve stored, they gain a +1 to ECM Status and Probe Rolls"
+      "Details": "The pilot gains <color=#F79B26>{0}</color> base Resolve each round of combat, increased by Guts.\nWhen a pilot become Inspired at 50 resolve stored, they gain +1 to ECM shield and probe."
     },
     "FuryBarDescription": {
       "Name": "Fury",
-      "Details": "Your lance gains Fury as bad things happen to it.\nWhen the bar fills, you can use it to perform a Precision Strike with one MechWarrior."
+      "Details": "Your lance gains Fury as bad things happen to it.\nWhen the bar fills, you can use it to perform a Precision Strike with one pilot."
     },
     "MoraleAttackDescription": {
       "Name": "Offensive Push",
-      "Details": "Take a Called Shot against a single target with an Accuracy Penalty. Tactics and Piloting improve this.\n The target's next Initiative is reduced by your Gunnery and Tactics skills / 2.\n"
+      "Details": "Take a Called Shot against a single target, but with lowered accuracy. Tactics and certain quirks, affinities and equipment counteract this penalty.\nThe target's next Initiative is reduced by your (Gunnery+Tactics)/2."
     },
     "MoraleCostAttackDescription": {
       "Name": "PRECISION STRIKE COST",
-      "Details": "<b><color=#8080ff>Resolve Cost: {0}</color></b>"
+      "Details": "<b><color=#8080ff>Resolve cost: {0}</color></b>"
     },
     "MoraleCostAttackDescriptionFury": {
       "Name": "PRECISION STRIKE COST FURY",
@@ -1287,47 +1287,47 @@
     },
     "MoraleCostAttackDescriptionLow": {
       "Name": "PRECISION STRIKE COST LOW",
-      "Details": "<b><color=#8080ff>Base Resolve Cost: </color><color=#F04228FF>{0} </color><color=#8080ff> (this MechWarrior has Low Spirits)</color>"
+      "Details": "<b><color=#8080ff>Base Resolve cost: </color><color=#F04228FF>{0} </color><color=#8080ff> (this pilot has Low Spirits)</color>"
     },
     "MoraleCostAttackDescriptionHigh": {
       "Name": "PRECISION STRIKE COST HIGH",
-      "Details": "<b><color=#8080ff>Base Resolve Cost: </color><color=#28f039>{0} </color><color=#8080ff> (this MechWarrior has High Spirits)</color>"
+      "Details": "<b><color=#8080ff>Base Resolve cost: </color><color=#28f039>{0} </color><color=#8080ff> (this pilot has High Spirits)</color>"
     },
     "MoraleDefendDescription": {
       "Name": "VIGILANCE",
-      "Details": "Gain GUARDED and ENTRENCHED and remove all stability damage.\n Your next Initiative is increased by Guts and Tactics / 2.\n"
+      "Details": "Gain GUARDED and ENTRENCHED and remove all stability damage.\nYour next Initiative is increased by your (Guts+Tactics)/2.\n"
     },
     "MoraleCostDefendDescription": {
       "Name": "VIGILANCE COST",
-      "Details": "<b><color=#8080ff>Base Resolve Cost: {0}</color></b>"
+      "Details": "<b><color=#8080ff>Base Resolve cost: {0}</color></b>"
     },
     "MoraleCostDefendDescriptionLow": {
       "Name": "VIGILANCE COST LOW",
-      "Details": "<b><color=#8080ff>Base Resolve Cost: </color><color=#F04228FF>{0} </color><color=#8080ff> (this MechWarrior has Low Spirits)</color>"
+      "Details": "<b><color=#8080ff>Base Resolve cost: </color><color=#F04228FF>{0} </color><color=#8080ff> (this pilot has Low Spirits)</color>"
     },
     "MoraleCostDefendDescriptionHigh": {
       "Name": "VIGILANCE COST HIGH",
-      "Details": "<b><color=#8080ff>Base Resolve Cost: </color><color=#28f039>{0} </color><color=#8080ff> (this MechWarrior has High Spirits)</color>"
+      "Details": "<b><color=#8080ff>Base Resolve cost: </color><color=#28f039>{0} </color><color=#8080ff> (this pilot has High Spirits)</color>"
     },
     "FireMultiDescription": {
       "Name": "MULTI-TARGET",
-      "Details": "Fire weapons at up to three separate targets within this 'Mech's current firing arc."
+      "Details": "Fire weapons at up to three separate targets within this unit's current firing arc."
     },
     "DoneDescription": {
       "Name": "BRACE (END TURN)",
-      "Details": "Remove UNSTEADY and end this 'Mech's turn. Gain GUARDED (10% damage reduction against ranged attacks to the front and side) and ENTRENCHED (50% stability damage reduction)."
+      "Details": "Remove UNSTEADY and end this unit's turn. Gain GUARDED (10% damage reduction against ranged attacks to the front and side) and ENTRENCHED (50% stability damage reduction)."
     },
     "DoneDescriptionBulwark": {
       "Name": "BRACE (END TURN)",
-      "Details": "Remove UNSTEADY and end this 'Mech's turn. Gain BULWARK (20% damage reduction against ranged attacks to the front and side) and ENTRENCHED (50% stability damage reduction)."
+      "Details": "Remove UNSTEADY and end this unit's turn. Gain BULWARK (20% damage reduction against ranged attacks to the front and side) and ENTRENCHED (50% stability damage reduction)."
     },
     "DoneDescriptionNoBrace": {
       "Name": "END TURN",
-      "Details": "End this 'Mech's turn."
+      "Details": "End this unit's turn."
     },
     "EjectDescription": {
       "Name": "EJECT",
-      "Details": "Eject your pilot. They will be saved from further injuries, but their 'Mech will be unusable for the rest of this mission, and its Head location will be destroyed."
+      "Details": "Eject your pilot. They will be saved from further injuries, but the piloted unit will be unusable for the rest of this mission, and its head location will be destroyed."
     },
     "BadFaithRetreatDesc": {
       "Name": "Start WITHDRAW (BAD FAITH)",
@@ -1339,12 +1339,12 @@
     },
     "PoorlyMaintained25Desc": {
       "Name": "MAKESHIFT",
-      "Details": "This unit has been maintained in a substandard way, it's armor and weapons are not in perfect condition.",
+      "Details": "This unit has been maintained in a substandard way. Armor and weapons are in less than perfect condition.",
       "Icon": "uixSvgIcon_maint_Level0"
     },
     "PoorlyMaintained50Desc": {
       "Name": "SHODDY",
-      "Details": "This unit has received little upkeep and resupply and armor and weapon are in poor condition.",
+      "Details": "This unit has received little upkeep and resupply. Armor and weapon are in poor condition.",
       "Icon": "uixSvgIcon_maint_Level1"
     },
     "PoorlyMaintained75Desc": {
@@ -1366,7 +1366,7 @@
     },
     "MovementTutorialDesc": {
       "Name": "Unit Select",
-      "Details": "Click on a MechWarrior's portrait, or press TAB to cycle between available units."
+      "Details": "Click on a pilot's portrait, or press TAB to cycle between available units."
     },
     "MovementStageTwoTutorialDesc": {
       "Name": "Movement",
@@ -1394,7 +1394,7 @@
     },
     "InterleaveIntroTutorialDesc": {
       "Name": "Combat Phases",
-      "Details": "Once combat has begun, different 'Mechs move in different Phases. Lighter units generally move earlier than heavier ones.\nTo Reserve all units' actions to a later Phase, use the Reserve button, or press the End key."
+      "Details": "Once combat has begun, different units move in different Phases. Lighter units generally move earlier than heavier ones.\nTo Reserve all units' actions to a later Phase, use the Reserve button, or press the End key."
     },
     "MoraleGeneralTutorialDesc": {
       "Name": "Resolve",
@@ -1414,7 +1414,7 @@
     },
     "EvasiveTutorialDesc": {
       "Name": "Evasion",
-      "Details": "The farther you move, the more EVASIVE charges you will gain. Each EVASIVE charge makes you harder to hit."
+      "Details": "The farther you move, the more EVASIVE Pips you will gain. Each EVASIVE Pip makes you harder to hit."
     },
     "InjuryStringAmmoExplosion": "killed by an explosion",
     "InjuryStringArtillery": "caught in a massive explosion",

--- a/Core/RogueTechCore/CombatGame/CombatGameConstants.json
+++ b/Core/RogueTechCore/CombatGame/CombatGameConstants.json
@@ -1275,7 +1275,7 @@
     },
     "MoraleAttackDescription": {
       "Name": "Offensive Push",
-      "Details": "Take a Called Shot against a single target, but with lowered accuracy. Tactics and certain quirks, affinities and equipment counteract this penalty.\nThe target's next Initiative is reduced by your (Gunnery+Tactics)/2."
+      "Details": "Take a Called Shot against a single target, but with lowered accuracy. Tactics and certain quirks, affinities, and equipment counteract this penalty.\nThe target's next Initiative is reduced by your (Gunnery+Tactics)/2.\n"
     },
     "MoraleCostAttackDescription": {
       "Name": "PRECISION STRIKE COST",

--- a/Core/RogueTechCore/abilities/AbilityDefCAC_AttackGround.json
+++ b/Core/RogueTechCore/abilities/AbilityDefCAC_AttackGround.json
@@ -1,8 +1,8 @@
 {
   "Description": {
     "Id": "AbilityDefCAC_AttackGround",
-    "Name": "ATTACK GROUND",
-    "Details": "Use this Ability to Perform an Attack against the Ground. Left Alt + Click on friendly to target Friendly Units.",
+    "Name": "ATTACK GROUND / ALLY",
+    "Details": "ACTION: Attack a point on the ground with selected weapons.\r\n\r\nACTION: Target a friendly unit with Left Alt + click.",
     "Icon": "uixSvgIcon_artillery"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/RogueTechCore/abilities/AbilityMultiTracker.json
+++ b/Core/RogueTechCore/abilities/AbilityMultiTracker.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityMultiTracker",
     "Name": "MULTI-TARGET",
-    "Details": "ACTION: Fire weapons at up to three separate targets within this 'Mech's current firing arc.",
+    "Details": "ACTION: Fire weapons at up to three separate targets within this unit's current firing arc",
     "Icon": "uixSvgIcon_action_multitarget"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/RogueTechCore/abilities/TraitDefGuts1.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts1.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+0 Ini Injury & Melee Resist, +3% Resolve Gen, 1% Fail Effect & Jam Damage Resist",
+  "ShortDesc": "0 injury & melee Ini penalty\n+3% Resolve gen\n-1% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts10.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts10.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+5 Ini Injury&Melee Resist, +30% Resolve Gen, 10% Fail Effect Resist",
+  "ShortDesc": "-5 injury & melee Ini penalty\n+30% Resolve gen\n-10% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts2.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts2.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+1 Ini Injury&Melee Resist, +6% Resolve Gen, 2% Fail Effect Resist",
+  "ShortDesc": "-1 injury & melee Ini penalty\n+6% Resolve gen\n-2% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts3.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts3.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+1 Ini Injury&Melee Resist, +9% Resolve Gen, 3% Fail Effect Resist",
+  "ShortDesc": "-1 injury & melee Ini penalty\n+9% Resolve gen\n-3% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts4.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts4.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+2 Ini Injury&Melee Resist, +12% Resolve Gen, 4% Fail Effect Resist",
+  "ShortDesc": "-2 injury & melee Ini penalty\n+12% Resolve gen\n-4% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts5.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts5.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+2 Ini Injury&Melee Resist, +15% Resolve Gen, 5% Fail Effect Resist",
+  "ShortDesc": "-2 injury & melee Ini penalty\n+15% Resolve gen\n-5% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts6.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts6.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+3 Ini Injury&Melee Resist, +18% Resolve Gen, 6% Fail Effect Resist",
+  "ShortDesc": "-3 injury & melee Ini penalty\n+18% Resolve gen\n-6% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts7.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts7.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+3 Ini Injury&Melee Resist, +21% Resolve Gen, 7% Fail Effect Resist",
+  "ShortDesc": "-3 injury & melee Ini penalty\n+21% Resolve gen\n-7% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts8.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts8.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+4 Ini Injury&Melee Resist, +24% Resolve Gen, 8% Fail Effect Resist",
+  "ShortDesc": "-4 injury & melee Ini penalty\n+24% Resolve gen\n-8% fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefGuts9.json
+++ b/Core/RogueTechCore/abilities/TraitDefGuts9.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "GutsEffects",
-  "ShortDesc": "+4 Ini Injury&Melee Resist, +27% Resolve Gen, 9% Fail Effect Resist",
+  "ShortDesc": "-4 injury & melee Ini penalty\n+27% Resolve gen\n-9%  fail effect chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit1.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit1.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+2% Melee Acc, +3m Tank/VTOL Move",
+  "ShortDesc": "+2% melee ACC\n+3m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit10.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit10.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+3 Max Evasion, +20% Melee Acc, -5 Ini Randomness, +30m Tank/VTOL Move",
+  "ShortDesc": "+3 max evasion\n+20% melee ACC\n-5 Ini RNG\n+30m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit2.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit2.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+4% Melee Acc,-1 Ini Randomness, +6m Tank/VTOL Move",
+  "ShortDesc": "+4% melee ACC\n-1 Ini RNG\n+6m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit3.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit3.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+1 Max Evasion, +6% Melee Acc,-1 Ini Randomness, +9m Tank/VTOL Move",
+  "ShortDesc": "+1 max evasion\n+6% melee ACC\n-1 Ini RNG\n+9m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit4.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit4.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+1 Max Evasion, +8% Melee Acc,-2 Ini Randomness, +12m Tank/VTOL Move",
+  "ShortDesc": "+1 max evasion\n+8% melee ACC\n-2 Ini RNG\n+12m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit5.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit5.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+1 Max Evasion, +10% Melee Acc,-2 Ini Randomness, +15m Tank/VTOL Move",
+  "ShortDesc": "+1 max evasion\n+10% melee ACC\n-2 Ini RNG\n+15m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit6.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit6.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+2 Max Evasion, +12% Melee Acc,-3 Ini Randomness, +18m Tank/VTOL Move",
+  "ShortDesc": "+2 max evasion\n+12% melee ACC\n-3 Ini RNG\n+18m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit7.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit7.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+2 Max Evasion, +14% Melee Acc,-3 Ini Randomness, +21m Tank/VTOL Move",
+  "ShortDesc": "+2 max evasion\n+14% melee ACC\n-3 Ini RNG\n+21m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit8.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit8.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+2 Max Evasion, +16% Melee Acc,-4 Ini Randomness, +24m Tank/VTOL Move",
+  "ShortDesc": "+2 max evasion\n+16% melee ACC\n-4 Ini RNG\n+24m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefMeleeHit9.json
+++ b/Core/RogueTechCore/abilities/TraitDefMeleeHit9.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "MeleeHit",
-  "ShortDesc": "+3 Max Evasion, +18% Melee Acc,-4 Ini Randomness, +27m Tank/VTOL Move",
+  "ShortDesc": "+3 max evasion\n+18% melee ACC\n-4 Ini RNG\n+27m vehicle move",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [

--- a/Core/RogueTechCore/abilities/TraitDefTactics1.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics1.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+0 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -1% Resolve Cost.",
+  "ShortDesc": "+0 Ini, sensor roll & OP ACC\nReduced hesitation\n-1% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 1: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 1: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 1%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics10.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics10.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+5 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -10% Resolve Cost.",
+  "ShortDesc": "+5 Ini, sensor roll & OP ACC\nReduced hesitation\n-10% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 10: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 10: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 10%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics2.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics2.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+1 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -2% Resolve Cost.",
+  "ShortDesc": "+1 Ini, sensor roll & OP ACC\nReduced hesitation\n-2% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 2: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 2: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 2%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics3.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics3.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+1 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -3% Resolve Cost.",
+  "ShortDesc": "+1 Ini, sensor roll & OP ACC\nReduced hesitation\n-3% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 3: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 3: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 3%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics4.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics4.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+2 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -4% Resolve Cost.",
+  "ShortDesc": "+2 Ini, sensor roll & OP ACC\nReduced hesitation\n-4% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 4: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 4: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 4%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics5.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics5.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+2 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -5% Resolve Cost.",
+  "ShortDesc": "+2 Ini, sensor roll & OP ACC\nReduced hesitation\n-5% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 5: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 5: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 5%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics6.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics6.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+3 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -6% Resolve Cost.",
+  "ShortDesc": "+3 Ini, sensor roll & OP ACC\nReduced hesitation\n-6% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 6: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 6: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 6%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics7.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics7.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+3 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -7% Resolve Cost.",
+  "ShortDesc": "+3 Ini, sensor roll & OP ACC\nReduced hesitation\n-7% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 7: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 7: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 7%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics8.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics8.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+4 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -8% Resolve Cost.",
+  "ShortDesc": "+4 Ini, sensor roll & OP ACC\nReduced hesitation\n-8% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 8: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 8: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 8%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefTactics9.json
+++ b/Core/RogueTechCore/abilities/TraitDefTactics9.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "TacticsEffects",
-  "ShortDesc": "+4 Initiative, Sensor Roll, OP Acc. and Reduced Hesitation. -9% Resolve Cost.",
+  "ShortDesc": "+4 Ini, sensor roll & OP ACC\nReduced hesitation\n-9% Resolve cost",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive",
   "EffectData": [
@@ -23,7 +23,7 @@
       "nature": "Buff",
       "Description": {
         "Id": "Tactics-ReducedResolveCost",
-        "Name": "Trait Tactics 9: Decreased Ability Resolve Cost",
+        "Name": "Trait Tactics 9: Decreased Ability Resolve cost",
         "Details": "Reduces resolve cost by 9%",
         "Icon": "uixSvgIcon_ability_mastertactician"
       },

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit1.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit1.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "85.6% Base Chance to Hit, 10% Unjam",
+  "ShortDesc": "85.6% base chance to hit\n10% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit10.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit10.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "100% Base Chance to Hit, -4.5% Jam, 100% Unjam",
+  "ShortDesc": "100% base chance to hit\n-4.5% jam chance\n100% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit2.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit2.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "87.2% Base Chance to Hit, -0.5% Jam, 20% Unjam",
+  "ShortDesc": "87.2% base chance to hit,\n-0.5% jam chance\n20% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit3.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit3.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "88.8% Base Chance to Hit, -1% Jam, 30% Unjam",
+  "ShortDesc": "88.8% base chance to hit\n-1% jam chance\n30% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit4.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit4.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "90.4% Base Chance to Hit, -1.5% Jam, 40% Unjam",
+  "ShortDesc": "90.4% base chance to hit\n-1.5% jam chance\n40% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit5.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit5.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "92% Base Chance to Hit, -2% Jam, 50% Unjam",
+  "ShortDesc": "92% base chance to hit\n-2% jam chance\n50% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit6.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit6.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "93.6% Base Chance to Hit, -2.5% Jam, 60% Unjam",
+  "ShortDesc": "93.6% base chance to hit\n-2.5% jam chance\n60% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit7.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit7.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "95.2% Base Chance to Hit, -3% Jam, 70% Unjam",
+  "ShortDesc": "95.2% base chance to hit\n-3% jam chance\n70% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit8.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit8.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "96.8% Base Chance to Hit, -3.5% Jam, 80% Unjam",
+  "ShortDesc": "96.8% base chance to hit\n-3.5% jam chance\n80% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/RogueTechCore/abilities/TraitDefWeaponHit9.json
+++ b/Core/RogueTechCore/abilities/TraitDefWeaponHit9.json
@@ -6,7 +6,7 @@
     "Icon": ""
   },
   "Type": "WeaponHit",
-  "ShortDesc": "98.4% Base Base Chance to Hit, -4% Jam, 90% Unjam",
+  "ShortDesc": "98.4% base chance to hit\n-4% jam chance\n90% unjam chance",
   "DisplayParams": "ShowInPilotToolTip",
   "ActivationTime": "Passive"
 }

--- a/Core/StrategicOperations/abilities/AbilityDefAirliftActivate.json
+++ b/Core/StrategicOperations/abilities/AbilityDefAirliftActivate.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefAirliftActivate",
     "Name": "Pickup",
-    "Details": "ACTION: Unit will Pickup target",
+    "Details": "ACTION: Pick up the selected target with this unit.",
     "Icon": "mounted-knight"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/StrategicOperations/abilities/AbilityDefBattleArmorMount.json
+++ b/Core/StrategicOperations/abilities/AbilityDefBattleArmorMount.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefBattleArmorMount",
     "Name": "Mount Up",
-    "Details": "ACTION: Battle armor will mount/dismount selected unit",
+    "Details": "ACTION: Battle Armor mounts/dismounts the selected unit.",
     "Icon": "mounted-knight"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/StrategicOperations/abilities/AbilityDefBattleArmorMount.json
+++ b/Core/StrategicOperations/abilities/AbilityDefBattleArmorMount.json
@@ -1,8 +1,8 @@
 {
   "Description": {
     "Id": "AbilityDefBattleArmorMount",
-    "Name": "Mount Up",
-    "Details": "ACTION: Battle Armor mounts/dismounts the selected unit.",
+    "Name": "Mount up",
+    "Details": "ACTION: Mount/dismount the selected target with Battle Armor. Performs a swarm attack when used on a hostile target.",
     "Icon": "mounted-knight"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/StrategicOperations/abilities/AbilityDefCMD_Strafe.json
+++ b/Core/StrategicOperations/abilities/AbilityDefCMD_Strafe.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_Strafe",
     "Name": "STRAFE",
-    "Details": "CALLS IN A STRAFING RUN BY THE ARGO'S TWO ATTACHED AEROSPACE FIGHTERS.\r\n\r\n <b><color=#099ff2>Has a 2 turn cooldown! Costs 15 Resolve to use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in three strafes per contract! The fighters attack in two waves, one after another!</color></b>\r\n\r\n <b><color=#e11919>Costs 50000 C-Bills per use!</color></b>",
+    "Details": "Call in a strafing run by the Argo's two aerospace fighters.\r\n\r\n <b><color=#099ff2>Has a 2 turn cooldown! Costs 15 Resolve to use!</color></b>\r\n\r\n <b><color=#15df37>Can only call in three strafes per contract! The fighters attack in two waves, one after another!</color></b>\r\n\r\n <b><color=#e11919>Costs 50000 C-bills per use!</color></b>",
     "Icon": "strafe"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch.json
+++ b/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_UAVLaunch",
     "Name": "UAV Launch",
-    "Details": "DEPLOYS A UAV FROM THE UNIT'S STORAGE.\r\n\r\n <b><color=#e11919>Costs 10 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only deploy one UAV per contract!\n Cannot be used in duels, Solaris matches or on lunar biomes.</color></b>",
+    "Details": "ACTION: Deploy a UAV from storage.\r\n\r\n <b><color=#e11919>Costs 10 000 C-bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only deploy one UAV per contract!\nCannot be used in duels, Solaris matches or on lunar biomes.</color></b>",
     "Icon": "uav"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch_DroneController.json
+++ b/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch_DroneController.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_UAVLaunch_DroneController",
     "Name": "UAV Launch",
-    "Details": "DEPLOYS A UAV FROM THE UNIT'S STORAGE.\r\n\r\n <b><color=#e11919>Costs 10 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only deploy in one UAV per contract!\n Cannot be used in duels, Solaris matches or on lunar biomes.</color></b>",
+    "Details": "ACTION: Deploy a UAV from storage.\r\n\r\n <b><color=#e11919>Costs 10 000 C-bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can only deploy in one UAV per contract!\nCannot be used in duels, Solaris matches or on lunar biomes.</color></b>",
     "Icon": "uav"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch_Twice.json
+++ b/Core/StrategicOperations/abilities/AbilityDefCMD_UAVLaunch_Twice.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefCMD_UAVLaunch_Twice",
     "Name": "UAV Launch",
-    "Details": "DEPLOYS A UAV FROM THE UNIT'S STORAGE.\r\n\r\n <b><color=#e11919>Costs 10 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can deploy two UAV per contract!\n Cannot be used in duels, Solaris matches or on lunar biomes.</color></b>",
+    "Details": "ACTION: Deploy a UAV from storage.\r\n\r\n <b><color=#e11919>Costs 10 000 C-Bills per use!</color></b>\r\n\r\n <b><color=#15df37>Can deploy two UAV per contract!\nCannot be used in duels, Solaris matches or on lunar biomes.</color></b>",
     "Icon": "uav"
   },
   "ActivationTime": "CommandAbility",

--- a/Core/StrategicOperations/abilities/AbilityDefDeSwarmerMovement.json
+++ b/Core/StrategicOperations/abilities/AbilityDefDeSwarmerMovement.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefDeSwarmerMovement",
     "Name": "Erratic Maneuvering",
-    "Details": "ACTION: Do fancy footworks and barrel rolls to get rid of swarming Battle Armor. Lowers your accuracy by 6.\r\n\r\nBase chance 30%\n+5% per evasion gained, multiplied by 1.2 if jumping\nMaximum chance 95%",
+    "Details": "ACTION: Do fancy footworks and barrel rolls to get rid of swarming Battle Armor. Lowers your accuracy by 6.\r\n\r\nBase chance 30%\n+5% per evasion gained, x1.2 if jumping\nMaximum chance 95%",
     "Icon": "ShakeTank_BA"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/StrategicOperations/abilities/AbilityDefDeSwarmerMovement.json
+++ b/Core/StrategicOperations/abilities/AbilityDefDeSwarmerMovement.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefDeSwarmerMovement",
     "Name": "Erratic Maneuvering",
-    "Details": "ACTION: Do fancy footworks and barrel rolls to get rid of swarming Battle Armor but suffer a -6 accuracy penalty while doing so. 30% base chance, +5% per evasion gained, Multiplied by 1.2 if Jumping, to a max of 95%",
+    "Details": "ACTION: Do fancy footworks and barrel rolls to get rid of swarming Battle Armor. Lowers your accuracy by 6.\r\n\r\nBase chance 30%\n+5% per evasion gained, multiplied by 1.2 if jumping\nMaximum chance 95%",
     "Icon": "ShakeTank_BA"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/StrategicOperations/abilities/AbilityDefDeSwarmerRoll.json
+++ b/Core/StrategicOperations/abilities/AbilityDefDeSwarmerRoll.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefDeSwarmerRoll",
     "Name": "Roll",
-    "Details": "ACTION: Unit will drop prone (self-knockdown) in an attempt to remove swarming Battle Armor. 45% Base, +5% per point of Piloting to a maximum of 90%. Deals 40 Damage on success. Your mech takes fall damage.",
+    "Details": "ACTION: Drop prone (self-knockdown) in an attempt to remove swarming Battle Armor and deal 40 damage to them. Your 'Mech will take fall damage.\r\n\r\nBase chance 45%\n+5% per point of Piloting\nMaximum chance 90%\n\n",
     "Icon": "rolling-energy"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/StrategicOperations/abilities/AbilityDefDeSwarmerRoll.json
+++ b/Core/StrategicOperations/abilities/AbilityDefDeSwarmerRoll.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefDeSwarmerRoll",
     "Name": "Roll",
-    "Details": "ACTION: Drop prone (self-knockdown) in an attempt to remove swarming Battle Armor and deal 40 damage to them. Your 'Mech will take fall damage.\r\n\r\nBase chance 45%\n+5% per point of Piloting\nMaximum chance 90%\n\n",
+    "Details": "ACTION: Drop prone (self-knockdown) in an attempt to remove swarming Battle Armor and deal 40 damage to them. Your 'Mech will take fall damage.\r\n\r\nBase chance 45%\n+5% per point of Piloting\nMaximum chance 90%",
     "Icon": "rolling-energy"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/StrategicOperations/abilities/AbilityDefDeSwarmerSwat.json
+++ b/Core/StrategicOperations/abilities/AbilityDefDeSwarmerSwat.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefDeSwarmerSwat",
     "Name": "Swat",
-    "Details": "ACTION: Unit will attempt to remove swarming Battle Armor with hands/limbs. Base 25% chance, +5% for each point of piloting, -5% for each missing arm actuator.",
+    "Details": "ACTION: Attempt to remove swarming Battle Armor with hands/limbs.\r\n\r\nBase chance 25%\n+5% for each point of Piloting\n-5% for each missing arm actuator",
     "Icon": "hand"
   },
   "ActivationTime": "ConsumedByFiring",

--- a/Core/StrategicOperations/abilities/AbilityDefResupply.json
+++ b/Core/StrategicOperations/abilities/AbilityDefResupply.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDefResupply",
     "Name": "RESUPPLY",
-    "Details": "ACTION: Unit will resupply from target",
+    "Details": "ACTION: Resupply from selected target.",
     "Icon": "mounted-knight"
   },
   "DisplayParams": "ShowInMWTRay",

--- a/Core/StrategicOperations/abilities/AbilityDef_UAV_Sensor_Lock.json
+++ b/Core/StrategicOperations/abilities/AbilityDef_UAV_Sensor_Lock.json
@@ -2,7 +2,7 @@
   "Description": {
     "Id": "AbilityDef_UAV_Sensor_Lock",
     "Name": "SENSOR LOCK",
-    "Details": "ACTION: Select a target within sensor range to remove 2 of its EVASIVE charges, Double its Signature & Visibility and disable its Stealth; Effects decrease with target movement. Does not End Your Turn.",
+    "Details": "ACTION: Select a target within sensor range to remove 2 of its Evasive Pips, double its visibility and sensor signature, and disable its stealth. Effects decrease with target movement.\r\n\r\n<color=#F79B26>Does not end your turn.</color>",
     "Icon": "uixSvgIcon_action_sensorlock"
   },
   "ActivationTime": "ConsumedByFiring",


### PR DESCRIPTION
Improvements on existing ability texts both on the combat UI and the barracks MW tree. Removed excess capital letters, fixed typos and added and reformatted some of the text blocks to both make them look neater as well as easier to read and understand.