### PR TITLE
 hardpoint override for Banshee and Orion IIC to put weapons into proper groups;

### DIFF
--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_banshee.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_banshee.json
@@ -1,0 +1,182 @@
+{
+    "ID" : "hardpointdatadef_banshee",
+    "HardpointData" : [
+        {
+            "location" : "centertorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_banshee_centertorso_flamer_eh1",
+                    "chrPrfWeap_banshee_centertorso_laser_eh1"
+                ],
+				[
+					"chrPrfWeap_banshee_centertorso_ams_ah1"
+				]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "head",
+            "weapons" : [
+                [
+                    "chrPrfWeap_banshee_head_flamer_eh1"
+                ],
+				[
+                    "chrPrfWeap_banshee_head_laser_eh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "leftarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_banshee_leftarm_flamer_eh1"
+				],
+				[
+                    "chrPrfWeap_banshee_leftarm_laser_eh1",
+                    "chrPrfWeap_banshee_leftarm_ppc_eh1"
+                ]
+            ],
+            "blanks" : [
+                "chrPrfWeap_banshee_leftarm_blank_eh1"
+            ],
+            "mountingPoints" : [
+                "chrPrfWeap_banshee_leftarm_hardpoint_eh1"
+            ]
+        },
+        {
+            "location" : "lefttorso",
+            "weapons" : [
+				[
+					"chrPrfWeap_banshee_lefttorso_mg_bh1"
+				],
+				[
+					"chrPrfWeap_banshee_lefttorso_mg_bh2"
+				],
+				[
+					"chrPrfWeap_banshee_lefttorso_mg_bh3"
+				],
+				[
+					"chrPrfWeap_banshee_lefttorso_mg_bh4"
+				],
+                [
+                    "chrPrfWeap_banshee_lefttorso_ac10_bh1",
+                    "chrPrfWeap_banshee_lefttorso_ac20_bh1",
+                    "chrPrfWeap_banshee_lefttorso_ac2_bh1",
+                    "chrPrfWeap_banshee_lefttorso_ac5_bh1",
+                    "chrPrfWeap_banshee_lefttorso_flamer_eh1",
+                    "chrPrfWeap_banshee_lefttorso_gauss_bh1",
+                    "chrPrfWeap_banshee_lefttorso_laser_eh1",
+                    "chrPrfWeap_banshee_lefttorso_lbx_bh1",
+                    "chrPrfWeap_banshee_lefttorso_ppc_eh1",
+                    "chrPrfWeap_banshee_lefttorso_uac5_bh1"
+                ],
+                [
+                    "chrPrfWeap_banshee_lefttorso_ac2_bh2",
+                    "chrPrfWeap_banshee_lefttorso_ac5_bh2",
+                    "chrPrfWeap_banshee_lefttorso_lbx_bh2",
+                    "chrPrfWeap_banshee_lefttorso_ppc_eh2",
+                    "chrPrfWeap_banshee_lefttorso_uac5_bh2"
+                ],
+                [
+                    "chrPrfWeap_banshee_lefttorso_ac2_bh3",
+                    "chrPrfWeap_banshee_lefttorso_ac5_bh3",
+                    "chrPrfWeap_banshee_lefttorso_ppc_eh3",
+                    "chrPrfWeap_banshee_lefttorso_uac5_bh3"
+                ],
+                [
+                    "chrPrfWeap_banshee_lefttorso_ac2_bh4",
+                    "chrPrfWeap_banshee_lefttorso_ac5_bh4",
+                    "chrPrfWeap_banshee_lefttorso_uac5_bh4"
+                ],
+				[
+					"chrPrfWeap_banshee_lefttorso_flamer_eh2",
+                    "chrPrfWeap_banshee_lefttorso_laser_eh2"
+				],
+				[
+					"chrPrfWeap_banshee_lefttorso_flamer_eh3",
+                    "chrPrfWeap_banshee_lefttorso_laser_eh3"
+				]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "rightarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_banshee_rightarm_flamer_eh1",
+                    "chrPrfWeap_banshee_rightarm_laser_eh1",
+                    "chrPrfWeap_banshee_rightarm_ppc_eh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "righttorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_banshee_righttorso_flamer_eh1",
+                    "chrPrfWeap_banshee_righttorso_laser_eh1",
+                    "chrPrfWeap_banshee_righttorso_ppc_eh1" 
+                ],
+                [
+                    "chrPrfWeap_banshee_righttorso_ppc_eh2"
+                ],
+                [
+					"chrPrfWeap_banshee_righttorso_flamer_eh2",
+                    "chrPrfWeap_banshee_righttorso_laser_eh2",
+                    "chrPrfWeap_banshee_righttorso_ppc_eh3"
+                ],
+				[
+                    "chrPrfWeap_banshee_righttorso_flamer_eh3",
+                    "chrPrfWeap_banshee_righttorso_laser_eh3",
+                    "chrPrfWeap_banshee_righttorso_ppc_eh3"
+                ],
+                [
+                    "chrPrfWeap_banshee_righttorso_flamer_eh4",
+                    "chrPrfWeap_banshee_righttorso_laser_eh4"
+                ],
+                [
+                    "chrPrfWeap_banshee_righttorso_flamer_eh5",
+                    "chrPrfWeap_banshee_righttorso_laser_eh5"
+                ],
+				[
+					"chrPrfWeap_banshee_righttorso_ppc_eh4",
+                    "chrPrfWeap_banshee_righttorso_lrm5_mh1",
+					"chrPrfWeap_banshee_righttorso_lrm10_mh1",
+                    "chrPrfWeap_banshee_righttorso_lrm15_mh1",
+					"chrPrfWeap_banshee_righttorso_lrm20_mh1",
+                    "chrPrfWeap_banshee_righttorso_srm2_mh1",
+                    "chrPrfWeap_banshee_righttorso_srm4_mh1",
+                    "chrPrfWeap_banshee_righttorso_srm6_mh1"
+				]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        }
+    ]
+}

--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniic.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniic.json
@@ -1,0 +1,147 @@
+{
+    "ID" : "hardpointdatadef_orioniic",
+    "HardpointData" : [
+        {
+            "location" : "centertorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_centertorso_mg_bh1",
+                    "chrPrfWeap_orioniic_centertorso_laser_eh1",
+                    "chrPrfWeap_orioniic_centertorso_srm6_mh1",
+                    "chrPrfWeap_orioniic_centertorso_ac10_bh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "head",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_head_mg_bh1",
+                    "chrPrfWeap_orioniic_head_laser_eh1",
+                    "chrPrfWeap_orioniic_head_srm6_mh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },		
+        {
+            "location" : "leftarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_leftarm_flamer_eh1",
+                    "chrPrfWeap_orioniic_leftarm_laser_eh1",
+                    "chrPrfWeap_orioniic_leftarm_ppc_eh1",
+                    "chrPrfWeap_orioniic_leftarm_ac10_bh1",
+                    "chrPrfWeap_orioniic_leftarm_mg_bh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_leftarm_flamer_eh2",
+                    "chrPrfWeap_orioniic_leftarm_laser_eh2",
+                    "chrPrfWeap_orioniic_leftarm_ppc_eh2"
+                ],
+                [
+                    "chrPrfWeap_orioniic_leftarm_srm20_mh1",
+                    "chrPrfWeap_orioniic_leftarm_lrm15_mh1",
+                    "chrPrfWeap_orioniic_leftarm_srm4_mh1",
+                    "chrPrfWeap_orioniic_leftarm_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_leftarm_lrm15_mh2",
+                    "chrPrfWeap_orioniic_leftarm_srm6_mh2"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "lefttorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_lefttorso_flamer_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_laser_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_ppc_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_mg_bh1",
+                    "chrPrfWeap_orioniic_lefttorso_ac10_bh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_lefttorso_lrm15_mh1",
+                    "chrPrfWeap_orioniic_lefttorso_srm20_mh1",
+                    "chrPrfWeap_orioniic_lefttorso_srm4_mh1",
+                    "chrPrfWeap_orioniic_lefttorso_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_lefttorso_lrm15_mh2",
+                    "chrPrfWeap_orioniic_lefttorso_srm20_mh2",
+                    "chrPrfWeap_orioniic_lefttorso_srm4_mh2",
+                    "chrPrfWeap_orioniic_lefttorso_srm6_mh2"
+                ]
+            ],
+            "blanks" : [
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "rightarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_rightarm_flamer_eh1",
+                    "chrPrfWeap_orioniic_rightarm_laser_eh1",
+                    "chrPrfWeap_orioniic_rightarm_ppc_eh1", 
+                    "chrPrfWeap_orioniic_rightarm_mg_bh1",
+                    "chrPrfWeap_orioniic_rightarm_ac10_bh1",
+                    "chrPrfWeap_orioniic_rightarm_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_rightarm_flamer_eh2",
+                    "chrPrfWeap_orioniic_rightarm_laser_eh2",
+                    "chrPrfWeap_orioniic_rightarm_ppc_eh2"   
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+            ]
+        },
+        {
+            "location" : "righttorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_righttorso_ac10_bh1",
+                    "chrPrfWeap_orioniic_righttorso_gauss_bh1",
+                    "chrPrfWeap_orioniic_righttorso_mg_bh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_righttorso_laser_eh1",
+                    "chrPrfWeap_orioniic_righttorso_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_righttorso_ac10_bh2",
+                    "chrPrfWeap_orioniic_righttorso_gauss_bh2",
+                    "chrPrfWeap_orioniic_righttorso_mg_bh2"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+            ]
+        }
+    ]
+}

--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniic.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniic.json
@@ -73,7 +73,9 @@
                 [
                     "chrPrfWeap_orioniic_lefttorso_flamer_eh1",
                     "chrPrfWeap_orioniic_lefttorso_laser_eh1",
-                    "chrPrfWeap_orioniic_lefttorso_ppc_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_ppc_eh1"
+                ],
+                [
                     "chrPrfWeap_orioniic_lefttorso_mg_bh1",
                     "chrPrfWeap_orioniic_lefttorso_ac10_bh1"
                 ],
@@ -102,7 +104,9 @@
                 [
                     "chrPrfWeap_orioniic_rightarm_flamer_eh1",
                     "chrPrfWeap_orioniic_rightarm_laser_eh1",
-                    "chrPrfWeap_orioniic_rightarm_ppc_eh1", 
+                    "chrPrfWeap_orioniic_rightarm_ppc_eh1"
+                ],
+                [
                     "chrPrfWeap_orioniic_rightarm_mg_bh1",
                     "chrPrfWeap_orioniic_rightarm_ac10_bh1",
                     "chrPrfWeap_orioniic_rightarm_srm6_mh1"

--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniica.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniica.json
@@ -1,0 +1,147 @@
+{
+    "ID" : "hardpointdatadef_orioniic",
+    "HardpointData" : [
+        {
+            "location" : "centertorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_centertorso_mg_bh1",
+                    "chrPrfWeap_orioniic_centertorso_laser_eh1",
+                    "chrPrfWeap_orioniic_centertorso_srm6_mh1",
+                    "chrPrfWeap_orioniic_centertorso_ac10_bh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "head",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_head_mg_bh1",
+                    "chrPrfWeap_orioniic_head_laser_eh1",
+                    "chrPrfWeap_orioniic_head_srm6_mh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },		
+        {
+            "location" : "leftarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_leftarm_flamer_eh1",
+                    "chrPrfWeap_orioniic_leftarm_laser_eh1",
+                    "chrPrfWeap_orioniic_leftarm_ppc_eh1",
+                    "chrPrfWeap_orioniic_leftarm_ac10_bh1",
+                    "chrPrfWeap_orioniic_leftarm_mg_bh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_leftarm_flamer_eh2",
+                    "chrPrfWeap_orioniic_leftarm_laser_eh2",
+                    "chrPrfWeap_orioniic_leftarm_ppc_eh2"
+                ],
+                [
+                    "chrPrfWeap_orioniic_leftarm_lrm15_mh2",
+                    "chrPrfWeap_orioniic_leftarm_srm6_mh2"
+                ],
+                [
+                    "chrPrfWeap_orioniic_leftarm_srm20_mh1",
+                    "chrPrfWeap_orioniic_leftarm_lrm15_mh1",
+                    "chrPrfWeap_orioniic_leftarm_srm4_mh1",
+                    "chrPrfWeap_orioniic_leftarm_srm6_mh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+			
+            ]
+        },
+        {
+            "location" : "lefttorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_lefttorso_lrm15_mh2",
+                    "chrPrfWeap_orioniic_lefttorso_srm20_mh2",
+                    "chrPrfWeap_orioniic_lefttorso_srm4_mh2",
+                    "chrPrfWeap_orioniic_lefttorso_srm6_mh2"
+                ],
+                [
+                    "chrPrfWeap_orioniic_lefttorso_lrm15_mh1",
+                    "chrPrfWeap_orioniic_lefttorso_srm20_mh1",
+                    "chrPrfWeap_orioniic_lefttorso_srm4_mh1",
+                    "chrPrfWeap_orioniic_lefttorso_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_lefttorso_flamer_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_laser_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_ppc_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_mg_bh1",
+                    "chrPrfWeap_orioniic_lefttorso_ac10_bh1"
+                ]
+            ],
+            "blanks" : [
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "rightarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_rightarm_flamer_eh1",
+                    "chrPrfWeap_orioniic_rightarm_laser_eh1",
+                    "chrPrfWeap_orioniic_rightarm_ppc_eh1", 
+                    "chrPrfWeap_orioniic_rightarm_mg_bh1",
+                    "chrPrfWeap_orioniic_rightarm_ac10_bh1",
+                    "chrPrfWeap_orioniic_rightarm_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_rightarm_flamer_eh2",
+                    "chrPrfWeap_orioniic_rightarm_laser_eh2",
+                    "chrPrfWeap_orioniic_rightarm_ppc_eh2"   
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+            ]
+        },
+        {
+            "location" : "righttorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_orioniic_righttorso_ac10_bh1",
+                    "chrPrfWeap_orioniic_righttorso_gauss_bh1",
+                    "chrPrfWeap_orioniic_righttorso_mg_bh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_righttorso_laser_eh1",
+                    "chrPrfWeap_orioniic_righttorso_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_orioniic_righttorso_ac10_bh2",
+                    "chrPrfWeap_orioniic_righttorso_gauss_bh2",
+                    "chrPrfWeap_orioniic_righttorso_mg_bh2"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+            ]
+        }
+    ]
+}

--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniica.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_orioniica.json
@@ -85,7 +85,9 @@
                 [
                     "chrPrfWeap_orioniic_lefttorso_flamer_eh1",
                     "chrPrfWeap_orioniic_lefttorso_laser_eh1",
-                    "chrPrfWeap_orioniic_lefttorso_ppc_eh1",
+                    "chrPrfWeap_orioniic_lefttorso_ppc_eh1"
+                ],
+                [
                     "chrPrfWeap_orioniic_lefttorso_mg_bh1",
                     "chrPrfWeap_orioniic_lefttorso_ac10_bh1"
                 ]
@@ -102,7 +104,9 @@
                 [
                     "chrPrfWeap_orioniic_rightarm_flamer_eh1",
                     "chrPrfWeap_orioniic_rightarm_laser_eh1",
-                    "chrPrfWeap_orioniic_rightarm_ppc_eh1", 
+                    "chrPrfWeap_orioniic_rightarm_ppc_eh1"
+                ],
+                [
                     "chrPrfWeap_orioniic_rightarm_mg_bh1",
                     "chrPrfWeap_orioniic_rightarm_ac10_bh1",
                     "chrPrfWeap_orioniic_rightarm_srm6_mh1"

--- a/Eras/Jihad3068-3080/Base/chassis/chassisdef_pandarus_LFA-1X.json
+++ b/Eras/Jihad3068-3080/Base/chassis/chassisdef_pandarus_LFA-1X.json
@@ -48,7 +48,7 @@
   "YangsThoughts": "A light field artillery, experimental BattleMech, the Pandarus, named for a famous archer from the mythical battle of Troy on ancient Terra, is an Extended LRM Missile boat. Originally a Kali Yama design team proposal for an OmniMech missile boat capable of carrying both common and Experimental Technology missile systems, ultimately the high cost of building an all new design with all new OmniPods proved too high, with the design team forced to scale back their project to a non-Omni ELRM-equipped prototype built on a mothballed Orion chassis.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_orioniic",
+  "HardpointDataDefID": "hardpointdatadef_orioniica",
   "PrefabIdentifier": "chrprfmech_orioniicbase-001",
   "PrefabBase": "orioniic",
   "Tonnage": 75.0,

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_pandarus_LFA-1A.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_pandarus_LFA-1A.json
@@ -44,7 +44,7 @@
   "YangsThoughts": "A light field artillery, experimental BattleMech, the Pandarus, named for a famous archer from the mythical battle of Troy on ancient Terra, is an Extended LRM Missile boat. Originally a Kali Yama design team proposal for an OmniMech missile boat capable of carrying both common and Experimental Technology missile systems, ultimately the high cost of building an all new design with all new OmniPods proved too high, with the design team forced to scale back their project to a non-Omni ELRM-equipped prototype built on a mothballed Orion chassis.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_orioniic",
+  "HardpointDataDefID": "hardpointdatadef_orioniica",
   "PrefabIdentifier": "chrprfmech_orioniicbase-001",
   "PrefabBase": "orioniic",
   "Tonnage": 75.0,


### PR DESCRIPTION
variant hardpoint override for Orion IIC for the Pandarus, to rearrange the left torso and arm missile group priority