### PR TITLE
Change proxy models for Patriot, Rokurokubi, Tundra Wolf, Yu Huang, G…

### DIFF
--- a/Core/CustomUnits/mod.json
+++ b/Core/CustomUnits/mod.json
@@ -501,6 +501,16 @@
           "x": 0.97,
           "y": 0.97,
           "z": 0.97
+      },
+      "hammerhands": {
+          "x": 0.94,
+          "y": 0.94,
+          "z": 0.94
+      },
+      "emperor": {
+          "x": 1.01,
+          "y": 1.01,
+          "z": 1.01
       }
     },
     "vehicleSizePrefabMultipliers": {},

--- a/DLC/RogueFlashPointModule/Chassis/chassisdef_gunsmith_CH11-NGC.json
+++ b/DLC/RogueFlashPointModule/Chassis/chassisdef_gunsmith_CH11-NGC.json
@@ -35,16 +35,18 @@
   },
   "VariantName": "CH11-NGC",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.52"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Light Striker & Scout",
   "YangsThoughts": "The “Cinderella” is a high speed flashbulb. Fast and nimble, this Gunsmith variant—developed for Team Godmother with a little help from FedSuns benefactors—features Clan-spec weapons and a laser antimissile system to maximize its reach, hitting power, and accuracy all at once",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mongoose",
-  "PrefabIdentifier": "chrprfmech_mongoosebase-001",
-  "PrefabBase": "mongoose",
+  "HardpointDataDefID": "hardpointdatadef_wight",
+  "PrefabIdentifier": "chrprfmech_wightbase-001",
+  "PrefabBase": "wight",
   "Tonnage": 25.0,
   "InitialTonnage": 2.5,
   "weightClass": "LIGHT",

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_bombardier_BMB-14C.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_bombardier_BMB-14C.json
@@ -36,7 +36,7 @@
   "VariantName": "BMB-14C",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_war_dog_WR-DG-03FC.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_war_dog_WR-DG-03FC.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",
-      "mr-resize-0.97-0.99-1.0"
+      "mr-resize-0.92-0.97-0.82"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_yu_huang_Y-H9GC.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_yu_huang_Y-H9GC.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "Developed during the 3060s, this model was designed to take on the role of a command unit. To that end, the 'Mech is equipped with a C3 Master Computer in its left torso, replacing the original LRM-10. The weight saved by removing the LRM ammunition goes towards an additional double heat sink.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_bombardier_BMB-10D.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_bombardier_BMB-10D.json
@@ -36,7 +36,7 @@
   "VariantName": "BMB-10D",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_bombardier_BMB-12D-EC.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_bombardier_BMB-12D-EC.json
@@ -36,7 +36,7 @@
   "VariantName": "BMB-12D-EC",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_bombardier_BMB-12D.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_bombardier_BMB-12D.json
@@ -36,7 +36,7 @@
   "VariantName": "BMB-12D",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_masauwu_MWU-1.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_masauwu_MWU-1.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.97-0.99-1.0"
+      "mr-resize-0.92-0.97-0.82"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_paladin_PAL-1.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_paladin_PAL-1.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ArmLimitUpperLeft",
-      "mr-resize-0.85-0.92-0.89"
+      "mr-resize-0.81-0.88-0.84"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_quasit_QUA-51T.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_quasit_QUA-51T.json
@@ -46,7 +46,7 @@
   "ChassisTags": {
     "items": [
       "IndustrialMech",
-      "mr-resize-0.6"
+      "mr-resize-0.69"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_tai-sho_TSH-7S.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_tai-sho_TSH-7S.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-0.97"
+      "mr-resize-0.99"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_war_dog_WR-DG-02FC.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_war_dog_WR-DG-02FC.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",
-      "mr-resize-0.97-0.99-1.0"
+      "mr-resize-0.92-0.97-0.82"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_war_dog_WR-DG-03WDR.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_war_dog_WR-DG-03WDR.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ClanMech",
-      "mr-resize-0.97-0.99-1.0"
+      "mr-resize-0.92-0.97-0.82"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_yu_huang_Y-H10G.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_yu_huang_Y-H10G.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperLeft",
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The H10G variant is designed to directly engage an enemy at short ranges. The 10G removes all of the 'Mechs weapons. Instead, it carries a powerful Gauss Rifle for long range combat. This is supported by an ER Large Laser for additional long range firepower. For close combat, the 10G has six ER Medium Lasers and also carries a Guardian ECM Suite and a Beagle Active Probe to both protect the 'Mech from advanced enemy electronics systems and find hidden enemy units to prevent ambushes.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_yu_huang_Y-H11F.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_yu_huang_Y-H11F.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperLeft",
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Yu Huang, named for the Jade Emperor that rules the Heavenly Court in the ancient Chinese pantheon, debuted with the promise from Sun-Tzu Liao that \"it shall sit in judgment over a battlefield, meting out justice to those who would transgress against us\". To live up to the promise of the Chancellor of the Capellan Confederation, the Yu Huang carries some of the most advanced technologies available at the time of its initial production. The Yu Huang is built on an Endo Steel chassis and carries a 360 XL engine that gives the 'Mech a top speed of 64.8 km/h. The 'Mech is capable of jumping up to one hundred and twenty meters with its four jump jets.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_yu_huang_Y-H9G.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_yu_huang_Y-H9G.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Yu Huang, named for the Jade Emperor that rules the Heavenly Court in the ancient Chinese pantheon, debuted with the promise from Sun-Tzu Liao that 'it shall sit in judgment over a battlefield, meting out justice to those who would transgress against us'. To live up to the promise of the Chancellor of the Capellan Confederation, the Yu Huang carries some of the most advanced technologies available at the time of its initial production. The Yu Huang is built on a Chariot Type II Endo Steel chassis and carries a Hermes 360 XL engine that gives the 'Mech a top speed of 64.8 km/h. The 'Mech is capable of jumping up to one hundred and twenty meters with its four Rodan 90 jump jets.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_gunsmith_CH11-NG.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_gunsmith_CH11-NG.json
@@ -35,16 +35,18 @@
   },
   "VariantName": "CH11-NG",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.52"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Light Striker & Scout",
   "YangsThoughts": "Manufactured by Jalastar Aerospace from their plant on Panpour, the Gunsmith entered service shortly before the Blackout. Armed with 4 medium X-Pulses lasers,the Gunsmith quickly earned a fearsome reputation as a pursuit BattleMech and raider.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mongoose",
-  "PrefabIdentifier": "chrprfmech_mongoosebase-001",
-  "PrefabBase": "mongoose",
+  "HardpointDataDefID": "hardpointdatadef_wight",
+  "PrefabIdentifier": "chrprfmech_wightbase-001",
+  "PrefabBase": "wight",
   "Tonnage": 25.0,
   "InitialTonnage": 2.5,
   "weightClass": "LIGHT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_rokurokubi_RK-4K.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_rokurokubi_RK-4K.json
@@ -63,7 +63,7 @@
   "VariantName": "RK-4K",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.85"
+      "mr-resize-0.65-0.76-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -71,9 +71,9 @@
   "YangsThoughts": "The Rokurokubi is a light BattleMech built for the armed forces of the Draconis Combine and was styled after ancient Japanese bushido armor. Designed to be a light strike 'Mech, the Rokurokubi uses its speed and robust armor to close with an enemy unit while employing its singular ranged weapon until it can bring its sword to bear. The 'Mech was popular among the young samurai of House Kurita, who used it for honor duels between warriors in addition to regular combat.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_orion",
-  "PrefabIdentifier": "chrPrfMech_orionBase-001",
-  "PrefabBase": "orion",
+  "HardpointDataDefID": "hardpointdatadef_hito",
+  "PrefabIdentifier": "chrprfmech_hitobase-001",
+  "PrefabBase": "hito",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_rokurokubi_RK-4T.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_rokurokubi_RK-4T.json
@@ -63,7 +63,7 @@
   "VariantName": "RK-4T",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.85"
+      "mr-resize-0.65-0.76-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -71,9 +71,9 @@
   "YangsThoughts": "The Rokurokubi is a light BattleMech built for the armed forces of the Draconis Combine and was styled after ancient Japanese bushido armor. Designed to be a light strike 'Mech, the Rokurokubi uses its speed and robust armor to close with an enemy unit while employing its singular ranged weapon until it can bring its sword to bear. The 'Mech was popular among the young samurai of House Kurita, who used it for honor duels between warriors in addition to regular combat.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_orion",
-  "PrefabIdentifier": "chrPrfMech_orionBase-001",
-  "PrefabBase": "orion",
+  "HardpointDataDefID": "hardpointdatadef_hito",
+  "PrefabIdentifier": "chrprfmech_hitobase-001",
+  "PrefabBase": "hito",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_rokurokubi_RK-4X.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_rokurokubi_RK-4X.json
@@ -63,7 +63,7 @@
   "VariantName": "RK-4X",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.85"
+      "mr-resize-0.65-0.76-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -71,9 +71,9 @@
   "YangsThoughts": "The Rokurokubi is a light BattleMech built for the armed forces of the Draconis Combine and was styled after ancient Japanese bushido armor. Designed to be a light strike 'Mech, the Rokurokubi uses its speed and robust armor to close with an enemy unit while employing its singular ranged weapon until it can bring its sword to bear. The 'Mech was popular among the young samurai of House Kurita, who used it for honor duels between warriors in addition to regular combat.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_orion",
-  "PrefabIdentifier": "chrPrfMech_orionBase-001",
-  "PrefabBase": "orion",
+  "HardpointDataDefID": "hardpointdatadef_hito",
+  "PrefabIdentifier": "chrprfmech_hitobase-001",
+  "PrefabBase": "hito",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_tundra_wolf_TWF-1.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_tundra_wolf_TWF-1.json
@@ -38,7 +38,8 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "ClanMech"
+      "ClanMech",
+      "mr-resize-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +47,9 @@
   "YangsThoughts": "The Tundra Wolf was the first brand new Clan Wolf BattleMech fully developed and solely produced in the Inner Sphere. With losses mounting during the Word of Blake's Jihad, rather than a costly and complex OmniMech, Wolf technicians focused on producing a standard generalist design that could be readily manufactured and fill as many roles within their depleted touman as possible. While somewhat slow for a Clan-made 75-ton 'Mech, the Tundra Wolf made up for that with MASC, that allowed it to sprint in bursts and jump jets, enabling it to leap up to 120 meters at a time.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_toyama",
-  "PrefabIdentifier": "chrprfmech_toyamabase-001",
-  "PrefabBase": "toyama",
+  "HardpointDataDefID": "hardpointdatadef_t74mackie",
+  "PrefabIdentifier": "chrprfmech_t74mackiebase-001",
+  "PrefabBase": "t74mackie",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,
   "weightClass": "HEAVY",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_yu_huang_Y-H12GC.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_yu_huang_Y-H12GC.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitUpperLeft",
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Yu Huang, named for the Jade Emperor that rules the Heavenly Court in the ancient Chinese pantheon, debuted with the promise from Sun-Tzu Liao that \"it shall sit in judgment over a battlefield, meting out justice to those who would transgress against us\". To live up to the promise of the Chancellor of the Capellan Confederation, the Yu Huang carries some of the most advanced technologies available at the time of its initial production. The Yu Huang is built on an Endo Steel chassis and carries a 360 XL engine that gives the 'Mech a top speed of 64.8 km/h. The 'Mech is capable of jumping up to one hundred and twenty meters with its four jump jets.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/DarkAge3131-/Uniques/chassis/chassisdef_yu_huang_Y-HC.json
+++ b/Eras/DarkAge3131-/Uniques/chassis/chassisdef_yu_huang_Y-HC.json
@@ -41,7 +41,8 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "UniqueMech"
+      "UniqueMech",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -49,9 +50,9 @@
   "YangsThoughts": "The Yu Huang, named for the Jade Emperor that rules the Heavenly Court in the ancient Chinese pantheon, debuted with the promise from Sun-Tzu Liao that \"it shall sit in judgment over a battlefield, meting out justice to those who would transgress against us\". To live up to the promise of the Chancellor of the Capellan Confederation, the Yu Huang carries some of the most advanced technologies available at the time of its initial production. The Yu Huang is built on an Endo Steel chassis and carries a 360 XL engine that gives the 'Mech a top speed of 64.8 km/h.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_bombardier_BMB-05A.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_bombardier_BMB-05A.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ArmLimitUpperLeft",
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_bombardier_BMB-14K.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_bombardier_BMB-14K.json
@@ -36,7 +36,7 @@
   "VariantName": "BMB-14K",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_paladin_PAL-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_paladin_PAL-2.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ArmLimitUpperLeft",
-      "mr-resize-0.85-0.92-0.89"
+      "mr-resize-0.81-0.88-0.84"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_paladin_PAL-3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_paladin_PAL-3.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ArmLimitUpperLeft",
-      "mr-resize-0.85-0.92-0.89"
+      "mr-resize-0.81-0.88-0.84"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_patriot_PKM-2C.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_patriot_PKM-2C.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-0.9"
+      "mr-resize-0.89"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "The Patriot is a BattleMech produced by Ronin Incorporated on Wallis. Its genesis lies in the development of the Pikeman, a 'Mech that was in R&D when Kirc Cameron-Jones declared himself Captain-General of the Free Worlds League in 3069. With an eye to developing his military, he ordered Ronin to develop a 'Mech that could command a regiment and use artillery so that the commander would not be tempted to close with the enemy. Ronin was quickly able to convert their Pikeman to the necessary specifications, leading to production in late 3070. The variants of the 2C have seen greater production numbers and more widespread use, as their more general battlefield roles have surpassed the niche of the standard version.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gunslinger",
-  "PrefabIdentifier": "chrprfmech_gunslingerbase-001",
-  "PrefabBase": "gunslinger",
+  "HardpointDataDefID": "hardpointdatadef_ltmackie",
+  "PrefabIdentifier": "chrprfmech_ltmackiebase-001",
+  "PrefabBase": "ltmackie",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_patriot_PKM-2D.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_patriot_PKM-2D.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-0.9"
+      "mr-resize-0.89"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "The Patriot is a BattleMech produced by Ronin Incorporated on Wallis. Its genesis lies in the development of the Pikeman, a 'Mech that was in R&D when Kirc Cameron-Jones declared himself Captain-General of the Free Worlds League in 3069. With an eye to developing his military, he ordered Ronin to develop a 'Mech that could command a regiment and use artillery so that the commander would not be tempted to close with the enemy. Ronin was quickly able to convert their Pikeman to the necessary specifications, leading to production in late 3070. The variants of the 2C have seen greater production numbers and more widespread use, as their more general battlefield roles have surpassed the niche of the standard version.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gunslinger",
-  "PrefabIdentifier": "chrprfmech_gunslingerbase-001",
-  "PrefabBase": "gunslinger",
+  "HardpointDataDefID": "hardpointdatadef_ltmackie",
+  "PrefabIdentifier": "chrprfmech_ltmackiebase-001",
+  "PrefabBase": "ltmackie",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_patriot_PKM-2E.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_patriot_PKM-2E.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerRight",
       "ArmLimitUpperLeft",
-      "mr-resize-0.9"
+      "mr-resize-0.89"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +46,9 @@
   "YangsThoughts": "The Patriot is a BattleMech produced by Ronin Incorporated on Wallis. Its genesis lies in the development of the Pikeman, a 'Mech that was in R&D when Kirc Cameron-Jones declared himself Captain-General of the Free Worlds League in 3069. With an eye to developing his military, he ordered Ronin to develop a 'Mech that could command a regiment and use artillery so that the commander would not be tempted to close with the enemy. Ronin was quickly able to convert their Pikeman to the necessary specifications, leading to production in late 3070. The variants of the 2C have seen greater production numbers and more widespread use, as their more general battlefield roles have surpassed the niche of the standard version.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gunslinger",
-  "PrefabIdentifier": "chrprfmech_gunslingerbase-001",
-  "PrefabBase": "gunslinger",
+  "HardpointDataDefID": "hardpointdatadef_ltmackie",
+  "PrefabIdentifier": "chrprfmech_ltmackiebase-001",
+  "PrefabBase": "ltmackie",
   "Tonnage": 65.0,
   "InitialTonnage": 6.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_quasit_QUA-51M.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_quasit_QUA-51M.json
@@ -46,7 +46,7 @@
   "ChassisTags": {
     "items": [
       "IndustrialMech",
-      "mr-resize-0.6"
+      "mr-resize-0.69"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_quasit_QUA-51P.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_quasit_QUA-51P.json
@@ -46,7 +46,7 @@
   "ChassisTags": {
     "items": [
       "IndustrialMech",
-      "mr-resize-0.6"
+      "mr-resize-0.69"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_tai-sho_TSH-8S.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_tai-sho_TSH-8S.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-0.97"
+      "mr-resize-0.99"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_tundra_wolf_TWF-2.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_tundra_wolf_TWF-2.json
@@ -38,7 +38,8 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "ClanMech"
+      "ClanMech",
+      "mr-resize-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +47,9 @@
   "YangsThoughts": "The Tundra Wolf was the first brand new Clan Wolf BattleMech fully developed and solely produced in the Inner Sphere. With losses mounting during the Word of Blake's Jihad, rather than a costly and complex OmniMech, Wolf technicians focused on producing a standard generalist design that could be readily manufactured and fill as many roles within their depleted touman as possible. While somewhat slow for a Clan-made 75-ton 'Mech, the Tundra Wolf made up for that with MASC, that allowed it to sprint in bursts and jump jets, enabling it to leap up to 120 meters at a time.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_toyama",
-  "PrefabIdentifier": "chrprfmech_toyamabase-001",
-  "PrefabBase": "toyama",
+  "HardpointDataDefID": "hardpointdatadef_t74mackie",
+  "PrefabIdentifier": "chrprfmech_t74mackiebase-001",
+  "PrefabBase": "t74mackie",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_tundra_wolf_TWF-3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_tundra_wolf_TWF-3.json
@@ -38,7 +38,8 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "ClanMech"
+      "ClanMech",
+      "mr-resize-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +47,9 @@
   "YangsThoughts": "The Tundra Wolf was the first brand new Clan Wolf BattleMech fully developed and solely produced in the Inner Sphere. With losses mounting during the Word of Blake's Jihad, rather than a costly and complex OmniMech, Wolf technicians focused on producing a standard generalist design that could be readily manufactured and fill as many roles within their depleted touman as possible. While somewhat slow for a Clan-made 75-ton 'Mech, the Tundra Wolf made up for that with MASC, that allowed it to sprint in bursts and jump jets, enabling it to leap up to 120 meters at a time.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_toyama",
-  "PrefabIdentifier": "chrprfmech_toyamabase-001",
-  "PrefabBase": "toyama",
+  "HardpointDataDefID": "hardpointdatadef_t74mackie",
+  "PrefabIdentifier": "chrprfmech_t74mackiebase-001",
+  "PrefabBase": "t74mackie",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_tundra_wolf_TWF-4.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_tundra_wolf_TWF-4.json
@@ -38,7 +38,8 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "ClanMech"
+      "ClanMech",
+      "mr-resize-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +47,9 @@
   "YangsThoughts": "The Tundra Wolf was the first brand new Clan Wolf BattleMech fully developed and solely produced in the Inner Sphere. With losses mounting during the Word of Blake's Jihad, rather than a costly and complex OmniMech, Wolf technicians focused on producing a standard generalist design that could be readily manufactured and fill as many roles within their depleted touman as possible. While somewhat slow for a Clan-made 75-ton 'Mech, the Tundra Wolf made up for that with MASC, that allowed it to sprint in bursts and jump jets, enabling it to leap up to 120 meters at a time.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_toyama",
-  "PrefabIdentifier": "chrprfmech_toyamabase-001",
-  "PrefabBase": "toyama",
+  "HardpointDataDefID": "hardpointdatadef_t74mackie",
+  "PrefabIdentifier": "chrprfmech_t74mackiebase-001",
+  "PrefabBase": "t74mackie",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,
   "weightClass": "HEAVY",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-1LAW-SC.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-1LAW-SC.json
@@ -36,7 +36,7 @@
   "VariantName": "WGT-1LAW/SC",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.63"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-1LAW-SC3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-1LAW-SC3.json
@@ -36,7 +36,7 @@
   "VariantName": "WGT-1LAW/SC3",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.63"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-2LAW.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-2LAW.json
@@ -36,7 +36,7 @@
   "VariantName": "WGT-2LAW",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.63"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-2LAWC3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-2LAWC3.json
@@ -36,7 +36,7 @@
   "VariantName": "WGT-2LAWC3",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.63"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-2SC.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-2SC.json
@@ -36,7 +36,7 @@
   "VariantName": "WGT-2SC",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.63"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-3SC.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-3SC.json
@@ -36,7 +36,7 @@
   "VariantName": "WGT-3SC",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.63"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-4NC.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_wight_WGT-4NC.json
@@ -92,7 +92,7 @@
   "VariantName": "WGT-4NC",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.75"
+      "mr-resize-0.63"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_yu_huang_Y-H11G.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_yu_huang_Y-H11G.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "This variant was introduced during the throes of the Jihad. The H-11 is armed with a pair of Plasma Rifles, one in each arm, with four tons of ammunition feeding from the center torso. An 5-Tubed Multi-Missile Launchers is mounted in each of the side torsos, with 2 tons of CASE protected ammunition for each launcher. The left arm mounts the 'Mech's energy weapons, which consists of two standard Medium Lasers and a single Medium Pulse Laser.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_yu_huang_Y-H9GB.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_yu_huang_Y-H9GB.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-1.11-1.04-1.04"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "Based on the original 9G, this variant was produced during the Jihad. The 'Mech's long-range weaponry included an LRM-10 launcher with 1 ton of ammunition and a standard Large Laser fitted in the left arm. The 'Mech's close-in weaponry included an Class 20 Ultra Autocannon with 3 tons of ammunition and three standard Medium Lasers.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_emperor",
-  "PrefabIdentifier": "chrprfmech_emperorbase-001",
-  "PrefabBase": "emperor",
+  "HardpointDataDefID": "hardpointdatadef_hammerhands",
+  "PrefabIdentifier": "chrprfmech_hammerhandsbase-001",
+  "PrefabBase": "hammerhands",
   "Tonnage": 90.0,
   "InitialTonnage": 9.0,
   "weightClass": "ASSAULT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_tundra_wolf_TWF-5.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_tundra_wolf_TWF-5.json
@@ -38,7 +38,8 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "ClanMech"
+      "ClanMech",
+      "mr-resize-0.92"
     ],
     "tagSetSourceFile": ""
   },
@@ -46,9 +47,9 @@
   "YangsThoughts": "The Tundra Wolf was the first brand new Clan Wolf BattleMech fully developed and solely produced in the Inner Sphere. With losses mounting during the Word of Blake's Jihad, rather than a costly and complex OmniMech, Wolf technicians focused on producing a standard generalist design that could be readily manufactured and fill as many roles within their depleted touman as possible. While somewhat slow for a Clan-made 75-ton 'Mech, the Tundra Wolf made up for that with MASC, that allowed it to sprint in bursts and jump jets, enabling it to leap up to 120 meters at a time.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_toyama",
-  "PrefabIdentifier": "chrprfmech_toyamabase-001",
-  "PrefabBase": "toyama",
+  "HardpointDataDefID": "hardpointdatadef_t74mackie",
+  "PrefabIdentifier": "chrprfmech_t74mackiebase-001",
+  "PrefabBase": "t74mackie",
   "Tonnage": 75.0,
   "InitialTonnage": 7.5,
   "weightClass": "HEAVY",

--- a/Optionals/RISCtech/Base/chassis/chassisdef_bombardier_BMB-XR.json
+++ b/Optionals/RISCtech/Base/chassis/chassisdef_bombardier_BMB-XR.json
@@ -53,7 +53,7 @@
     "items": [
       "EliteMech",
       "RISCBattleMech",
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/RogueElites/Base/chassis/chassisdef_bombardier_BMB-MM.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_bombardier_BMB-MM.json
@@ -40,7 +40,7 @@
   "ChassisTags": {
     "items": [
       "EliteMech",
-      "mr-resize-0.9"
+      "mr-resize-0.98"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/RogueElites/Base/chassis/chassisdef_gunsmith_CH11-HB.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_gunsmith_CH11-HB.json
@@ -39,7 +39,8 @@
   "VariantName": "CH11-HB",
   "ChassisTags": {
     "items": [
-      "EliteMech"
+      "EliteMech",
+      "mr-resize-0.52"
     ],
     "tagSetSourceFile": ""
   },
@@ -47,9 +48,9 @@
   "YangsThoughts": "This is one of Jalastar Aerospace's Gunsmith 'Mechs, greatly upgraded and retrofitted. The X-Pulses have been replaced with Medium Heavy Lasers, with a special FCS installed to help control the heat. A Clan-tech MASC and enormous XL engine ensure it's the fastest 'Mech on the battlefield, while the heavily upgraded arm actuators help hitting a shot on the run. Boss, this thing is extremely dangerous, and fast even for a light. Whoever used this 'Mech must have been one hell of a crack shot to hit anything at these speeds.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mongoose",
-  "PrefabIdentifier": "chrprfmech_mongoosebase-001",
-  "PrefabBase": "mongoose",
+  "HardpointDataDefID": "hardpointdatadef_wight",
+  "PrefabIdentifier": "chrprfmech_wightbase-001",
+  "PrefabBase": "wight",
   "Tonnage": 25.0,
   "InitialTonnage": 2.5,
   "weightClass": "LIGHT",


### PR DESCRIPTION
…unsmith; resize Quasit, Bombardier, Paladin, Tai-Sho, Hammerhands, War Dog, Emperor, Wight;

Patriot now using LT Mackie model
Rokurokubi now using Hitotsume Kozo model
Tundra Wolf now using T74 Mackie model
Yu Huang now using Hammerhands model
Gunsmith now using Wight model