### PR TITLE
emphasize default actuator BIG arm UI name; update Raven LR descripti…

### DIFF
--- a/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_TAG.json
+++ b/Core/RogueModuleTech/Aircraft/ExternalArmament/Other/Weapon_WingMounted_TAG.json
@@ -60,7 +60,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "EjectWeapon": true,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_TAG",

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_TAG_ArrowIV.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_TAG_ArrowIV.json
@@ -2,9 +2,6 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "NeverMelee"
-      },
-      {
         "CategoryID": "w/s/t/tag"
       },
       {
@@ -18,6 +15,7 @@
       "AreaOfEffectDmg: 125",
       "AreaOfEffectSTABDmg: 50",
       "NoAA",
+      "WordsWords: <size=115%><color=yellow>CAUTION!</color=yellow> <size=100%>This weapon can fire during melee",
       "AmmoCost: 3000"
     ],
     "Flags": [
@@ -64,7 +62,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "deferredEffect": {
     "id": "BARRAGE",
     "rounds": 1,

--- a/Core/RogueModuleTech/Artillery/Weapon_Artillery_TAG_Barrage.json
+++ b/Core/RogueModuleTech/Artillery/Weapon_Artillery_TAG_Barrage.json
@@ -2,9 +2,6 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "NeverMelee"
-      },
-      {
         "CategoryID": "w/s/t/tag"
       },
       {
@@ -24,6 +21,7 @@
       "FireTerrainStrength: 15",
       "DesignMask: RoughTerrain",
       "NoAA",
+      "WordsWords: <size=115%><color=yellow>CAUTION!</color=yellow> <size=100%>This weapon can fire during melee",
       "AmmoCost: 4000"
     ],
     "Flags": [
@@ -69,7 +67,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "deferredEffect": {
     "id": "BARRAGE",
     "rounds": 2,

--- a/Core/RogueModuleTech/Basic/ChassisDefaults/Default_Actuator_OneBIGArm.json
+++ b/Core/RogueModuleTech/Basic/ChassisDefaults/Default_Actuator_OneBIGArm.json
@@ -65,7 +65,7 @@
     "Purchasable": true,
     "Manufacturer": "Coventry",
     "Model": "Evil Dead",
-    "UIName": "One BIG Arm",
+    "UIName": "One <size=111%><b>BIG</b><size=100%> Arm",
     "Id": "Default_Actuator_OneBIGArm",
     "Name": "Arm Hand Actuator",
     "Details": "A specialised full arm designed specifically to allow one-handed mechs to perform comparably in melee to two-handed variants",

--- a/Core/RogueModuleTech/BattleArmor/Weapons/InnerSphere/Weapon_BattleArmor_TAG_Barrage.json
+++ b/Core/RogueModuleTech/BattleArmor/Weapons/InnerSphere/Weapon_BattleArmor_TAG_Barrage.json
@@ -2,9 +2,6 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "NeverMelee"
-      },
-      {
         "CategoryID": "w/s/t/tag"
       },
       {
@@ -26,6 +23,7 @@
       "WpnCooldown: 1",
       "DelayedImpact: 2",
       "AccuracyUnit: +5, Battle Armor & Protomech",
+      "WordsWords: <size=115%><color=yellow>CAUTION!</color=yellow> <size=100%>This weapon can fire during melee",
       "AmmoCost: 300",
       "CanUseDWP"
     ],
@@ -76,7 +74,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "deferredEffect": {
     "id": "PAMORTARS",
     "rounds": 1,

--- a/Core/RogueModuleTech/BattleArmor/Weapons/InnerSphere/Weapon_BattleArmor_TAG_Light.json
+++ b/Core/RogueModuleTech/BattleArmor/Weapons/InnerSphere/Weapon_BattleArmor_TAG_Light.json
@@ -65,7 +65,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_TAG",
   "Description": {

--- a/Core/RogueModuleTech/Clan/Weapons/Weapon_TAG_Light.json
+++ b/Core/RogueModuleTech/Clan/Weapons/Weapon_TAG_Light.json
@@ -51,7 +51,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_TAG",
   "Description": {

--- a/Core/RogueModuleTech/Cockpit/CockpitWeapon/Weapon_FCS_TAG.json
+++ b/Core/RogueModuleTech/Cockpit/CockpitWeapon/Weapon_FCS_TAG.json
@@ -55,7 +55,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_TAG",
   "Description": {

--- a/Core/RogueModuleTech/HandHeld/ClanHandHelds/HandHeld_Weapon_TAG_Super_Clan.json
+++ b/Core/RogueModuleTech/HandHeld/ClanHandHelds/HandHeld_Weapon_TAG_Super_Clan.json
@@ -61,7 +61,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "CanBeBlocked": false,
   "blockWeaponsInInstalledLocation": true,
   "EjectWeapon": true,

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Cuss.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Cuss.json
@@ -54,7 +54,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_TAG",
   "Description": {

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_FBOMB.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_FBOMB.json
@@ -2,9 +2,6 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "NeverMelee"
-      },
-      {
         "CategoryID": "w/s/t/tag"
       },
       {
@@ -24,6 +21,7 @@
       "FireTerrainStrength: 10",
       "DesignMask: RoughTerrain",
       "NoAA",
+      "WordsWords: <size=115%><color=yellow>CAUTION!</color=yellow> <size=100%>This weapon can fire during melee",
       "AmmoCost: 3000"
     ],
     "Flags": [
@@ -72,7 +70,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "deferredEffect": {
     "id": "F-BOMB",
     "rounds": 1,

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_HeyListen.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_HeyListen.json
@@ -55,7 +55,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "FireDelayMultiplier": 2,
   "ProjectileSpeedMultiplier": 3,

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Orbital.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Orbital.json
@@ -2,9 +2,6 @@
   "Custom": {
     "Category": [
       {
-        "CategoryID": "NeverMelee"
-      },
-      {
         "CategoryID": "w/s/t/tag"
       },
       {
@@ -25,6 +22,7 @@
       "DesignMask: Radiation",
       "PPCDEBUFF: 4",
       "NoAA",
+      "WordsWords: <size=115%><color=yellow>CAUTION!</color=yellow> <size=100%>This weapon can fire during melee",
       "AmmoCost: 10000"
     ],
     "Flags": [
@@ -72,7 +70,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "deferredEffect": {
     "id": "Orbital",
     "rounds": 3,

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Overlord.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Overlord.json
@@ -393,7 +393,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_LaserER_Small",
   "Description": {

--- a/Core/RogueModuleTech/Weapons/Weapon_C3_Master_TAG.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_C3_Master_TAG.json
@@ -58,7 +58,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_TAG",
   "Description": {

--- a/Core/RogueModuleTech/Weapons/Weapon_TAG.json
+++ b/Core/RogueModuleTech/Weapons/Weapon_TAG.json
@@ -51,7 +51,7 @@
   "IndirectFireCapable": false,
   "GunneryJammingMult": 0.005,
   "GunneryJammingBase": 1,
-  "NotUseInMelee": true,
+  "NotUseInMelee": false,
   "AttackRecoil": 1,
   "WeaponEffectID": "WeaponEffect-Weapon_TAG",
   "Description": {

--- a/Eras/CivilWar3062-3067/UrbanWarfare/chassis/chassisdef_raven_RVN-LR.json
+++ b/Eras/CivilWar3062-3067/UrbanWarfare/chassis/chassisdef_raven_RVN-LR.json
@@ -30,7 +30,7 @@
     "UIName": "Raven",
     "Id": "chassisdef_raven_RVN-LR",
     "Name": "Raven",
-    "Details": "The Raven LR 'Dagger' sports a prototype Electronics Warfare suite, Stealth Armor, TAG, and HayWire and NARC launchers.\n\n<b><color=#e62e00>Quirk: Nimble</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.02</color></b>\n\n<color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Details": "The Raven LR 'Dagger' sports a prototype Electronics Warfare suite, Stealth Armor, TAG, and a pair of NARC launchers with explosive and standard ammo.\n\n<b><color=#e62e00>Quirk: Nimble</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.02</color></b>\n\n<color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
     "Icon": "Raven2"
   },
   "VariantName": "RVN-LR",

--- a/Eras/CivilWar3062-3067/UrbanWarfare/mech/mechdef_raven_RVN-LR.json
+++ b/Eras/CivilWar3062-3067/UrbanWarfare/mech/mechdef_raven_RVN-LR.json
@@ -45,7 +45,7 @@
     "UIName": "Raven 'Dagger'",
     "Id": "mechdef_raven_RVN-LR",
     "Name": "Raven RVN-LR",
-    "Details": "The Raven LR 'Dagger' sports a prototype Electronics Warfare suite, Stealth Armor, TAG, and HayWire and NARC launchers.\n\n<b><color=#e62e00>Quirk: Nimble</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.02</color></b>\n\n<color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
+    "Details": "The Raven LR 'Dagger' sports a prototype Electronics Warfare suite, Stealth Armor, TAG, and a pair of NARC launchers with explosive and standard ammo.\n\n<b><color=#e62e00>Quirk: Nimble</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.02</color></b>\n\n<color=#FFEF00>Arm Actuator Limits: Left Upper, Right Upper</color>",
     "Icon": "Raven2"
   },
   "simGameMechPartCost": 86071,


### PR DESCRIPTION
…on to remove mention of non-existent Narc Haywire; enable TAG for use in melee, and add caution bonusdescription to the artillery versions