### PR TITLE
variant hardpoint overrides for the Avatar for use by the Orca superh…

### DIFF
--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_avatara.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_avatara.json
@@ -1,0 +1,151 @@
+{
+	"ID": "hardpointdatadef_avatar",
+	"HardpointData": [
+		{
+			"location": "head",
+			"weapons": [
+				[
+					"chrprfweap_avatar_head_flag_eh1",
+					"chrprfweap_avatar_head_laser_eh1"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "centertorso",
+			"weapons": [
+				[
+					"chrprfweap_avatar_centertorso_laser_eh1"
+				],
+				[
+					"chrprfweap_avatar_centertorso_laser_eh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "leftarm",
+			"weapons": [
+				[
+					"chrprfweap_avatar_leftarm_ac20_bh1",
+					"chrprfweap_avatar_leftarm_flamer_eh1",
+					"chrprfweap_avatar_leftarm_gauss_bh1",
+					"chrprfweap_avatar_leftarm_laser_eh1",
+					"chrprfweap_avatar_leftarm_lbx10_bh1",
+					"chrprfweap_avatar_leftarm_lrm15_mh1",
+					"chrprfweap_avatar_leftarm_mg_bh1",
+					"chrprfweap_avatar_leftarm_ppc_eh1",
+					"chrprfweap_avatar_leftarm_srm6_mh1"
+				],
+				[
+					"chrprfweap_avatar_leftarm_flamer_eh2",
+					"chrprfweap_avatar_leftarm_laser_eh2",
+					"chrprfweap_avatar_leftarm_lrm15_mh2",
+					"chrprfweap_avatar_leftarm_ppc_eh2",
+					"chrprfweap_avatar_leftarm_srm6_mh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "lefttorso",
+			"weapons": [
+				[
+					"chrprfweap_avatar_lefttorso_laser_eh2",
+					"chrprfweap_avatar_lefttorso_ppc_eh2"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_ac20_bh1",
+					"chrprfweap_avatar_lefttorso_gauss_bh1",
+					"chrprfweap_avatar_lefttorso_laser_eh1",
+					"chrprfweap_avatar_lefttorso_lbx10_bh1",
+					"chrprfweap_avatar_lefttorso_mg_bh1",
+					"chrprfweap_avatar_lefttorso_ppc_eh1",
+					"chrprfweap_avatar_lefttorso_uac5_bh1"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_ams_ah1"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_arrow_mh1",
+					"chrprfweap_avatar_lefttorso_lrm10_mh1",
+					"chrprfweap_avatar_lefttorso_lrm15_mh1",
+					"chrprfweap_avatar_lefttorso_lrm20_mh1",
+					"chrprfweap_avatar_lefttorso_srm6_mh1"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_lrm10_mh2",
+					"chrprfweap_avatar_lefttorso_lrm15_mh2",
+					"chrprfweap_avatar_lefttorso_lrm20_mh2",
+					"chrprfweap_avatar_lefttorso_srm6_mh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "rightarm",
+			"weapons": [
+				[
+					"chrprfweap_avatar_rightarm_ac20_bh1",
+					"chrprfweap_avatar_rightarm_artillery_bh1",
+					"chrprfweap_avatar_rightarm_gauss_bh1",
+					"chrprfweap_avatar_rightarm_laser_eh1",
+					"chrprfweap_avatar_rightarm_lbx10_bh1",
+					"chrprfweap_avatar_rightarm_lrm15_mh1",
+					"chrprfweap_avatar_rightarm_lrm20_mh1",
+					"chrprfweap_avatar_rightarm_mg_bh1",
+					"chrprfweap_avatar_rightarm_ppc_eh1",
+					"chrprfweap_avatar_rightarm_srm6_mh1",
+					"chrprfweap_avatar_rightarm_uac5_bh1"
+				],
+				[
+					"chrprfweap_avatar_rightarm_laser_eh2",
+					"chrprfweap_avatar_rightarm_mg_bh2",
+					"chrprfweap_avatar_rightarm_ppc_eh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "righttorso",
+			"weapons": [
+				[
+					"chrprfweap_avatar_righttorso_laser_eh2",
+					"chrprfweap_avatar_righttorso_ppc_eh2"
+				],
+				[
+					"chrprfweap_avatar_righttorso_ac20_bh1",
+					"chrprfweap_avatar_righttorso_gauss_bh1",
+					"chrprfweap_avatar_righttorso_laser_eh1",
+					"chrprfweap_avatar_righttorso_lbx10_bh1",
+					"chrprfweap_avatar_righttorso_mg_bh1",
+					"chrprfweap_avatar_righttorso_ppc_eh1",
+					"chrprfweap_avatar_righttorso_uac5_bh1"
+				],
+				[
+					"chrprfweap_avatar_righttorso_ams_ah1"
+				],
+				[
+					"chrprfweap_avatar_righttorso_arrow_mh1",
+					"chrprfweap_avatar_righttorso_lrm10_mh1",
+					"chrprfweap_avatar_righttorso_lrm15_mh1",
+					"chrprfweap_avatar_righttorso_lrm20_mh1",
+					"chrprfweap_avatar_righttorso_srm6_mh1"
+				],
+				[
+					"chrprfweap_avatar_righttorso_lrm10_mh2",
+					"chrprfweap_avatar_righttorso_lrm15_mh2",
+					"chrprfweap_avatar_righttorso_lrm20_mh2",
+					"chrprfweap_avatar_righttorso_srm6_mh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		}
+	]
+}

--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_avatarb.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_avatarb.json
@@ -1,0 +1,151 @@
+{
+	"ID": "hardpointdatadef_avatar",
+	"HardpointData": [
+		{
+			"location": "head",
+			"weapons": [
+				[
+					"chrprfweap_avatar_head_flag_eh1",
+					"chrprfweap_avatar_head_laser_eh1"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "centertorso",
+			"weapons": [
+				[
+					"chrprfweap_avatar_centertorso_laser_eh1"
+				],
+				[
+					"chrprfweap_avatar_centertorso_laser_eh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "leftarm",
+			"weapons": [
+				[
+					"chrprfweap_avatar_leftarm_ac20_bh1",
+					"chrprfweap_avatar_leftarm_flamer_eh1",
+					"chrprfweap_avatar_leftarm_gauss_bh1",
+					"chrprfweap_avatar_leftarm_laser_eh1",
+					"chrprfweap_avatar_leftarm_lbx10_bh1",
+					"chrprfweap_avatar_leftarm_lrm15_mh1",
+					"chrprfweap_avatar_leftarm_mg_bh1",
+					"chrprfweap_avatar_leftarm_ppc_eh1",
+					"chrprfweap_avatar_leftarm_srm6_mh1"
+				],
+				[
+					"chrprfweap_avatar_leftarm_flamer_eh2",
+					"chrprfweap_avatar_leftarm_laser_eh2",
+					"chrprfweap_avatar_leftarm_lrm15_mh2",
+					"chrprfweap_avatar_leftarm_ppc_eh2",
+					"chrprfweap_avatar_leftarm_srm6_mh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "lefttorso",
+			"weapons": [
+				[
+					"chrprfweap_avatar_lefttorso_laser_eh2",
+					"chrprfweap_avatar_lefttorso_ppc_eh2"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_ac20_bh1",
+					"chrprfweap_avatar_lefttorso_gauss_bh1",
+					"chrprfweap_avatar_lefttorso_laser_eh1",
+					"chrprfweap_avatar_lefttorso_lbx10_bh1",
+					"chrprfweap_avatar_lefttorso_mg_bh1",
+					"chrprfweap_avatar_lefttorso_ppc_eh1",
+					"chrprfweap_avatar_lefttorso_uac5_bh1"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_ams_ah1"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_lrm10_mh2",
+					"chrprfweap_avatar_lefttorso_lrm15_mh2",
+					"chrprfweap_avatar_lefttorso_lrm20_mh2",
+					"chrprfweap_avatar_lefttorso_srm6_mh2"
+				],
+				[
+					"chrprfweap_avatar_lefttorso_arrow_mh1",
+					"chrprfweap_avatar_lefttorso_lrm10_mh1",
+					"chrprfweap_avatar_lefttorso_lrm15_mh1",
+					"chrprfweap_avatar_lefttorso_lrm20_mh1",
+					"chrprfweap_avatar_lefttorso_srm6_mh1"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "rightarm",
+			"weapons": [
+				[
+					"chrprfweap_avatar_rightarm_ac20_bh1",
+					"chrprfweap_avatar_rightarm_artillery_bh1",
+					"chrprfweap_avatar_rightarm_gauss_bh1",
+					"chrprfweap_avatar_rightarm_laser_eh1",
+					"chrprfweap_avatar_rightarm_lbx10_bh1",
+					"chrprfweap_avatar_rightarm_lrm15_mh1",
+					"chrprfweap_avatar_rightarm_lrm20_mh1",
+					"chrprfweap_avatar_rightarm_mg_bh1",
+					"chrprfweap_avatar_rightarm_ppc_eh1",
+					"chrprfweap_avatar_rightarm_srm6_mh1",
+					"chrprfweap_avatar_rightarm_uac5_bh1"
+				],
+				[
+					"chrprfweap_avatar_rightarm_laser_eh2",
+					"chrprfweap_avatar_rightarm_mg_bh2",
+					"chrprfweap_avatar_rightarm_ppc_eh2"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		},
+		{
+			"location": "righttorso",
+			"weapons": [
+				[
+					"chrprfweap_avatar_righttorso_laser_eh2",
+					"chrprfweap_avatar_righttorso_ppc_eh2"
+				],
+				[
+					"chrprfweap_avatar_righttorso_ac20_bh1",
+					"chrprfweap_avatar_righttorso_gauss_bh1",
+					"chrprfweap_avatar_righttorso_laser_eh1",
+					"chrprfweap_avatar_righttorso_lbx10_bh1",
+					"chrprfweap_avatar_righttorso_mg_bh1",
+					"chrprfweap_avatar_righttorso_ppc_eh1",
+					"chrprfweap_avatar_righttorso_uac5_bh1"
+				],
+				[
+					"chrprfweap_avatar_righttorso_ams_ah1"
+				],
+				[
+					"chrprfweap_avatar_righttorso_lrm10_mh2",
+					"chrprfweap_avatar_righttorso_lrm15_mh2",
+					"chrprfweap_avatar_righttorso_lrm20_mh2",
+					"chrprfweap_avatar_righttorso_srm6_mh2"
+				],
+				[
+					"chrprfweap_avatar_righttorso_arrow_mh1",
+					"chrprfweap_avatar_righttorso_lrm10_mh1",
+					"chrprfweap_avatar_righttorso_lrm15_mh1",
+					"chrprfweap_avatar_righttorso_lrm20_mh1",
+					"chrprfweap_avatar_righttorso_srm6_mh1"
+				]
+			],
+			"blanks": [],
+			"mountingPoints": []
+		}
+	]
+}

--- a/Eras/ClanInvasion3061/Base/chassis/chassisdef_starhawk_SHK-Prime.json
+++ b/Eras/ClanInvasion3061/Base/chassis/chassisdef_starhawk_SHK-Prime.json
@@ -91,7 +91,7 @@
   "YangsThoughts": "After winning the design to the Timberwolf legs from Clan Wolf during a Trial of Possession, Clan Snow Raven quickly combined the legs with the torso  of a Hellbringer. The result was the 70 ton OmniMech called the Starhawk. It sports a 350 XL engine to carry, making it adequately agile for the Clan's needs, but not much of the design made it stand out compared to other already established 'Mechs. The Starhawk was never seen as a success and are now rare to spot outside of garrison duties.",
   "MovementCapDefID": "movedef_heavymech",
   "PathingCapDefID": "pathingdef_heavy",
-  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "HardpointDataDefID": "hardpointdatadef_avatarb",
   "PrefabIdentifier": "chrprfmech_avatarbase-001",
   "PrefabBase": "avatar",
   "Tonnage": 70.0,

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_peacekeeper_PKP-1A.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_peacekeeper_PKP-1A.json
@@ -46,7 +46,7 @@
   "YangsThoughts": "The Peacekeeper BattleMech is a joint venture developed in the Post-Jihad era by the Republic of the Sphere and the Draconis Combine. The design is intended for anti-insurgency combat as well as garrison duty.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "HardpointDataDefID": "hardpointdatadef_avatara",
   "PrefabIdentifier": "chrprfmech_avatarbase-001",
   "PrefabBase": "avatar",
   "Tonnage": 95.0,

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_peacekeeper_PKP-1B.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_peacekeeper_PKP-1B.json
@@ -46,7 +46,7 @@
   "YangsThoughts": "The Peacekeeper BattleMech is a joint venture developed in the Post-Jihad era by the Republic of the Sphere and the Draconis Combine. The design is intended for anti-insurgency combat as well as garrison duty.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "HardpointDataDefID": "hardpointdatadef_avatara",
   "PrefabIdentifier": "chrprfmech_avatarbase-001",
   "PrefabBase": "avatar",
   "Tonnage": 95.0,

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_peacekeeper_PKP-2K.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_peacekeeper_PKP-2K.json
@@ -46,7 +46,7 @@
   "YangsThoughts": "The Peacekeeper BattleMech is a joint venture developed in the Post-Jihad era by the Republic of the Sphere and the Draconis Combine. The design is intended for anti-insurgency combat as well as garrison duty.",
   "MovementCapDefID": "movedef_assaultmech",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "HardpointDataDefID": "hardpointdatadef_avatara",
   "PrefabIdentifier": "chrprfmech_avatarbase-001",
   "PrefabBase": "avatar",
   "Tonnage": 95.0,

--- a/Optionals/Superheavys/Base/chassis/chassisdef_orca_OC-1X.json
+++ b/Optionals/Superheavys/Base/chassis/chassisdef_orca_OC-1X.json
@@ -59,7 +59,7 @@
   "YangsThoughts": "The Orca was constructed as a secret project. Its development occurred under such total secrecy, that even 'an unfortunate delivery driver who slipped through security due to a lapse and was caught filming a livefire test with his personal device' was only released from custody 5 years later.",
   "MovementCapDefID": "movedef_superheavy",
   "PathingCapDefID": "pathingdef_assault",
-  "HardpointDataDefID": "hardpointdatadef_avatar",
+  "HardpointDataDefID": "hardpointdatadef_avatara",
   "PrefabIdentifier": "chrprfmech_avatarbase-001",
   "PrefabBase": "avatar",
   "Tonnage": 200.0,


### PR DESCRIPTION
…eavy mech, Peacekeeper assault mech, and Starhawk heavy mech

This prioritizes the low torso mounts for PPC/laser, and additionally for the Starhawk prioritizes the high torso missile mounts