### PR TITLE
Change proxy models for Storm Raider, Sojourner, Gestalt, Dart, Tesse…

### DIFF
--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_ronin_SA-RN7.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_ronin_SA-RN7.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",
-      "mr-resize-0.97"
+      "mr-resize-0.82-0.95-0.84"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_tessen_TSN-C3.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_tessen_TSN-C3.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.78-0.88-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Tessen began as a joint project between the Draconis Combine and ComStar to build a heavy scout 'Mech. The project fell through and was left unfinished until ComStar continued the project independently when they were looking for a new 'Mech to deploy the new improved C3 system when it was initially developed. The Tessen is built on a lightweight Endo Steel chassis and is powered by a lightweight Vlar 300 XL engine, giving the 'Mech a top speed of 97.2 km/h.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_firebeev2",
+  "PrefabIdentifier": "chrprfmech_firebeev2base-001",
+  "PrefabBase": "firebeev2",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_thunder_THR-2L.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_thunder_THR-2L.json
@@ -36,7 +36,8 @@
   "VariantName": "THR-2L",
   "ChassisTags": {
     "items": [
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.06-0.92-1.06"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/CivilWar3062-3067/Base/chassis/chassisdef_thunder_THR-3L.json
+++ b/Eras/CivilWar3062-3067/Base/chassis/chassisdef_thunder_THR-3L.json
@@ -36,7 +36,8 @@
   "VariantName": "THR-3L",
   "ChassisTags": {
     "items": [
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.06-0.92-1.06"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_dart_DRT-3S.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_dart_DRT-3S.json
@@ -36,16 +36,18 @@
   },
   "VariantName": "DRT-3S",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.66-0.66-0.51"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Extremely Maneuverable Scout",
   "YangsThoughts": "The Dart is armed with three Magna 200P Small Pulse Lasers which do not have a long range but provide the Dart with highly accurate short range firepower.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_spider",
-  "PrefabIdentifier": "chrPrfMech_spiderBase-001",
-  "PrefabBase": "spider",
+  "HardpointDataDefID": "hardpointdatadef_iceferret",
+  "PrefabIdentifier": "chrprfmech_iceferretbase-001",
+  "PrefabBase": "iceferret",
   "Tonnage": 25.0,
   "InitialTonnage": 2.5,
   "weightClass": "LIGHT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_dart_DRT-4S.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_dart_DRT-4S.json
@@ -36,16 +36,18 @@
   },
   "VariantName": "DRT-4S",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.66-0.66-0.51"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Extremely Maneuverable Scout",
   "YangsThoughts": "The 4S modifies the Dart in an attempt to add much needed firepower to the design without sacrificing the 'Mechs independence from ammunition. This is done by removing the three Small Pulse Lasers and replacing them with three Medium Lasers. While this reduces the 'Mech's accuracy, the range and damage profiles are both increased over the 3S model.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_spider",
-  "PrefabIdentifier": "chrPrfMech_spiderBase-001",
-  "PrefabBase": "spider",
+  "HardpointDataDefID": "hardpointdatadef_iceferret",
+  "PrefabIdentifier": "chrprfmech_iceferretbase-001",
+  "PrefabBase": "iceferret",
   "Tonnage": 25.0,
   "InitialTonnage": 2.5,
   "weightClass": "LIGHT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_dart_DRT-6S.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_dart_DRT-6S.json
@@ -36,16 +36,18 @@
   },
   "VariantName": "DRT-6S",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.66-0.66-0.51"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Extremely Maneuverable Scout",
   "YangsThoughts": "The 6S variant of the Dart increases both its firepower and armor protection. The 'Mech carries four and a half tons of Ferro-Fibrous armor. The 'Mech is armed with two Medium Lasers. Even with one less Medium Laser than the 4S model, the 6S brings more overall firepower to the field than the 3S.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_spider",
-  "PrefabIdentifier": "chrPrfMech_spiderBase-001",
-  "PrefabBase": "spider",
+  "HardpointDataDefID": "hardpointdatadef_iceferret",
+  "PrefabIdentifier": "chrprfmech_iceferretbase-001",
+  "PrefabBase": "iceferret",
   "Tonnage": 25.0,
   "InitialTonnage": 2.5,
   "weightClass": "LIGHT",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_jackrabbit_JKR-8T.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_jackrabbit_JKR-8T.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-0.8"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_jackrabbit_JKR-9R.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_jackrabbit_JKR-9R.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-0.8"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_ronin_SA-RN.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_ronin_SA-RN.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",
-      "mr-resize-0.97"
+      "mr-resize-0.82-0.95-0.84"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_ronin_SA-RNS.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_ronin_SA-RNS.json
@@ -37,7 +37,7 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerRight",
-      "mr-resize-0.97"
+      "mr-resize-0.82-0.95-0.84"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_tessen_TSN-1C.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_tessen_TSN-1C.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.78-0.88-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Tessen began as a joint project between the Draconis Combine and ComStar to build a heavy scout 'Mech. The project fell through and was left unfinished until ComStar continued the project independently when they were looking for a new 'Mech to deploy the new improved C3 system when it was initially developed. The Tessen is built on a lightweight Endo Steel chassis and is powered by a lightweight Vlar 300 XL engine, giving the 'Mech a top speed of 97.2 km/h.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_firebeev2",
+  "PrefabIdentifier": "chrprfmech_firebeev2base-001",
+  "PrefabBase": "firebeev2",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_thunder_THR-1L.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_thunder_THR-1L.json
@@ -36,7 +36,8 @@
   "VariantName": "THR-1L",
   "ChassisTags": {
     "items": [
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.06-0.92-1.06"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_oxide_JR7-O.json
+++ b/Eras/ClanInvasion3061/Uniques/chassis/chassisdef_oxide_JR7-O.json
@@ -42,7 +42,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "UniqueMech",
-      "mr-resize-1.1-1.0-1.05"
+      "mr-resize-0.86-0.89-0.86"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5B.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5B.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-1.0"
+      "mr-resize-1.02"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_juliano_JLN-5C.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-1.0"
+      "mr-resize-1.02"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-A.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-A.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.01-1.01-1.16"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "The A configuration changes the role of the Sojourner to be more of a close quarters brawler with its weaponry of a Rotary AC/2, a ProtoMech AC/8, a Large Pulse Laser and 4 ER Micro Lasers.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gargoyle",
-  "PrefabIdentifier": "chrprfmech_gargoylebase-001",
-  "PrefabBase": "gargoyle",
+  "HardpointDataDefID": "hardpointdatadef_roughneck",
+  "PrefabIdentifier": "chrprfmech_roughneckbase-001",
+  "PrefabBase": "roughneck",
   "Tonnage": 60.0,
   "InitialTonnage": 6.0,
   "weightClass": "HEAVY",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-B.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-B.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.01-1.01-1.16"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "With the B configuration the Sojourner gets more of a support role, carrying an ECM suite and 2 ER Large Pulse lasers combined with a single Streak SRM-6. Four Jump Jets together with a Supercharger ensures the mobility of the configuration.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gargoyle",
-  "PrefabIdentifier": "chrprfmech_gargoylebase-001",
-  "PrefabBase": "gargoyle",
+  "HardpointDataDefID": "hardpointdatadef_roughneck",
+  "PrefabIdentifier": "chrprfmech_roughneckbase-001",
+  "PrefabBase": "roughneck",
   "Tonnage": 60.0,
   "InitialTonnage": 6.0,
   "weightClass": "HEAVY",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-C.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-C.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.01-1.01-1.16"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "The C configuration converts the Sojourner to a missile boat by arming it with two LRM 20s. The configuration also sports a Heavy Large Laser and a Micro Pulse Laser to defend itself.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gargoyle",
-  "PrefabIdentifier": "chrprfmech_gargoylebase-001",
-  "PrefabBase": "gargoyle",
+  "HardpointDataDefID": "hardpointdatadef_roughneck",
+  "PrefabIdentifier": "chrprfmech_roughneckbase-001",
+  "PrefabBase": "roughneck",
   "Tonnage": 60.0,
   "InitialTonnage": 6.0,
   "weightClass": "HEAVY",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-D.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-D.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.01-1.01-1.16"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "Configuration D combines an Ultra AC/10 with an ER PPC and two Medium Pulse Lasers for better mid range performance.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gargoyle",
-  "PrefabIdentifier": "chrprfmech_gargoylebase-001",
-  "PrefabBase": "gargoyle",
+  "HardpointDataDefID": "hardpointdatadef_roughneck",
+  "PrefabIdentifier": "chrprfmech_roughneckbase-001",
+  "PrefabBase": "roughneck",
   "Tonnage": 60.0,
   "InitialTonnage": 6.0,
   "weightClass": "HEAVY",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-Prime.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_sojourner_SJN-Prime.json
@@ -81,7 +81,8 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "ClanMech",
-      "OmniMech"
+      "OmniMech",
+      "mr-resize-1.01-1.01-1.16"
     ],
     "tagSetSourceFile": ""
   },
@@ -89,9 +90,9 @@
   "YangsThoughts": "The Sojourner is a simple 'Mech designed by Clan Wolf-in-Exile after the staggering loss at Arc-Royal. The 'Mech went through several design phases resulting in a final design that was both easy to maintain and pilot, with the primary use being to teach younger MechWarriors the trade of 'Mech-on-'Mech combat. As a result the pilots of these 'Mechs have a considerably higher survival rate compared to other, harder to pilot 'Mechs like the Linebacker. The base variant of the Sojourner carries a Gauss Rifle, with the compliment of a single ER Large Laser and a Plasma Cannon. The combination of 3 Jump Jets, a Supercharger and an AES system makes the 'Mech quite mobile on the battlefield despite its somewhat underpowered 240-rated Fusion Core. A CASE II system and a single external Double Heat Sink finishes up the design.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_gargoyle",
-  "PrefabIdentifier": "chrprfmech_gargoylebase-001",
-  "PrefabBase": "gargoyle",
+  "HardpointDataDefID": "hardpointdatadef_roughneck",
+  "PrefabIdentifier": "chrprfmech_roughneckbase-001",
+  "PrefabBase": "roughneck",
   "Tonnage": 60.0,
   "InitialTonnage": 6.0,
   "weightClass": "HEAVY",

--- a/Eras/DarkAge3131-/Uniques/chassis/chassisdef_tessen_TSN-X4R.json
+++ b/Eras/DarkAge3131-/Uniques/chassis/chassisdef_tessen_TSN-X4R.json
@@ -39,7 +39,8 @@
   "VariantName": "TSN-X4R",
   "ChassisTags": {
     "items": [
-      "UniqueMech"
+      "UniqueMech",
+      "mr-resize-0.78-0.88-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -47,9 +48,9 @@
   "YangsThoughts": "The Tessen began as a joint project between the Draconis Combine and ComStar to build a heavy scout 'Mech. The project fell through and was left unfinished until ComStar continued the project independently when they were looking for a new 'Mech to deploy the new improved C3 system when it was initially developed. The Tessen is built on a lightweight Endo Steel chassis and is powered by a lightweight Vlar 300 XL engine, giving the 'Mech a top speed of 97.2 km/h.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_firebeev2",
+  "PrefabIdentifier": "chrprfmech_firebeev2base-001",
+  "PrefabBase": "firebeev2",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_dart_DRT-6T.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_dart_DRT-6T.json
@@ -36,16 +36,18 @@
   },
   "VariantName": "DRT-6T",
   "ChassisTags": {
-    "items": [],
+    "items": [
+      "mr-resize-0.66-0.66-0.51"
+    ],
     "tagSetSourceFile": ""
   },
   "StockRole": "Extremely Maneuverable Scout",
   "YangsThoughts": "A Jihad-era variant, by using a Light Fusion Engine and removing the other weapons, engineers were able to install a Light PPC and ER Small Laser connected to a Targeting Computer.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_spider",
-  "PrefabIdentifier": "chrPrfMech_spiderBase-001",
-  "PrefabBase": "spider",
+  "HardpointDataDefID": "hardpointdatadef_iceferret",
+  "PrefabIdentifier": "chrprfmech_iceferretbase-001",
+  "PrefabBase": "iceferret",
   "Tonnage": 25.0,
   "InitialTonnage": 2.5,
   "weightClass": "LIGHT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_gestalt_D2X-G.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_gestalt_D2X-G.json
@@ -36,7 +36,7 @@
   "VariantName": "D2X-G",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.85-1.1-1"
+      "mr-resize-0.85-0.85-0.97"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Produced from the Gibson Federated BattleMechs factories on Gibson for a brief period in the 3070s prior to the destruction of Gibson in 3078 at the hands of forces from the Principality of Regulus, the Gestalt was the first and only BattleMech in the Machina Domini class of 'Mechs. The 'Mech was given the name Gestalt not by the Word of Blake, who manufactured it, but by the rebel forces on Gibson who faced it in combat; although the design was only at the prototype stage, the Gestalt underwent extensive field-testing on Gibson in a range of roles, from ambush duties making full use of the combination of Angel ECM and the Void Signature System to interdiction, recon and high-speed pursuit.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_preta",
-  "PrefabIdentifier": "chrPrfMech_pretabase-001",
-  "PrefabBase": "preta",
+  "HardpointDataDefID": "hardpointdatadef_phoenix",
+  "PrefabIdentifier": "chrprfmech_phoenixbase-001",
+  "PrefabBase": "phoenix",
   "Tonnage": 45.0,
   "InitialTonnage": 4.5,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_jackrabbit_JKR-9W.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_jackrabbit_JKR-9W.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-0.8"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_jenner_JR8-X.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_jenner_JR8-X.json
@@ -39,7 +39,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "PrototypeMech",
-      "mr-resize-1.22-1.11-1.16"
+      "mr-resize-0.87"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_storm_raider_STM-M3.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_storm_raider_STM-M3.json
@@ -36,7 +36,7 @@
   "VariantName": "STM-M3",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.82"
+      "mr-resize-0.70-0.70-0.80"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Designed by Defiance Industries, the Storm Raider was intended to be an alternative to the Hollander light 'Mech. Unfortunately for Defiance, the Storm Raider was 50 years too late for the market, and the various prototypes were poorly received - so poorly received, in fact, that Defiance licensed all of the designs to Coventry Metal Works. Coventry Metal Works was manufacturing four different variants of the Storm Raider intended for use in urban defense roles or for small-scale surgical strikes, but the Storm Raider was a poor performer in both roles, outgunned by contemporaries and slower than most. Despite that, the Storm Raider proved an able fighter in the arenas at Solaris VII, where it became a fan favorite.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_warhammer",
-  "PrefabIdentifier": "chrPrfMech_warhammerBase-001",
-  "PrefabBase": "warhammer",
+  "HardpointDataDefID": "hardpointdatadef_kintaro",
+  "PrefabIdentifier": "chrPrfMech_kintaroBase-001",
+  "PrefabBase": "kintaro",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_tessen_TSN-1Cr.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_tessen_TSN-1Cr.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.78-0.88-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Tessen began as a joint project between the Draconis Combine and ComStar to build a heavy scout 'Mech. The project fell through and was left unfinished until ComStar continued the project independently when they were looking for a new 'Mech to deploy the new improved C3 system when it was initially developed. The Tessen is built on a lightweight Endo Steel chassis and is powered by a lightweight Vlar 300 XL engine, giving the 'Mech a top speed of 97.2 km/h.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_firebeev2",
+  "PrefabIdentifier": "chrprfmech_firebeev2base-001",
+  "PrefabBase": "firebeev2",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_tessen_TSN-C3M.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_tessen_TSN-C3M.json
@@ -36,7 +36,8 @@
   "VariantName": "TSN-C3M",
   "ChassisTags": {
     "items": [
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.78-0.88-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +45,9 @@
   "YangsThoughts": "The Tessen began as a joint project between the Draconis Combine and ComStar to build a heavy scout 'Mech. The project fell through and was left unfinished until ComStar continued the project independently when they were looking for a new 'Mech to deploy the new improved C3 system when it was initially developed. The Tessen is built on a lightweight Endo Steel chassis and is powered by a lightweight Vlar 300 XL engine, giving the 'Mech a top speed of 97.2 km/h.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_firebeev2",
+  "PrefabIdentifier": "chrprfmech_firebeev2base-001",
+  "PrefabBase": "firebeev2",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_tessen_TSN-X-4.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_tessen_TSN-X-4.json
@@ -37,7 +37,8 @@
   "ChassisTags": {
     "items": [
       "ArmLimitLowerLeft",
-      "ArmLimitLowerRight"
+      "ArmLimitLowerRight",
+      "mr-resize-0.78-0.88-0.73"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +46,9 @@
   "YangsThoughts": "The Tessen began as a joint project between the Draconis Combine and ComStar to build a heavy scout 'Mech. The project fell through and was left unfinished until ComStar continued the project independently when they were looking for a new 'Mech to deploy the new improved C3 system when it was initially developed. The Tessen is built on a lightweight Endo Steel chassis and is powered by a lightweight Vlar 300 XL engine, giving the 'Mech a top speed of 97.2 km/h.",
   "MovementCapDefID": "movedef_mediummech",
   "PathingCapDefID": "pathingdef_medium",
-  "HardpointDataDefID": "hardpointdatadef_centurion",
-  "PrefabIdentifier": "chrPrfMech_centurionBase-001",
-  "PrefabBase": "centurion",
+  "HardpointDataDefID": "hardpointdatadef_firebeev2",
+  "PrefabIdentifier": "chrprfmech_firebeev2base-001",
+  "PrefabBase": "firebeev2",
   "Tonnage": 50.0,
   "InitialTonnage": 5.0,
   "weightClass": "MEDIUM",

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_thunder_THR-C4.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_thunder_THR-C4.json
@@ -36,7 +36,8 @@
   "VariantName": "THR-C4",
   "ChassisTags": {
     "items": [
-      "ArmLimitUpperRight"
+      "ArmLimitUpperRight",
+      "mr-resize-1.06-0.92-1.06"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_juliano_JLN-5A.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_juliano_JLN-5A.json
@@ -38,7 +38,7 @@
     "items": [
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
-      "mr-resize-1.0"
+      "mr-resize-1.02"
     ],
     "tagSetSourceFile": ""
   },

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_lightning_LHN-C5.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_lightning_LHN-C5.json
@@ -37,7 +37,7 @@
   "VariantName": "LHN-C5",
   "ChassisTags": {
     "items": [
-      "mr-resize-1.2"
+      "mr-resize-0.95-0.97-0.85"
     ],
     "tagSetSourceFile": ""
   },
@@ -45,9 +45,9 @@
   "YangsThoughts": "The Lightning 'Mech was developed as a partner for the Thunder-2L BattleMech. It uses the same chassis, engine, gyro, and communications systems as the Thunder. This greatly simplifies logistics and repair operations.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_trebuchet",
-  "PrefabIdentifier": "chrPrfMech_trebuchetBase-001",
-  "PrefabBase": "trebuchet",
+  "HardpointDataDefID": "hardpointdatadef_quickdraw",
+  "PrefabIdentifier": "chrPrfMech_quickdrawBase-001",
+  "PrefabBase": "quickdraw",
   "Tonnage": 70.0,
   "InitialTonnage": 7.0,
   "weightClass": "HEAVY",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R1.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R1.json
@@ -36,7 +36,7 @@
   "VariantName": "STM-R1",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.82"
+      "mr-resize-0.70-0.70-0.80"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Designed by Defiance Industries, the Storm Raider was intended to be an alternative to the Hollander light 'Mech. Unfortunately for Defiance, the Storm Raider was 50 years too late for the market, and the various prototypes were poorly received - so poorly received, in fact, that Defiance licensed all of the designs to Coventry Metal Works. Coventry Metal Works was manufacturing four different variants of the Storm Raider intended for use in urban defense roles or for small-scale surgical strikes, but the Storm Raider was a poor performer in both roles, outgunned by contemporaries and slower than most. Despite that, the Storm Raider proved an able fighter in the arenas at Solaris VII, where it became a fan favorite.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_warhammer",
-  "PrefabIdentifier": "chrPrfMech_warhammerBase-001",
-  "PrefabBase": "warhammer",
+  "HardpointDataDefID": "hardpointdatadef_kintaro",
+  "PrefabIdentifier": "chrPrfMech_kintaroBase-001",
+  "PrefabBase": "kintaro",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R2.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R2.json
@@ -36,7 +36,7 @@
   "VariantName": "STM-R2",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.82"
+      "mr-resize-0.70-0.70-0.80"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Designed by Defiance Industries, the Storm Raider was intended to be an alternative to the Hollander light 'Mech. Unfortunately for Defiance, the Storm Raider was 50 years too late for the market, and the various prototypes were poorly received - so poorly received, in fact, that Defiance licensed all of the designs to Coventry Metal Works. Coventry Metal Works was manufacturing four different variants of the Storm Raider intended for use in urban defense roles or for small-scale surgical strikes, but the Storm Raider was a poor performer in both roles, outgunned by contemporaries and slower than most. Despite that, the Storm Raider proved an able fighter in the arenas at Solaris VII, where it became a fan favorite.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_warhammer",
-  "PrefabIdentifier": "chrPrfMech_warhammerBase-001",
-  "PrefabBase": "warhammer",
+  "HardpointDataDefID": "hardpointdatadef_kintaro",
+  "PrefabIdentifier": "chrPrfMech_kintaroBase-001",
+  "PrefabBase": "kintaro",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R3.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R3.json
@@ -36,7 +36,7 @@
   "VariantName": "STM-R3",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.82"
+      "mr-resize-0.70-0.70-0.80"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Designed by Defiance Industries, the Storm Raider was intended to be an alternative to the Hollander light 'Mech. Unfortunately for Defiance, the Storm Raider was 50 years too late for the market, and the various prototypes were poorly received - so poorly received, in fact, that Defiance licensed all of the designs to Coventry Metal Works. Coventry Metal Works was manufacturing four different variants of the Storm Raider intended for use in urban defense roles or for small-scale surgical strikes, but the Storm Raider was a poor performer in both roles, outgunned by contemporaries and slower than most. Despite that, the Storm Raider proved an able fighter in the arenas at Solaris VII, where it became a fan favorite.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_warhammer",
-  "PrefabIdentifier": "chrPrfMech_warhammerBase-001",
-  "PrefabBase": "warhammer",
+  "HardpointDataDefID": "hardpointdatadef_kintaro",
+  "PrefabIdentifier": "chrPrfMech_kintaroBase-001",
+  "PrefabBase": "kintaro",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R4.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_storm_raider_STM-R4.json
@@ -36,7 +36,7 @@
   "VariantName": "STM-R4",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.82"
+      "mr-resize-0.70-0.70-0.80"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "Designed by Defiance Industries, the Storm Raider was intended to be an alternative to the Hollander light 'Mech. Unfortunately for Defiance, the Storm Raider was 50 years too late for the market, and the various prototypes were poorly received - so poorly received, in fact, that Defiance licensed all of the designs to Coventry Metal Works. Coventry Metal Works was manufacturing four different variants of the Storm Raider intended for use in urban defense roles or for small-scale surgical strikes, but the Storm Raider was a poor performer in both roles, outgunned by contemporaries and slower than most. Despite that, the Storm Raider proved an able fighter in the arenas at Solaris VII, where it became a fan favorite.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_warhammer",
-  "PrefabIdentifier": "chrPrfMech_warhammerBase-001",
-  "PrefabBase": "warhammer",
+  "HardpointDataDefID": "hardpointdatadef_kintaro",
+  "PrefabIdentifier": "chrPrfMech_kintaroBase-001",
+  "PrefabBase": "kintaro",
   "Tonnage": 35.0,
   "InitialTonnage": 3.5,
   "weightClass": "LIGHT",

--- a/Optionals/PirateTech/Base/chassis/chassisdef_jenner_JR7-RX.json
+++ b/Optionals/PirateTech/Base/chassis/chassisdef_jenner_JR7-RX.json
@@ -39,7 +39,7 @@
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
       "PrototypeMech",
-      "mr-resize-1.22-1.11-1.16"
+      "mr-resize-0.87"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/RogueElites/Base/chassis/chassisdef_jackrabbit_JKR-AP.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_jackrabbit_JKR-AP.json
@@ -42,7 +42,7 @@
       "ArmLimitLowerLeft",
       "ArmLimitLowerRight",
       "EliteMech",
-      "mr-resize-0.8"
+      "mr-resize-0.6"
     ],
     "tagSetSourceFile": ""
   },

--- a/Optionals/RogueElites/Base/chassis/chassisdef_jenner_JR7-CHP.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_jenner_JR7-CHP.json
@@ -62,7 +62,7 @@
     "items": [
       "ArmLimitUpperLeft",
       "ArmLimitUpperRight",
-      "mr-resize-1.22-1.11-1.16"
+      "mr-resize-0.92-0.86-0.87"
     ],
     "tagSetSourceFile": ""
   },


### PR DESCRIPTION
…n, Lightning; Resize Jackrabbit, Juliano, Ronin, Thunder, some Jenner legendary variants

Storm Raider now using the Kintaro model
Sojourner now using the Roughneck model
Gestalt now using the Phoenix model
Dart now using the Ice Ferret model
Tessen now using the Firebee model
Lightning now using the Quickdraw model