### PR TITLE
Update Unique_Gear_Cockpit_LifesupportA_SecondaryCPU_Command-RTO.json

### DIFF
--- a/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_Cockpit_LifesupportA_SecondaryCPU_Command-RTO.json
+++ b/Core/RogueModuleTech/RTOSpecial/upgrade/Unique_Gear_Cockpit_LifesupportA_SecondaryCPU_Command-RTO.json
@@ -18,7 +18,7 @@
     }
   },
   "Description": {
-    "Cost": 0,
+    "Cost": 100000,
     "Rarity": 99,
     "Purchasable": false,
     "Manufacturer": "Unknown",


### PR DESCRIPTION
gave it a cost, matching regular life supports- to avoid possible issues with RTO "time capsule"