### PR TITLE
Blaen necromo

### DIFF
--- a/Core/Flashpoints/NecromoNightmare/contract/zombies/CaptureEscort_AbortedColonyZ1.json
+++ b/Core/Flashpoints/NecromoNightmare/contract/zombies/CaptureEscort_AbortedColonyZ1.json
@@ -1050,7 +1050,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_dead_fred",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1126,7 +1126,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_dead_shane",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1169,7 +1169,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_snowey",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"

--- a/Core/Flashpoints/NecromoNightmare/contract/zombies/CaptureEscort_AppearancesZ1.json
+++ b/Core/Flashpoints/NecromoNightmare/contract/zombies/CaptureEscort_AppearancesZ1.json
@@ -1046,7 +1046,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_dead_fred",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1085,7 +1085,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_dead_shane",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1124,7 +1124,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_snowey",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1163,7 +1163,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_zombiegirl",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"

--- a/Core/Flashpoints/NecromoNightmare/contract/zombies/CaptureEscort_HostageRescueZ1.json
+++ b/Core/Flashpoints/NecromoNightmare/contract/zombies/CaptureEscort_HostageRescueZ1.json
@@ -1052,7 +1052,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_dead_fred",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1095,7 +1095,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_dead_shane",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1138,7 +1138,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_snowey",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"
@@ -1181,7 +1181,7 @@
               "items": [],
               "tagSetSourceFile": "tags/SpawnEffectTags"
             },
-            "pilotDefId": "pilot_FP_AIZombie",
+            "pilotDefId": "pilot_zombiegirl",
             "pilotTagSet": {
               "items": [],
               "tagSetSourceFile": "tags/PilotTags"

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_fred.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_fred.json
@@ -32,6 +32,7 @@
   "PilotTags": {
     "items": [
       "pilot_backer",
+      "name_Zombie",
       "pilot_cautious",
       "BLACKLISTED",
       "pilot_military",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_fred.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_fred.json
@@ -34,7 +34,6 @@
       "pilot_backer",
       "pilot_cautious",
       "BLACKLISTED",
-      "MA_BLACKLISTED",
       "pilot_military",
       "pilot_criminal",
       "pilot_reckless",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_fred.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_fred.json
@@ -32,7 +32,7 @@
   "PilotTags": {
     "items": [
       "pilot_backer",
-      "name_Zombie",
+      "pilot_Zombie",
       "pilot_cautious",
       "BLACKLISTED",
       "pilot_military",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_girl2.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_girl2.json
@@ -32,7 +32,6 @@
   "PilotTags": {
     "items": [
       "BLACKLISTED",
-      "MA_BLACKLISTED",
       "pilot_backer",
       "pilot_military",
       "pilot_mechwarrior",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_girl2.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_girl2.json
@@ -33,6 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
+      "name_Zombie",
       "pilot_military",
       "pilot_mechwarrior",
       "pilot_criminal",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_girl2.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_girl2.json
@@ -33,7 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
-      "name_Zombie",
+      "pilot_Zombie",
       "pilot_military",
       "pilot_mechwarrior",
       "pilot_criminal",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_shane.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_shane.json
@@ -33,6 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
+      "name_Zombie",
       "pilot_military",
       "pilot_mechwarrior",
       "pilot_spacer",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_shane.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_shane.json
@@ -32,7 +32,6 @@
   "PilotTags": {
     "items": [
       "BLACKLISTED",
-      "MA_BLACKLISTED",
       "pilot_backer",
       "pilot_military",
       "pilot_mechwarrior",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_shane.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_dead_shane.json
@@ -33,7 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
-      "name_Zombie",
+      "pilot_Zombie",
       "pilot_military",
       "pilot_mechwarrior",
       "pilot_spacer",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_snowey.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_snowey.json
@@ -33,6 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
+      "name_Zombie",
       "pilot_military",
       "pilot_bookish",
       "pilot_tech",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_snowey.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_snowey.json
@@ -33,7 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
-      "name_Zombie",
+      "pilot_Zombie",
       "pilot_military",
       "pilot_bookish",
       "pilot_tech",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_snowey.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_snowey.json
@@ -32,7 +32,6 @@
   "PilotTags": {
     "items": [
       "BLACKLISTED",
-      "MA_BLACKLISTED",
       "pilot_backer",
       "pilot_military",
       "pilot_bookish",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombie6.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombie6.json
@@ -33,7 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
-      "name_Zombie",
+      "pilot_Zombie",
       "pilot_military",
       "pilot_honest",
       "pilot_dependable",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombie6.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombie6.json
@@ -32,7 +32,6 @@
   "PilotTags": {
     "items": [
       "BLACKLISTED",
-      "MA_BLACKLISTED",
       "pilot_backer",
       "pilot_military",
       "pilot_honest",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombie6.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombie6.json
@@ -33,6 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
+      "name_Zombie",
       "pilot_military",
       "pilot_honest",
       "pilot_dependable",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombiegirl.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombiegirl.json
@@ -32,7 +32,6 @@
   "PilotTags": {
     "items": [
       "BLACKLISTED",
-      "MA_BLACKLISTED",
       "pilot_backer",
       "pilot_military",
       "pilot_mechwarrior",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombiegirl.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombiegirl.json
@@ -33,7 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
-      "name_Zombie",
+      "pilot_Zombie",
       "pilot_military",
       "pilot_mechwarrior",
       "pilot_tech",

--- a/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombiegirl.json
+++ b/Core/Flashpoints/NecromoNightmare/pilot/pilot_zombiegirl.json
@@ -33,6 +33,7 @@
     "items": [
       "BLACKLISTED",
       "pilot_backer",
+      "name_Zombie",
       "pilot_military",
       "pilot_mechwarrior",
       "pilot_tech",

--- a/Core/MechAffinity/PilotRequirements/pilotRequirementsDef_zombie.json
+++ b/Core/MechAffinity/PilotRequirements/pilotRequirementsDef_zombie.json
@@ -1,0 +1,6 @@
+{
+  "TagId" : "name_Zombie",
+  "RequiredSystemCoreIds": [
+    "starsystemdef_Necromo"
+  ]
+}

--- a/Core/MechAffinity/PilotRequirements/pilotRequirementsDef_zombie.json
+++ b/Core/MechAffinity/PilotRequirements/pilotRequirementsDef_zombie.json
@@ -2,7 +2,7 @@
   "TagId" : "pilot_Zombie",
   "RequiredSystemCoreIds": [
     "starsystemdef_Necromo"
-  ]
+  ],
 "HiringVisibilityRequirements": [
     {
       "Scope": "Company",

--- a/Core/MechAffinity/PilotRequirements/pilotRequirementsDef_zombie.json
+++ b/Core/MechAffinity/PilotRequirements/pilotRequirementsDef_zombie.json
@@ -1,6 +1,16 @@
 {
-  "TagId" : "name_Zombie",
+  "TagId" : "pilot_Zombie",
   "RequiredSystemCoreIds": [
     "starsystemdef_Necromo"
   ]
+"HiringVisibilityRequirements": [
+    {
+      "Scope": "Company",
+      "RequirementTags": {
+        "tagSetSourceFile": "",
+        "items": [
+          "event_necromo_nightmare_complete",
+        ]
+      }
+   ]
 }


### PR DESCRIPTION
Enabling zombie pilots to be hired following the flashpoint completion, but only on Necromo. Updating the three escort missions to use named zombies rather generic zombies, all with Akodo's blessing. Added additional pilotRequirementsDef_zombie and name_Zombie to each pilot to ensure they can only ever be found in the Necromo Hiring Hall.