### PR TITLE
update death events to exclude immune pilots

### DIFF
--- a/Core/RGoBoom/events/event_mw_therearefourbolts.json
+++ b/Core/RGoBoom/events/event_mw_therearefourbolts.json
@@ -17,7 +17,9 @@
     },
     "ExclusionTags": {
       "items": [
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },
@@ -79,7 +81,9 @@
         },
         "ExclusionTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },
@@ -103,7 +107,9 @@
         },
         "ExclusionTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },

--- a/Core/RGoBoom/events/event_mw_therearefourbolts_Gamma.json
+++ b/Core/RGoBoom/events/event_mw_therearefourbolts_Gamma.json
@@ -17,7 +17,9 @@
     },
     "ExclusionTags": {
       "items": [
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },
@@ -79,7 +81,9 @@
         },
         "ExclusionTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },
@@ -103,7 +107,9 @@
         },
         "ExclusionTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },

--- a/Core/RGoBoom/events/event_mw_therearefourbolts_theSequel.json
+++ b/Core/RGoBoom/events/event_mw_therearefourbolts_theSequel.json
@@ -17,7 +17,9 @@
     },
     "ExclusionTags": {
       "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
       "tagSetSourceFile": ""
     },
@@ -83,7 +85,9 @@
         },
         "ExclusionTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },
@@ -107,7 +111,9 @@
         },
         "ExclusionTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },

--- a/Core/RGoBoom/events/event_mw_therearefourbolts_theSequel_Gamma.json
+++ b/Core/RGoBoom/events/event_mw_therearefourbolts_theSequel_Gamma.json
@@ -17,7 +17,9 @@
     },
     "ExclusionTags": {
       "items": [
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },
@@ -83,7 +85,9 @@
         },
         "ExclusionTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },
@@ -103,7 +107,9 @@
         "Scope": "TertiaryMechWarrior",
         "RequirementTags": {
           "items": [
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         },

--- a/Core/RGoBoom/events/forceevent_co_safetychecks.json
+++ b/Core/RGoBoom/events/forceevent_co_safetychecks.json
@@ -39,7 +39,9 @@
         "ExclusionTags": {
           "items": [
             "pilot_morale_low",
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         }
@@ -306,7 +308,9 @@
           "ExclusionTags": {
             "items": [
               "pilot_spacer",
-              "pilot_unavailable"
+              "pilot_unavailable",
+              "name_Casparamaris",
+              "name_Leeloo"
             ],
             "tagSetSourceFile": "Tags/PilotTags"
           }
@@ -1163,7 +1167,9 @@
           },
           "ExclusionTags": {
             "items": [
-              "pilot_unavailable"
+              "pilot_unavailable",
+              "name_Casparamaris",
+              "name_Leeloo"
             ],
             "tagSetSourceFile": ""
           }

--- a/Core/RGoBoom/events/forceevent_co_safetychecks_Gamma.json
+++ b/Core/RGoBoom/events/forceevent_co_safetychecks_Gamma.json
@@ -39,6 +39,8 @@
         "ExclusionTags": {
           "items": [
             "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo",
             "pilot_morale_low"
           ],
           "tagSetSourceFile": ""
@@ -305,8 +307,10 @@
           },
           "ExclusionTags": {
             "items": [
-              "pilot_spacer",
-              "pilot_unavailable"
+                "pilot_spacer",
+                "pilot_unavailable",
+                "name_Casparamaris",
+                "name_Leeloo"
             ],
             "tagSetSourceFile": "Tags/PilotTags"
           }
@@ -1163,7 +1167,9 @@
           },
           "ExclusionTags": {
             "items": [
-              "pilot_unavailable"
+                "pilot_unavailable",
+                "name_Casparamaris",
+                "name_Leeloo"
             ],
             "tagSetSourceFile": ""
           }

--- a/Core/RGoBoom/events/forceevent_co_safetychecks_sequel.json
+++ b/Core/RGoBoom/events/forceevent_co_safetychecks_sequel.json
@@ -33,7 +33,9 @@
         "ExclusionTags": {
           "items": [
             "pilot_morale_low",
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         }
@@ -302,7 +304,9 @@
           "ExclusionTags": {
             "items": [
               "pilot_spacer",
-              "pilot_unavailable"
+              "pilot_unavailable",
+              "name_Casparamaris",
+              "name_Leeloo"
             ],
             "tagSetSourceFile": "Tags/PilotTags"
           }
@@ -1177,7 +1181,9 @@
           },
           "ExclusionTags": {
             "items": [
-              "pilot_unavailable"
+              "pilot_unavailable",
+              "name_Casparamaris",
+              "name_Leeloo"
             ],
             "tagSetSourceFile": ""
           }

--- a/Core/RGoBoom/events/forceevent_co_safetychecks_sequel_Gamma.json
+++ b/Core/RGoBoom/events/forceevent_co_safetychecks_sequel_Gamma.json
@@ -33,7 +33,9 @@
         "ExclusionTags": {
           "items": [
             "pilot_morale_low",
-            "pilot_unavailable"
+            "pilot_unavailable",
+            "name_Casparamaris",
+            "name_Leeloo"
           ],
           "tagSetSourceFile": ""
         }
@@ -302,7 +304,9 @@
           "ExclusionTags": {
             "items": [
               "pilot_spacer",
-              "pilot_unavailable"
+              "pilot_unavailable",
+              "name_Casparamaris",
+              "name_Leeloo"
             ],
             "tagSetSourceFile": "Tags/PilotTags"
           }
@@ -1177,7 +1181,9 @@
           },
           "ExclusionTags": {
             "items": [
-              "pilot_unavailable"
+              "pilot_unavailable",
+              "name_Casparamaris",
+              "name_Leeloo"
             ],
             "tagSetSourceFile": ""
           }

--- a/Core/RogueTechCore/cargosevents/event_mw_gravewounds.json
+++ b/Core/RogueTechCore/cargosevents/event_mw_gravewounds.json
@@ -15,7 +15,9 @@
     },
     "ExclusionTags": {
       "items": [
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },

--- a/Core/RogueTechCore/events/event_mw_beyondRepair.json
+++ b/Core/RogueTechCore/events/event_mw_beyondRepair.json
@@ -17,7 +17,9 @@
     },
     "ExclusionTags": {
       "items": [
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },

--- a/Core/RogueTechCore/events/event_mw_fence_Pirate3_largeLaser.json
+++ b/Core/RogueTechCore/events/event_mw_fence_Pirate3_largeLaser.json
@@ -15,7 +15,9 @@
     },
     "ExclusionTags": {
       "items": [
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },

--- a/Core/RogueTechCore/events/event_mw_noGuarantees.json
+++ b/Core/RogueTechCore/events/event_mw_noGuarantees.json
@@ -20,7 +20,9 @@
         "pilot_dishonest",
         "pilot_dependable",
         "pilot_rebellious",
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },

--- a/Core/RogueTechCore/events/event_mw_rebelliousBloodsport.json
+++ b/Core/RogueTechCore/events/event_mw_rebelliousBloodsport.json
@@ -18,7 +18,9 @@
     "ExclusionTags": {
       "items": [
         "event_mw_rebelliousBloodsport",
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": "Tags/PilotTags"
     },

--- a/Core/RogueTechCore/events/event_mw_triage.json
+++ b/Core/RogueTechCore/events/event_mw_triage.json
@@ -15,7 +15,9 @@
     },
     "ExclusionTags": {
       "items": [
-        "pilot_unavailable"
+        "pilot_unavailable",
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     },

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout_1.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout_1.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout_2.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout_2.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout_4.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenBuyout_4.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime.json
@@ -56,6 +56,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead_1.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead_1.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead_2.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead_2.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead_4.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeDead_4.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo.json
@@ -54,6 +54,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo_1.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo_1.json
@@ -54,6 +54,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo_2.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo_2.json
@@ -54,6 +54,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo_4.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTimeToo_4.json
@@ -54,6 +54,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_1.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_1.json
@@ -56,6 +56,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_2.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_2.json
@@ -56,6 +56,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_4.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_4.json
@@ -56,6 +56,7 @@
             "Kraken_ExChampion",
             "pilot_player203",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss_1.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss_1.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss_2.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss_2.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss_4.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenGoodTime_dismiss_4.json
@@ -53,6 +53,7 @@
             "KrakenGame_Champion",
             "Kraken_ExChampion",
             "name_Casparamaris",
+            "name_Leeloo",
             "pilot_unavailable"
           ],
           "tagSetSourceFile": ""

--- a/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenMRBC.json
+++ b/Optionals/Eventualities/KrakenGoodTime/events/event_co_KrakenMRBC.json
@@ -19,7 +19,8 @@
       "items": [
         "KrakenGame_Champion",
         "Kraken_ExChampion",
-        "name_Casparamaris"
+        "name_Casparamaris",
+        "name_Leeloo"
       ],
       "tagSetSourceFile": ""
     }


### PR DESCRIPTION
Added Casparamaris and Leeloo to FOUR BOLTS, GRAVEWOUNDS, BEYONDREPAIR, FENCE PIRATE3, NOGUARANTEES,  BLOODSPORT and TRIAGE events  exclusion; Added Leeloo to KRAKEN GOOD TIMES events exclusion