### PR TITLE
Fix laser heat sink exploit with smaller engines

### DIFF
--- a/Core/Abilifier/EffectDataExtensions.json
+++ b/Core/Abilifier/EffectDataExtensions.json
@@ -520,5 +520,105 @@
 				]
 			}
 		}
+	},
+	"EngineHS_MinusOne": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusOne"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusTwo": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusTwo"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusThree": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusThree"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusFour": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusFour"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusFive": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusFive"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusSix": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusSix"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusSeven": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusSeven"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusEight": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusEight"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusNine": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusNine"
+				]
+			}
+		}
+	},
+	"EngineHS_MinusTen": {
+		"TargetCollectionsForSearch": {
+			"Component": {
+				"MustMatchAll": false,
+				"TargetCollectionTagMatch": [
+					"EngineHS_MinusTen"
+				]
+			}
+		}
 	}
 }

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_010.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_010.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTen",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_015.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_015.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTen",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_020.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_020.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTen",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_025.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_025.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusNine",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_030.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_030.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusNine",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_035.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_035.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusNine",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_040.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_040.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusNine",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_045.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_045.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusNine",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_050.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_050.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusEight",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_055.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_055.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusEight",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_060.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_060.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusEight",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_065.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_065.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusEight",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_070.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_070.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusEight",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_075.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_075.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSeven",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_080.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_080.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSeven",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_085.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_085.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSeven",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_090.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_090.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSeven",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_095.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_095.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSeven",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_100.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_100.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSix",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_105.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_105.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSix",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_110.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_110.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSix",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_115.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_115.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSix",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_120.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_120.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusSix",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_125.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_125.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFive",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_130.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_130.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFive",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_135.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_135.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFive",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_140.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_140.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFive",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_145.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_145.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFive",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_150.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_150.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFour",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_155.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_155.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFour",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_160.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_160.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFour",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_165.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_165.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFour",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_170.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_170.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusFour",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_175.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_175.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusThree",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_180.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_180.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusThree",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_185.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_185.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusThree",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_190.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_190.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusThree",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_195.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_195.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusThree",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_200.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_200.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTwo",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_205.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_205.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTwo",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_210.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_210.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTwo",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_215.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_215.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTwo",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_220.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_220.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusTwo",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_225.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_225.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusOne",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_230.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_230.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusOne",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_235.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_235.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusOne",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_240.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_240.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusOne",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_245.json
+++ b/Core/RogueModuleTech/Basic/EngineCores/Gear_EngineCore_245.json
@@ -112,6 +112,7 @@
     "items": [
       "component_type_stock",
       "EnginePart",
+      "EngineHS_MinusOne",
       "SquadIncompatible"
     ],
     "tagSetSourceFile": ""

--- a/Core/RogueModuleTech/Heatsink/Gear_HeatSinkKit_Laser.json
+++ b/Core/RogueModuleTech/Heatsink/Gear_HeatSinkKit_Laser.json
@@ -12,6 +12,7 @@
       "CoolingSystemLHS",
       "Signature: +40%",
       "EndMoveHeat: -60",
+      "LHSEngine",
       "CoolantCost: 17"
     ],
     "Cooling": {
@@ -108,6 +109,266 @@
         "statName": "EndMoveHeat",
         "operation": "Int_Add",
         "modValue": "-60",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusOne",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 1",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "6",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusTwo",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 2",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "12",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusThree",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 3",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "18",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusFour",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 4",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "24",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusFive",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 5",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "30",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusSix",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 6",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "36",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusSeven",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 7",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "42",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusEight",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 8",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "48",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusNine",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 9",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "54",
+        "modType": "System.Int32"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "EngineHS_MinusTen",
+        "Name": "Laser Heat Sink Kit - smaller engine penalty 10",
+        "Details": "Laser Heat Sink system venting less heat for smaller engines",
+        "Icon": "uixSvgIcon_equipment_ThermalExchanger"
+      },
+      "statisticData": {
+        "statName": "EndMoveHeat",
+        "operation": "Int_Add",
+        "modValue": "60",
         "modType": "System.Int32"
       }
     }

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Cooling.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_Cooling.json
@@ -31,6 +31,12 @@
       "Full": "Converts the 'Mech to use Laser Heat Sinks."
     },
     {
+      "Bonus": "LHSEngine",
+      "Short": "LHS Engine Sinks",
+      "Long": "Internal Engine Laser Heat Sink Adjustment",
+      "Full": "Engine cores 245 and lower will have reduced cooling due to fewer heat sinks in the engine."
+    },
+    {
       "Bonus": "CoolingSystemDHS",
       "Short": "DHS Kit",
       "Long": "DHS Kit",


### PR DESCRIPTION
Engines smaller than a 250 core will now reduce the base cooling amount a laser heat sink kit provides. Adding the free-weight heat sinks to reach the required 10 will bring cooling back to the proper amount for 10 heat sinks.