### PR TITLE
Fix Aries Dugite A, B, C loadouts

### DIFF
--- a/Optionals/AriesInitiative/vehicle/vehicledef_DUGITE_A.json
+++ b/Optionals/AriesInitiative/vehicle/vehicledef_DUGITE_A.json
@@ -241,13 +241,6 @@
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Probe_LightActive_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
       "MountedLocation": "Left",
       "ComponentDefID": "Default_Vehicle_Motive_Tracked_Left",
       "ComponentDefType": "Upgrade",

--- a/Optionals/AriesInitiative/vehicle/vehicledef_DUGITE_B.json
+++ b/Optionals/AriesInitiative/vehicle/vehicledef_DUGITE_B.json
@@ -223,13 +223,6 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Probe_LightActive_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
       "ComponentDefID": "Gear_ProtectivePadding",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,

--- a/Optionals/AriesInitiative/vehicle/vehicledef_DUGITE_C.json
+++ b/Optionals/AriesInitiative/vehicle/vehicledef_DUGITE_C.json
@@ -73,78 +73,36 @@
   ],
   "inventory": [
     {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Weapon_iATM_12",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Weapon_Laser_ImprovedHeavy_Medium_Clan",
-      "ComponentDefType": "Weapon",
-      "HardpointSlot": 0,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Weapon_Laser_ImprovedHeavy_Medium_Clan",
+      "MountedLocation": "Turret",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_AMS_Clan",
+      "ComponentDefID": "Weapon_Laser_ER_Medium_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_Gauss_Hyper_20_Clan",
+      "ComponentDefID": "Weapon_Gauss_Hyper_40_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Turret",
-      "ComponentDefID": "Weapon_Gauss_Hyper_20_Clan",
+      "ComponentDefID": "Weapon_Gauss_Hyper_40_Clan",
       "ComponentDefType": "Weapon",
       "HardpointSlot": 0,
       "DamageLevel": "Functional"
     },
     {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_AMS",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_AMS",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_iATM_HE",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_iATM_EMP",
-      "ComponentDefType": "AmmunitionBox",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Ammo_AmmunitionBox_iATM_Inferno",
+      "MountedLocation": "Rear",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Hyper",
       "ComponentDefType": "AmmunitionBox",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -221,14 +179,21 @@
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_TargetingTrackingSystem_Evasion",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Energy",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
     },
     {
       "MountedLocation": "Front",
-      "ComponentDefID": "Gear_Probe_LightActive_Clan",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Range",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Front",
+      "ComponentDefID": "Gear_TargetingTrackingSystem_Cluster",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"
@@ -306,34 +271,6 @@
     {
       "MountedLocation": "Rear",
       "ComponentDefID": "Gear_EngineCore_300",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Front",
-      "ComponentDefID": "Gear_HeatSink_Single",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Rear",
-      "ComponentDefID": "Gear_HeatSink_Single",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Left",
-      "ComponentDefID": "Gear_HeatSink_Single",
-      "ComponentDefType": "HeatSink",
-      "HardpointSlot": -1,
-      "DamageLevel": "Functional"
-    },
-    {
-      "MountedLocation": "Right",
-      "ComponentDefID": "Gear_HeatSink_Single",
       "ComponentDefType": "HeatSink",
       "HardpointSlot": -1,
       "DamageLevel": "Functional"

--- a/Optionals/AriesInitiative/vehicleChassis/vehiclechassisdef_DUGITE_C.json
+++ b/Optionals/AriesInitiative/vehicleChassis/vehiclechassisdef_DUGITE_C.json
@@ -40,20 +40,7 @@
   "Locations": [
     {
       "Location": "Front",
-      "Hardpoints": [
-        {
-          "WeaponMountID": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMountID": "Energy",
-          "Omni": false
-        },
-        {
-          "WeaponMountID": "Missile",
-          "Omni": false
-        }
-      ],
+      "Hardpoints": [],
       "Tonnage": 0,
       "InventorySlots": 0,
       "MaxArmor": 425,
@@ -95,7 +82,11 @@
           "Omni": false
         },
         {
-          "WeaponMountID": "AntiPersonnel",
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
           "Omni": false
         }
       ],


### PR DESCRIPTION
remove overweight probes from A and B, change C to the proper loadout (it was a copy of the A)