### PR TITLE
change proxy model for Cricket; hardpoint override for Preta;

### DIFF
--- a/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_preta.json
+++ b/Core/RogueTechCore/Mech/hardpoints/hardpointdatadef_preta.json
@@ -1,0 +1,145 @@
+{
+    "ID" : "hardpointdatadef_preta",
+    "HardpointData" : [
+        {
+            "location" : "head",
+            "weapons" : [
+                [
+                    "chrPrfWeap_preta_head_flamer_eh1",
+                    "chrPrfWeap_preta_head_laser_eh1",
+                    "chrPrfWeap_preta_head_ppc_eh1"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "leftarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_preta_leftarm_ac10_bh2",
+                    "chrPrfWeap_preta_leftarm_gauss_bh2",
+                    "chrPrfWeap_preta_leftarm_mg_bh2",
+                    "chrPrfWeap_preta_leftarm_flamer_eh2",
+                    "chrPrfWeap_preta_leftarm_laser_eh1",
+                    "chrPrfWeap_preta_leftarm_ppc_eh2",
+                    "chrPrfWeap_preta_leftarm_lrm5_mh1",
+                    "chrPrfWeap_preta_leftarm_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_preta_leftarm_ac10_bh1",
+                    "chrPrfWeap_preta_leftarm_gauss_bh1",
+                    "chrPrfWeap_preta_leftarm_mg_bh1",
+                    "chrPrfWeap_preta_leftarm_flamer_eh1",
+                    "chrPrfWeap_preta_leftarm_laser_eh2",
+                    "chrPrfWeap_preta_leftarm_ppc_eh1",
+                    "chrPrfWeap_preta_leftarm_lrm5_mh2",
+                    "chrPrfWeap_preta_leftarm_srm6_mh2"
+                ]
+            ],
+            "blanks" : [],
+            "mountingPoints" : []
+        },
+        {
+            "location" : "lefttorso",
+            "weapons" : [
+                [
+                    "chrPrfWeap_preta_lefttorso_ac10_bh1",
+                    "chrPrfWeap_preta_lefttorso_gauss_bh1",
+                    "chrPrfWeap_preta_lefttorso_mg_bh1",
+                    "chrPrfWeap_preta_lefttorso_flamer_eh1",
+                    "chrPrfWeap_preta_lefttorso_laser_eh1",
+                    "chrPrfWeap_preta_lefttorso_ppc_eh1",
+                    "chrPrfWeap_preta_lefttorso_lrm5_mh1",
+                    "chrPrfWeap_preta_lefttorso_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_preta_lefttorso_ac10_bh2",
+                    "chrPrfWeap_preta_lefttorso_gauss_bh2",
+                    "chrPrfWeap_preta_lefttorso_mg_bh2",
+                    "chrPrfWeap_preta_lefttorso_flamer_eh2",
+                    "chrPrfWeap_preta_lefttorso_laser_eh2",
+                    "chrPrfWeap_preta_lefttorso_ppc_eh2",
+                    "chrPrfWeap_preta_lefttorso_lrm5_mh2",
+                    "chrPrfWeap_preta_lefttorso_srm6_mh2"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "rightarm",
+            "weapons" : [
+                [
+                    "chrPrfWeap_preta_rightarm_ac10_bh1",
+                    "chrPrfWeap_preta_rightarm_gauss_bh1",
+                    "chrPrfWeap_preta_rightarm_mg_bh1",
+                    "chrPrfWeap_preta_rightarm_flamer_eh1",
+                    "chrPrfWeap_preta_rightarm_laser_eh1",
+                    "chrPrfWeap_preta_rightarm_ppc_eh1",
+                    "chrPrfWeap_preta_rightarm_lrm5_mh1",
+                    "chrPrfWeap_preta_rightarm_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_preta_rightarm_ac10_bh2",
+                    "chrPrfWeap_preta_rightarm_gauss_bh2",
+                    "chrPrfWeap_preta_rightarm_mg_bh2",
+                    "chrPrfWeap_preta_rightarm_flamer_eh2",
+                    "chrPrfWeap_preta_rightarm_laser_eh2",
+                    "chrPrfWeap_preta_rightarm_ppc_eh2",
+                    "chrPrfWeap_preta_rightarm_lrm5_mh1",
+                    "chrPrfWeap_preta_rightarm_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_preta_rightarm_lrm5_mh2",
+                    "chrPrfWeap_preta_rightarm_srm6_mh2"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        },
+        {
+            "location" : "righttorso",
+            "weapons" :[
+                [
+                    "chrPrfWeap_preta_righttorso_gauss_bh1",
+                    "chrPrfWeap_preta_righttorso_ac10_bh1",
+                    "chrPrfWeap_preta_righttorso_mg_bh1",
+                    "chrPrfWeap_preta_righttorso_flamer_eh1",
+                    "chrPrfWeap_preta_righttorso_laser_eh1",
+                    "chrPrfWeap_preta_righttorso_ppc_eh1",
+                    "chrPrfWeap_preta_righttorso_lrm5_mh1",
+                    "chrPrfWeap_preta_righttorso_srm6_mh1"
+                ],
+                [
+                    "chrPrfWeap_preta_righttorso_ac10_bh2",
+                    "chrPrfWeap_preta_righttorso_gauss_bh2",
+                    "chrPrfWeap_preta_righttorso_mg_bh2",
+                    "chrPrfWeap_preta_righttorso_flamer_eh2",
+                    "chrPrfWeap_preta_righttorso_laser_eh2",
+                    "chrPrfWeap_preta_righttorso_ppc_eh2",
+                    "chrPrfWeap_preta_righttorso_lrm5_mh2",
+                    "chrPrfWeap_preta_righttorso_srm6_mh2"
+                ]
+            ],
+            "blanks" : [
+                
+            ],
+            "mountingPoints" : [
+                
+            ]
+        }
+    ]
+}

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_cricket_RWN-01.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_cricket_RWN-01.json
@@ -36,7 +36,7 @@
   "VariantName": "RWN-01",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.61-0.74-0.63"
+      "mr-resize-0.55-0.65-0.53"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "The Cricket 'Mech was developed by the DCMS as a raider and harasser. Originally it was named the Roweena after Roweena Kurita, but the ISF suspected the designer was a Black Dragon Society sympathizer so a new name was assigned. The Cricket uses every weight saving technology possible to free enough room to have a high ground speed and pack on more armor. Capable of reaching over 150 km/h, it can also jump 180 meters at a time thanks to six jump jets. Despite its high speed and jump capability, the Cricket is unpopular for scouting and recon as it has a cramped cockpit and no electronics.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_hunchie",
-  "PrefabIdentifier": "chrprfmech_hunchiebase-001",
-  "PrefabBase": "hunchie",
+  "HardpointDataDefID": "hardpointdatadef_ionclint",
+  "PrefabIdentifier": "chrprfmech_ionclintbase-001",
+  "PrefabBase": "ionclint",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Eras/DarkAge3131-/Base/chassis/chassisdef_cricket_RWN-02.json
+++ b/Eras/DarkAge3131-/Base/chassis/chassisdef_cricket_RWN-02.json
@@ -36,7 +36,7 @@
   "VariantName": "RWN-02",
   "ChassisTags": {
     "items": [
-      "mr-resize-0.61-0.74-0.63"
+      "mr-resize-0.55-0.65-0.53"
     ],
     "tagSetSourceFile": ""
   },
@@ -44,9 +44,9 @@
   "YangsThoughts": "The Cricket 'Mech was developed by the DCMS as a raider and harasser. Originally it was named the Roweena after Roweena Kurita, but the ISF suspected the designer was a Black Dragon Society sympathizer so a new name was assigned. The Cricket uses every weight saving technology possible to free enough room to have a high ground speed and pack on more armor. Capable of reaching over 150 km/h, it can also jump 180 meters at a time thanks to six jump jets. Despite its high speed and jump capability, the Cricket is unpopular for scouting and recon as it has a cramped cockpit and no electronics.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_hunchie",
-  "PrefabIdentifier": "chrprfmech_hunchiebase-001",
-  "PrefabBase": "hunchie",
+  "HardpointDataDefID": "hardpointdatadef_ionclint",
+  "PrefabIdentifier": "chrprfmech_ionclintbase-001",
+  "PrefabBase": "ionclint",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",

--- a/Optionals/RogueElites/Base/chassis/chassisdef_cricket_RWN-HW.json
+++ b/Optionals/RogueElites/Base/chassis/chassisdef_cricket_RWN-HW.json
@@ -40,7 +40,7 @@
   "ChassisTags": {
     "items": [
       "EliteMech",
-      "mr-resize-0.61-0.74-0.63"
+      "mr-resize-0.55-0.65-0.53"
     ],
     "tagSetSourceFile": ""
   },
@@ -48,9 +48,9 @@
   "YangsThoughts": "This Cricket Variant shows up together with Daredevils and Pyromaniacs. Prone to Explosions and Fire, this Cricket was Made to Burn the Surroundings and Mechs alike. The Name comes from Trees that are suspectible to fire, barely needing any Spark to be set Ablaze. Doesnt come with Additional Fire Extuinguishers or a Fire Insurance Policy.",
   "MovementCapDefID": "movedef_lightmech",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_hunchie",
-  "PrefabIdentifier": "chrprfmech_hunchiebase-001",
-  "PrefabBase": "hunchie",
+  "HardpointDataDefID": "hardpointdatadef_ionclint",
+  "PrefabIdentifier": "chrprfmech_ionclintbase-001",
+  "PrefabBase": "ionclint",
   "Tonnage": 30.0,
   "InitialTonnage": 3.0,
   "weightClass": "LIGHT",


### PR DESCRIPTION
Cricket now using the Ion Clint model

hardpoint override for Preta to put weapons into groups