### PR TITLE
The Sharmat Arrives

### DIFF
--- a/Core/RogueModuleTech/Unique/Gear/Unique_Cockpit_Lorkahn.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Cockpit_Lorkahn.json
@@ -1,0 +1,402 @@
+{
+  "Custom": {
+    "Category": [
+      {
+        "CategoryID": "Cockpit"
+      }
+    ],
+    "BonusDescriptions": [
+      "Resolve: +15%",
+      "SkillTactics: +1",
+      "SkillGuts: +1",
+      "AllowsHeadshot",
+      "NightVision",
+      "ActiveInitiative: +2",
+      "ActiveEvaMax: +1",
+      "ActiveMelee: +10%",
+      "FailChance: 10%",
+      "FailInjury",
+      "FailStruct: 5",
+      "FailLocation: Head and CT",
+      "IsCockpit",
+      "BleedReduction: 20%"
+    ],
+    "Flags": [
+      "default",
+      "not_broken",
+      "no_salvage",
+      "autorepair"
+    ],
+      "ActivatableComponent": {
+      "ButtonName": "Lorkahn",
+      "CanNotBeActivatedManualy": false,
+      "CanActivateAfterMove": true,
+      "CanActivateAfterFire": false,
+      "SafeActivation": false,
+      "FailFlatChance": 0.10,
+      "FailRoundsStart": 1,
+      "FailChancePerTurn": 0.02,
+      "FailCheckOnActivationEnd": true,
+      "FailDamageLocations":["Head","CenterTorso"],
+      "FailISDamage":5,
+      "InjuryOnFail": true,
+      "FailPilotingBase": 1,
+      "FailPilotingMult": 0.01,
+      "InjuryReasonInt": 20,
+      "statusEffects": [
+        {
+          "durationData": {
+            "duration": -1,
+            "stackLimit": -1
+          },
+          "targetingData": {
+            "effectTriggerType": "Passive",
+            "effectTargetType": "Creator"
+          },
+          "effectType": "StatisticEffect",
+          "nature": "Buff",
+          "Description": {
+            "Id": "StatusEffect-Lorkahn-Init",
+            "Name": "Lorkahn Activatable: Increased Initiative",
+            "Details": "Provides + 2 Initiative and several buffs.",
+            "Icon": "uixSvgIcon_equipment_Cockpit"
+          },
+          "statisticData": {
+            "statName": "SBI_MOD_MISC",
+            "operation": "Int_Add",
+            "modValue": "2",
+            "modType": "System.Int32"
+          }
+        },
+        {
+          "durationData": {
+            "duration": -1,
+            "stackLimit": -1
+          },
+          "targetingData": {
+            "effectTriggerType": "Passive",
+            "effectTargetType": "Creator"
+          },
+          "effectType": "StatisticEffect",
+          "nature": "Buff",
+          "Description": {
+            "Id": "StatusEffect-Lorkahn-Eva",
+            "Name": "Lorkahn Cockpit Activatable: Increased Max Evasive Pips",
+            "Details": "This unit generates an extra EVASIVE charge from movement actions (up to its maximum).",
+            "Icon": "uixSvgIcon_action_evasivemove"
+          },
+          "statisticData": {
+            "statName": "MaxEvasivePips",
+            "operation": "Int_Add",
+            "modValue": "1",
+            "modType": "System.Int32"
+          }
+        },
+        {
+          "durationData": {
+            "duration": -1,
+            "stackLimit": -1
+          },
+          "targetingData": {
+            "effectTriggerType": "Passive",
+            "effectTargetType": "Creator",
+            "showInTargetPreview": false,
+            "showInStatusPanel": false
+          },
+          "effectType": "StatisticEffect",
+          "nature": "Buff",
+          "Description": {
+            "Id": "StatusEffect-Lorkahn-PWD",
+            "Name": "Lorkahn Cockpit Activatable: Increased Physical Weapon Damage",
+            "Details": "Damage Modifier",
+            "Icon": "uixSvgIcon_equipment_ActuatorArm"
+          },
+          "statisticData": {
+            "statName": "CBTBE_Physical_Weapon_Target_Damage_Multi",
+            "operation": "Float_Multiply",
+            "modValue": "1.1",
+            "modType": "System.Single"
+          }
+        },
+        {
+          "durationData": {
+            "duration": -1,
+            "stackLimit": -1
+          },
+          "targetingData": {
+            "effectTriggerType": "Passive",
+            "effectTargetType": "Creator",
+            "showInTargetPreview": false,
+            "showInStatusPanel": false
+          },
+          "effectType": "StatisticEffect",
+          "nature": "Buff",
+          "Description": {
+            "Id": "StatusEffect-Lorkahn-PDD",
+            "Name": "Lorkahn Cockpit Activatable: Increased Punch Damage",
+            "Details": "Damage Modifier",
+            "Icon": "uixSvgIcon_equipment_ActuatorArm"
+          },
+          "statisticData": {
+            "statName": "CBTBE_Punch_Target_Damage_Multi",
+            "operation": "Float_Multiply",
+            "modValue": "1.1",
+            "modType": "System.Single"
+          }
+        },
+        {
+          "durationData": {
+            "duration": -1,
+            "stackLimit": -1
+          },
+          "targetingData": {
+            "effectTriggerType": "Passive",
+            "effectTargetType": "Creator",
+            "showInTargetPreview": false,
+            "showInStatusPanel": false
+          },
+          "effectType": "StatisticEffect",
+          "nature": "Buff",
+          "Description": {
+            "Id": "StatusEffect-Lorkahn-KDD",
+            "Name": "Lorkahn Cockpit Activatable: Increased Kick Damage",
+            "Details": "Damage Modifier",
+            "Icon": "uixSvgIcon_equipment_ActuatorArm"
+          },
+          "statisticData": {
+            "statName": "CBTBE_Kick_Target_Damage_Multi",
+            "operation": "Float_Multiply",
+            "modValue": "1.1",
+            "modType": "System.Single"
+          }
+        },
+        {
+          "durationData": {
+            "duration": -1,
+            "stackLimit": -1
+          },
+          "targetingData": {
+            "effectTriggerType": "Passive",
+            "effectTargetType": "Creator",
+            "showInTargetPreview": false,
+            "showInStatusPanel": false
+          },
+          "effectType": "StatisticEffect",
+          "nature": "Buff",
+          "Description": {
+            "Id": "StatusEffect-Lorkahn-CHD",
+            "Name": "Lorkahn Cockpit Activatable: Increased Charge Damage",
+            "Details": "Damage Modifier",
+            "Icon": "uixSvgIcon_equipment_ActuatorArm"
+          },
+          "statisticData": {
+            "statName": "CBTBE_Charge_Target_Damage_Multi",
+            "operation": "Float_Multiply",
+            "modValue": "1.1",
+            "modType": "System.Single"
+          }
+        }
+      ]
+    },
+    "WorkOrderCosts": {
+      "Install": {
+        "TechCost": "0.2 * [[Chassis.Tonnage]]",
+        "CBillCost": "50 * [[Chassis.Tonnage]]"
+      }
+    },
+    "IBLS": {
+      "StorageSize": 1
+    },
+    "Lootable": "Gear_Cockpit_CommandConsole"
+  },
+  "Description": {
+    "Cost": 340000,
+    "Rarity": 99,
+    "Purchasable": true,
+    "Manufacturer": "Sithis",
+    "Model": "Doom Drum",
+    "UIName": "Mask of Lorkahn",
+    "Id": "Unique_Cockpit_Lorkahn",
+    "Name": "Mask of Lorkahn",
+    "Details": "Come! Lay down your weapons! It is not too late for my mercy...",
+    "Icon": "uixSvgIcon_equipment_Cockpit"
+  },
+  "BonusValueA": "",
+  "BonusValueB": "",
+  "ComponentType": "Upgrade",
+  "ComponentSubType": "NotSet",
+  "PrefabIdentifier": "",
+  "RelativeModifier": 0,
+  "AbsoluteModifier": 0,
+  "BattleValue": 0,
+  "InventorySize": 1,
+  "Tonnage": 1,
+  "AllowedLocations": "Head",
+  "DisallowedLocations": "All",
+  "CriticalComponent": false,
+  "statusEffects": [
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": 2
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "StatusEffect_Cockpit_Skill_Tactics",
+        "Name": "Lorkahn: Increased Tactics",
+        "Details": "Buffs Tactics Skill",
+        "Icon": "uixSvgIcon_equipment_Cockpit"
+      },
+      "statisticData": {
+        "statName": "Tactics",
+        "operation": "Int_Add",
+        "modValue": "1",
+        "modType": "System.Int32",
+        "targetCollection": "Pilot"
+      }
+    },
+        {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": 2
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "StatusEffect_Cockpit_Skill_Guts",
+        "Name": "Lorkahn: Increased Guts",
+        "Details": "Buffs Guts Skill",
+        "Icon": "uixSvgIcon_equipment_Cockpit"
+      },
+      "statisticData": {
+        "statName": "Guts",
+        "operation": "Int_Add",
+        "modValue": "1",
+        "modType": "System.Int32",
+        "targetCollection": "Pilot"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "StatusEffect-Morale_Gain-T4",
+        "Name": "Lorkahn: Increased Resolve Generation",
+        "Details": "Provides a [AMT] bonus to actions that generate Resolve.",
+        "Icon": "uixSvgIcon_equipment_Cockpit"
+      },
+      "statisticData": {
+        "statName": "resolveGenBaseMult",
+        "operation": "Float_Add",
+        "modValue": "0.15",
+        "modType": "System.Single"
+      }
+    },
+    {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator",
+        "showInTargetPreview": false,
+        "showInStatusPanel": false
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "CockpitBleed",
+        "Name": "Lorkahn: Decreased Bleeding Rate",
+        "Details": "Bleed Rate x 0.6",
+        "Icon": "blood"
+      },
+      "statisticData": {
+        "statName": "BleedingRateMulti",
+        "operation": "Float_Multiply",
+        "modValue": "0.8",
+        "modType": "System.Single",
+        "targetCollection": "Pilot"
+      }
+    },
+        {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "NightVision",
+        "Name": "Lorkahn Cockpit: Night Vision",
+        "Details": "PASSIVE: Enables Night Vision.",
+        "Icon": "uixSvgIcon_ability_precisionstrike"
+      },
+      "statisticData": {
+        "statName": "LV_NIGHT_VISION",
+        "operation": "Set",
+        "modValue": "true",
+        "modType": "System.Boolean"
+      }
+    },
+        {
+      "durationData": {
+        "duration": -1,
+        "stackLimit": -1
+      },
+      "targetingData": {
+        "effectTriggerType": "Passive",
+        "effectTargetType": "Creator"
+      },
+      "effectType": "StatisticEffect",
+      "nature": "Buff",
+      "Description": {
+        "Id": "TC-Headshot",
+        "Name": "FCS Headshot: Enable Always Allow Called Shot",
+        "Details": "PASSIVE: Attacking with a single weapon ignores COVER and GUARDED on the target.",
+        "Icon": "uixSvgIcon_ability_precisionstrike"
+      },
+      "statisticData": {
+        "statName": "IRTCalledShotAlwaysAllow",
+        "operation": "Set",
+        "modValue": "true",
+        "modType": "System.Boolean"
+      }
+    }
+  ],
+  "ComponentTags": {
+    "items": [
+      "component_type_stock",
+      "LootMagnetBlacklist",
+      "SquadIncompatible"
+    ],
+    "tagSetSourceFile": ""
+  }
+}

--- a/Core/RogueModuleTech/Unique/Gear/Unique_Cockpit_Lorkahn.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Cockpit_Lorkahn.json
@@ -225,7 +225,7 @@
   "BonusValueB": "",
   "ComponentType": "Upgrade",
   "ComponentSubType": "NotSet",
-  "PrefabIdentifier": "",
+  "PrefabIdentifier": "mask",
   "RelativeModifier": 0,
   "AbsoluteModifier": 0,
   "BattleValue": 0,

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-A-1.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-A-1.json
@@ -1,0 +1,295 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.0
+    },
+    "AssemblyVariant": {
+      "PrefabID": "dagoth",
+      "Exclude": false,
+      "Include": true
+    },
+    "ChassisCategory": [
+      {
+        "CategoryID": "SpecialShield",
+        "Limits": [
+          {
+            "Location": "All",
+            "Max": 1
+          },
+          {
+            "Location": "LeftArm",
+            "Min": 1,
+            "Max": 1
+          }
+        ]
+      }
+    ],
+    "MultiDefaults": [
+      {
+        "Location": "LeftArm",
+        "DefID": "Default_HandHeld_Shield_9tons",
+        "ComponentType": "Upgrade",
+        "Categories": [
+          "SpecialShield",
+          "HandHeld"
+        ]
+      }
+    ]
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_WellBalanced",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 1768143,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Vining Engineering and Salvage Team",
+    "Model": "",
+    "UIName": "Dagoth",
+    "Id": "chassisdef_dagoth_DG-A-1",
+    "Name": "Dagoth",
+    "Details": "Originally intended to be a Solaris one-off design, the Dagoth took an unusual turn when outside investors had interest in a relatively cheap and tough stand-off mech. The Dagoth's modest armament for its weight class consists of a Gauss rifle and a pair of MML-9 launchers as the primary weapons but is backed up by 18 tons of armor and a large shield to keep it standing longer than many other assaults. \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "VariantName": "DAG-A-1",
+  "ChassisTags": {
+    "items": [
+      "mr-resize-0.98"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Bruiser",
+  "YangsThoughts": "It's simple. It's pretty cheap. It's effective. VEST did something right with this export model.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_dagoth",
+  "PrefabIdentifier": "chrprfmech_dagothbase-001",
+  "PrefabBase": "dagoth",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 100,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "AlwaysPunchIfPossible": false,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-B-3.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-B-3.json
@@ -1,0 +1,264 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.0
+    },
+    "AssemblyVariant": {
+      "PrefabID": "dagoth",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_WellBalanced",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 1768143,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Vining Engineering and Salvage Team",
+    "Model": "",
+    "UIName": "Dagoth",
+    "Id": "chassisdef_dagoth_DG-B-3",
+    "Name": "Dagoth",
+    "Details": "The Dagoth B-3 model was met with a very luke warm reception in the export markets. Despite the staggering amount of RAC2 rounds it was able to send down range, the cost of the 285XL engine priced most fans of the original A-1 out of picking up a B-3. \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "VariantName": "DAG-B-3",
+  "ChassisTags": {
+    "items": [
+      "mr-resize-0.98"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Fire Support",
+  "YangsThoughts": "I really like RACs, boss but four may be too many on one frame.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_dagoth",
+  "PrefabIdentifier": "chrprfmech_dagothbase-001",
+  "PrefabBase": "dagoth",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 100,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "AlwaysPunchIfPossible": false,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+                {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-C-2.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-C-2.json
@@ -1,0 +1,264 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.0
+    },
+    "AssemblyVariant": {
+      "PrefabID": "dagoth",
+      "Exclude": false,
+      "Include": true
+    }
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_WellBalanced",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 1768143,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Vining Engineering and Salvage Team",
+    "Model": "",
+    "UIName": "Dagoth",
+    "Id": "chassisdef_dagoth_DG-C-2",
+    "Name": "Dagoth",
+    "Details": "The Dagoth C-2 was originally a special-order variant intended for a series of themed Solaris matches but saw limited export to various entities throughout the Inner Sphere. A pair of Sniper Artillery Cannons provide the C-2 with a flashy 1-2 punch which can then be supplemented with the ER Large Laser and Medium Pulse Lasers.  \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "VariantName": "DAG-C-2",
+  "ChassisTags": {
+    "items": [
+      "mr-resize-0.98"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Bruiser",
+  "YangsThoughts": "Boss, when I ask you 'Why?!' The answer should not be 'Why not?'.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_dagoth",
+  "PrefabIdentifier": "chrprfmech_dagothbase-001",
+  "PrefabBase": "dagoth",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 100,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "AlwaysPunchIfPossible": false,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+                {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Ballistic",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-UR-1.json
+++ b/Eras/Republic3081-3130/Base/chassis/chassisdef_dagoth_DG-UR-1.json
@@ -1,0 +1,284 @@
+{
+  "Custom": {
+    "DropCostFactor": {
+      "DropModifier": 1.0
+    },
+    "AssemblyVariant": {
+      "PrefabID": "dagoth",
+      "Exclude": false,
+      "Include": true
+    },
+        "ChassisDefaults": [
+      {
+        "CategoryID": "Cockpit",
+        "Defaults": [
+          {
+            "Location": "Head",
+            "DefID": "Unique_Cockpit_Lorkahn",
+            "Type": "Upgrade"
+          }
+        ]
+      }
+    ]
+  },
+  "CustomParts": {
+    "CustomParts": []
+  },
+  "FixedEquipment": [
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Quirk_WellBalanced",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "Description": {
+    "Cost": 1768143,
+    "Rarity": 5,
+    "Purchasable": true,
+    "Manufacturer": "Vining Engineering and Salvage Team",
+    "Model": "",
+    "UIName": "Dagoth",
+    "Id": "chassisdef_dagoth_DG-UR-1",
+    "Name": "Dagoth",
+    "Details": "The original Dagoth design was meant to be a competitor to Defiance's Berserker but never made it to full production. However, the original design did see a few prototypes dubbed the Dagoth Ur-1. A 380XL engine with supercharger strains to move the over 30 tons of Hardened armor at reasonable speeds to bring the sword and Snub-Nose PPC into range. \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "VariantName": "DAG-UR-1",
+  "ChassisTags": {
+    "items": [
+      "mr-resize-0.98"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "StockRole": "Brawler",
+  "YangsThoughts": "What a grand and intoxicating innocence! I, uh, I'm not sure what came over me boss. This is THE Dagoth Ur of Solaris fame.",
+  "MovementCapDefID": "movedef_assaultmech",
+  "PathingCapDefID": "pathingdef_assault",
+  "HardpointDataDefID": "hardpointdatadef_dagoth",
+  "PrefabIdentifier": "chrprfmech_dagothbase-001",
+  "PrefabBase": "dagoth",
+  "Tonnage": 95.0,
+  "InitialTonnage": 9.5,
+  "weightClass": "ASSAULT",
+  "BattleValue": 9360000,
+  "Heatsinks": 0,
+  "TopSpeed": 105,
+  "TurnRadius": 90,
+  "MaxJumpjets": 20,
+  "Stability": 100,
+  "StabilityDefenses": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "SpotterDistanceMultiplier": 1,
+  "VisibilityMultiplier": 1,
+  "SensorRangeMultiplier": 1,
+  "Signature": 1,
+  "Radius": 8,
+  "PunchesWithLeftArm": false,
+  "MeleeDamage": 48,
+  "MeleeInstability": 24,
+  "MeleeToHitModifier": 0,
+  "DFADamage": 95,
+  "DFAToHitModifier": 0,
+  "DFASelfDamage": 95,
+  "DFAInstability": 48,
+  "MechPartMax": 0,
+  "MechPartCount": 0,
+  "EngageRangeModifier": 0,
+  "AlwaysPunchIfPossible": false,
+  "Locations": [
+    {
+      "Location": "Head",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 45,
+      "MaxRearArmor": -1,
+      "InternalStructure": 16
+    },
+    {
+      "Location": "LeftArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "CenterTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "AntiPersonnel",
+          "Omni": false
+        },
+                {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 300,
+      "MaxRearArmor": 150,
+      "InternalStructure": 150
+    },
+    {
+      "Location": "RightTorso",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Missile",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "Special",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 200,
+      "MaxRearArmor": 100,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightArm",
+      "Hardpoints": [
+        {
+          "WeaponMountID": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMountID": "SpecialHandHeld",
+          "Omni": false
+        }
+      ],
+      "Tonnage": 0,
+      "InventorySlots": 13,
+      "MaxArmor": 160,
+      "MaxRearArmor": -1,
+      "InternalStructure": 80
+    },
+    {
+      "Location": "LeftLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    },
+    {
+      "Location": "RightLeg",
+      "Hardpoints": [],
+      "Tonnage": 0,
+      "InventorySlots": 6,
+      "MaxArmor": 200,
+      "MaxRearArmor": -1,
+      "InternalStructure": 100
+    }
+  ],
+  "LOSSourcePositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    }
+  ],
+  "LOSTargetPositions": [
+    {
+      "x": 0,
+      "y": 17,
+      "z": 0
+    },
+    {
+      "x": 5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": -5,
+      "y": 16,
+      "z": -1
+    },
+    {
+      "x": 3.5,
+      "y": 5.5,
+      "z": 1
+    },
+    {
+      "x": -3.5,
+      "y": 5.5,
+      "z": 1
+    }
+  ]
+}

--- a/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-A-1.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-A-1.json
@@ -1,0 +1,239 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_bracket_high",
+      "unit_role_brawler",
+      "unit_lance_vanguard",
+      "unit_optional_era",
+      "unit_era_civil_war",
+      "unit_release",
+      "unit_rt_custom",
+      "unit_chassis_dagoth",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_1",
+      "ai_heat_high",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_normal",
+      "ai_lance_high",
+      "ai_lethalself_normal",
+      "ai_move_normal",
+      "ai_priority_normal",
+      "ai_reserve_normal",
+      "ai_shooting_low",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_dagoth_DG-A-1",
+  "Description": {
+    "Cost": 9656543,
+    "Rarity": 4,
+    "Purchasable": false,
+    "UIName": "Dagoth A-1",
+    "Id": "mechdef_dagoth_DG-A-1",
+    "Name": "Dagoth A-1",
+    "Details": "Originally intended to be a Solaris one-off design, the Dagoth took an unusual turn when outside investors had interest in a relatively cheap and tough stand-off mech. The Dagoth's modest armament for its weight class consists of a Gauss rifle and a pair of MML-9 launchers as the primary weapons but is backed up by 18 tons of armor and a large shield to keep it standing longer than many other assaults. \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "simGameMechPartCost": 353629,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 80,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 80,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 300,
+      "CurrentRearArmor": 135,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 300,
+      "AssignedRearArmor": 135,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 80,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 80,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Pulse_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Pulse_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Gauss_Rifle",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_MML_9",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Rifle",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Rifle",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Gauss_Rifle",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_CASE2",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_MML_9",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_CASE2",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+
+  ]
+}

--- a/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-B-3.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-B-3.json
@@ -1,0 +1,323 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_bracket_high",
+      "unit_role_brawler",
+      "unit_lance_vanguard",
+      "unit_optional_era",
+      "unit_era_civil_war",
+      "unit_release",
+      "unit_rt_custom",
+      "unit_chassis_dagoth",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_1",
+      "ai_heat_high",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_normal",
+      "ai_lance_high",
+      "ai_lethalself_normal",
+      "ai_move_normal",
+      "ai_priority_normal",
+      "ai_reserve_normal",
+      "ai_shooting_low",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_dagoth_DG-B-3",
+  "Description": {
+    "Cost": 9656543,
+    "Rarity": 4,
+    "Purchasable": false,
+    "UIName": "Dagoth B-3",
+    "Id": "mechdef_dagoth_DG-B-3",
+    "Name": "Dagoth B-3",
+    "Details": "The Dagoth B-3 model was met with a very luke warm reception in the export markets. Despite the staggering amount of RAC2 rounds it was able to send down range, the cost of the 285XL engine priced most fans of the original A-1 out of picking up a B-3. \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "simGameMechPartCost": 353629,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 80,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 80,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 300,
+      "CurrentRearArmor": 115,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 300,
+      "AssignedRearArmor": 115,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 80,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 80,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+        {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Ballistic_Improved",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Sensors_BallisticRange",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Gyro_Armored",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": true,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Special_AddOn_ThermalVision_Mk2",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Special_AddOn_Exchanger",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Small",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Small",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_RAC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Autocannon_RAC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_RAC_2_Double",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_RAC_2_AP",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_RAC_2_Precision",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_CASE2",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Autocannon_RAC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_ER_Medium",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_RAC_2_Double",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_RAC_2_AP",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_RAC_2_Precision",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_CASE2",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Autocannon_RAC_2",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+
+  ]
+}

--- a/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-C-2.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-C-2.json
@@ -1,0 +1,231 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_bracket_high",
+      "unit_role_brawler",
+      "unit_lance_vanguard",
+      "unit_optional_era",
+      "unit_era_civil_war",
+      "unit_release",
+      "unit_rt_custom",
+      "unit_chassis_dagoth",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_1",
+      "ai_heat_high",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_normal",
+      "ai_lance_high",
+      "ai_lethalself_normal",
+      "ai_move_normal",
+      "ai_priority_normal",
+      "ai_reserve_normal",
+      "ai_shooting_low",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_dagoth_DG-C-2",
+  "Description": {
+    "Cost": 9656543,
+    "Rarity": 4,
+    "Purchasable": false,
+    "UIName": "Dagoth C-2",
+    "Id": "mechdef_dagoth_DG-C-2",
+    "Name": "Dagoth C-2",
+    "Details": "The Dagoth C-2 was originally a special-order variant intended for a series of themed Solaris matches but saw limited export to various entities throughout the Inner Sphere. A pair of Sniper Artillery Cannons provide the C-2 with a flashy 1-2 punch which can then be supplemented with the ER Large Laser and Medium Pulse Lasers.  \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "simGameMechPartCost": 353629,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 75,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 75,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 300,
+      "CurrentRearArmor": 125,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 300,
+      "AssignedRearArmor": 125,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 75,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 75,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+        {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Structure_EndoSteel",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_285",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_HeatSinkKit_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCooling_Heatsinks_1",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Gyro_Artillery",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Pulse_Medium_RakerIV",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Weapon_Laser_Pulse_Medium_RakerIV",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_ER_Large",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+            {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Artillery_Sniper_Cannon",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Sniper",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Sniper",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Artillery_Sniper_Cannon",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Sniper",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Sniper",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_HeatSink_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+
+  ]
+}

--- a/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-UR-1.json
+++ b/Eras/Republic3081-3130/Base/mech/mechdef_dagoth_DG-UR-1.json
@@ -1,0 +1,315 @@
+{
+  "MechTags": {
+    "items": [
+      "unit_mech",
+      "unit_assault",
+      "unit_bracket_high",
+      "unit_role_brawler",
+      "unit_lance_vanguard",
+      "unit_optional_era",
+      "unit_era_civil_war",
+      "unit_release",
+      "unit_rt_custom",
+      "unit_chassis_dagoth",
+      "unit_tonnage_95",
+      "unit_rarity_equipment_level_1",
+      "ai_heat_high",
+      "ai_dfa_low",
+      "ai_melee_normal",
+      "ai_flank_normal",
+      "ai_lance_high",
+      "ai_lethalself_normal",
+      "ai_move_normal",
+      "ai_priority_normal",
+      "ai_reserve_normal",
+      "ai_shooting_low",
+      "ai_surrounded_normal"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "ChassisID": "chassisdef_dagoth_DG-UR-1",
+  "Description": {
+    "Cost": 9656543,
+    "Rarity": 4,
+    "Purchasable": false,
+    "UIName": "Dagoth UR-1",
+    "Id": "mechdef_dagoth_DG-UR-1",
+    "Name": "Dagoth UR-1",
+    "Details": "The original Dagoth design was meant to be a competitor to Defiance's Berserker but never made it to full production. However, the original design did see a few prototypes dubbed the Dagoth Ur-1. A 380XL engine with supercharger strains to move the over 30 tons of Hardened armor at reasonable speeds to bring the sword and Snub-Nose PPC into range. \n\n<b><color=#e62e00>Quirk: Well Balanced</color></b>\n\n<b><color=#e62e00>Drop Cost Multiplier: 1.0</color></b>",
+    "Icon": "uixTxrIcon_sorcerer"
+  },
+  "simGameMechPartCost": 353629,
+  "Locations": [
+    {
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 16,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "CenterTorso",
+      "CurrentArmor": 300,
+      "CurrentRearArmor": 115,
+      "CurrentInternalStructure": 150,
+      "AssignedArmor": 300,
+      "AssignedRearArmor": 115,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightTorso",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 70,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 70,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightArm",
+      "CurrentArmor": 160,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 80,
+      "AssignedArmor": 160,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "LeftLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "Location": "RightLeg",
+      "CurrentArmor": 200,
+      "CurrentRearArmor": 0,
+      "CurrentInternalStructure": 100,
+      "AssignedArmor": 200,
+      "AssignedRearArmor": 0,
+      "DamageLevel": "Functional"
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Weapon_Laser_Pulse_Small",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportA_Tactics",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_Cockpit_LifeSupportB_Tactics",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "Head",
+      "ComponentDefID": "Gear_FCS_Melee",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Armor_Hardened",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Structure_EndoSteel",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_EngineCore_380",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+            {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Engine_XL",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Linked_Engine_Size_3",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Gyro_Melee_PlusPlus",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Supercharger",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "CenterTorso",
+      "ComponentDefID": "Gear_Spikes_Solaris",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Lootable_HandHeld_Melee_Sword_15tons",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Actuator_Arm_Upper_Hardened",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Actuator_Arm_Lower_Melee",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Actuator_MightyHand",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_Laser_Pulse_Small",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_Spikes_Solaris",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_TSM_Standard",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_Laser_Pulse_Small",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_Spikes_Solaris",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+        {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Actuator_Arm_Upper_Hardened",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Actuator_Arm_Lower_Melee",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Actuator_MightyHand",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_PPC_Snubnose",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "DamageLevel": "Functional"
+    },
+            {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_Spikes_Solaris",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    },
+            {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_Spikes_Solaris",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "DamageLevel": "Functional"
+    }
+
+  ]
+}


### PR DESCRIPTION
Adds the Dagoth mech, a 95t VEST design with variants intended for Solaris and export to the wider Inner Sphere.
Should be used to plug assault wholes or thin spots in Periphery and/or smaller House faction lance generation. Includes a hero mech, the UR-1 with custom cockpit module that _**should**_ spawn the Dagoth Ur mask prefab from the CAB model. 