### PR TITLE
Renamed Injuries Resisted to Bonus HP and added missing + signs

### DIFF
--- a/Core/MonsterMashup/upgrade/Gear_Overlord_CrewCompartment.json
+++ b/Core/MonsterMashup/upgrade/Gear_Overlord_CrewCompartment.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "Health: 6"
+      "Health: +6"
     ],
     "Flags": [
       "default",

--- a/Core/MonsterMashup/upgrade/Gear_Union_CrewCompartment.json
+++ b/Core/MonsterMashup/upgrade/Gear_Union_CrewCompartment.json
@@ -6,7 +6,7 @@
       }
     ],
     "BonusDescriptions": [
-      "Health: 4"
+      "Health: +4"
     ],
     "Flags": [
       "default",

--- a/Core/RogueModuleTech/Cockpit/Cockpit/Gear_Cockpit_SpikedHelmet.json
+++ b/Core/RogueModuleTech/Cockpit/Cockpit/Gear_Cockpit_SpikedHelmet.json
@@ -9,7 +9,7 @@
       }
     ],
     "BonusDescriptions": [
-      "Health: 1",
+      "Health: +1",
       "CBTBEChargeDamageMulti: +10%",
       "SkillGunnery: -1",
       "SkillPiloting: -1",

--- a/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole.json
+++ b/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole.json
@@ -24,7 +24,7 @@
       "LanceIndirectAcc: +1",
       "LanceScatter: -10%, -20%",
       "LanceResolve2: 1",
-      "Health: 2",
+      "Health: +2",
       "IsProbe: 1",
       "AdvancedSensors: 5",
       "MultiTracker",

--- a/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole_Armored.json
+++ b/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole_Armored.json
@@ -24,7 +24,7 @@
       "LanceIndirectAcc: +1",
       "LanceScatter: -10%, -20%",
       "LanceResolve2: 1",
-      "Health: 2",
+      "Health: +2",
       "IsProbe: 1",
       "AdvancedSensors: 5",
       "MultiTracker",

--- a/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole_Plus.json
+++ b/Core/RogueModuleTech/Cockpit/Other/Gear_Cockpit_CommandConsole_Plus.json
@@ -27,7 +27,7 @@
       "LanceIndirectAcc: +1",
       "LanceScatter: -10%, -20%",
       "LanceResolve2: 1",
-      "Health: 2",
+      "Health: +2",
       "IsProbe: 1",
       "AdvancedSensors: 5",
       "OffensivePushAcc: +1",

--- a/Core/RogueModuleTech/Unique/Gear/Unique_Cockpit_ZeusC.json
+++ b/Core/RogueModuleTech/Unique/Gear/Unique_Cockpit_ZeusC.json
@@ -13,7 +13,7 @@
       "Initiative: 1",
       "Tacticon: +2",
       "AllLanceSight: +20%",
-      "Health: 3",
+      "Health: +3",
       "IsCockpit",
       "BleedReduction: 20%"
     ],

--- a/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Overlord.json
+++ b/Core/RogueModuleTech/Unique/Weapon/Unique_Weapon_TAG_Overlord.json
@@ -35,7 +35,7 @@
       "Initiative: +1",
       "LanceResolve2: 1",
       "AdvancedSensors: 5",
-      "Health: 2",
+      "Health: +2",
       "IsCockpit",
       "FCS",
       "BleedReduction: 20%"

--- a/Core/RogueTechCore/Localization.json
+++ b/Core/RogueTechCore/Localization.json
@@ -16480,11 +16480,11 @@
   },
   {
     "FileName": "\\RogueTech Core\\bonusDescriptions\\BonusDescriptions_MechEngineer.json",
-    "Original": "{0} Bonus HP",
+    "Original": "{0} Bonus Health",
     "Commentary": "",
     "Name": "RogueTech_Core.BonusDescriptions_MechEngineer.Health.Full",
     "Localization": {
-      "CULTURE_EN_US": "{0} Bonus HP"
+      "CULTURE_EN_US": "{0} Bonus Health"
     }
   },
   {

--- a/Core/RogueTechCore/Localization.json
+++ b/Core/RogueTechCore/Localization.json
@@ -16480,11 +16480,11 @@
   },
   {
     "FileName": "\\RogueTech Core\\bonusDescriptions\\BonusDescriptions_MechEngineer.json",
-    "Original": "{0} Injuries resisted",
+    "Original": "{0} Bonus HP",
     "Commentary": "",
     "Name": "RogueTech_Core.BonusDescriptions_MechEngineer.Health.Full",
     "Localization": {
-      "CULTURE_EN_US": "{0} Injuries resisted"
+      "CULTURE_EN_US": "{0} Bonus HP"
     }
   },
   {

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -2007,8 +2007,8 @@
     {
       "Bonus": "Health",
       "Short": "{0} HP",
-      "Long": "{0} Bonus HP.",
-      "Full": "{0} Bonus HP."
+      "Long": "{0} Bonus Health.",
+      "Full": "{0} Bonus Health."
     },
     {
       "Bonus": "Evasion",

--- a/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/Core/RogueTechCore/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -2006,9 +2006,9 @@
     },
     {
       "Bonus": "Health",
-      "Short": "{0} Injury",
-      "Long": "{0} Injury res.",
-      "Full": "{0} Injuries resisted."
+      "Short": "{0} HP",
+      "Long": "{0} Bonus HP.",
+      "Full": "{0} Bonus HP."
     },
     {
       "Bonus": "Evasion",

--- a/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.csv
+++ b/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.csv
@@ -9710,7 +9710,7 @@ Once the camera is off, Sumire says, «There's no way they push you on this. Too
 "MechEngineer.Haywire.Full";"Targets suffer penalty to movement, accuracy and heat management";"Цели получают штраф движения, точности и нагрева.";;"#000000";"#FFFFFF"
 "MechEngineer.Haywire.Long";"Haywire EMP scrambles a Target's systems";"Haywire EMP портят системы цели";;"#000000";"#FFFFFF"
 "MechEngineer.Haywire.Short";"Haywire EMP";"Haywire EMP заряды";;"#000000";"#FFFFFF"
-"MechEngineer.Health.Full";"{0} Bonus HP";"Сопротивление {0} травмам.";;"#000000";"#FFFFFF"
+"MechEngineer.Health.Full";"{0} Bonus Health";"Сопротивление {0} травмам.";;"#000000";"#FFFFFF"
 "MechEngineer.Health.Long";"{0} Injury res.";"{0} сопр. травм.";;"#000000";"#FFFFFF"
 "MechEngineer.Health.Short";"{0} Injury";"{0} травмы";;"#000000";"#FFFFFF"
 "MechEngineer.HeatDamage.Full";"{0} heat damage dealt";"{0} нагрева цели.";;"#000000";"#FFFFFF"

--- a/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.csv
+++ b/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.csv
@@ -9710,7 +9710,7 @@ Once the camera is off, Sumire says, «There's no way they push you on this. Too
 "MechEngineer.Haywire.Full";"Targets suffer penalty to movement, accuracy and heat management";"Цели получают штраф движения, точности и нагрева.";;"#000000";"#FFFFFF"
 "MechEngineer.Haywire.Long";"Haywire EMP scrambles a Target's systems";"Haywire EMP портят системы цели";;"#000000";"#FFFFFF"
 "MechEngineer.Haywire.Short";"Haywire EMP";"Haywire EMP заряды";;"#000000";"#FFFFFF"
-"MechEngineer.Health.Full";"{0} Injuries resisted";"Сопротивление {0} травмам.";;"#000000";"#FFFFFF"
+"MechEngineer.Health.Full";"{0} Bonus HP";"Сопротивление {0} травмам.";;"#000000";"#FFFFFF"
 "MechEngineer.Health.Long";"{0} Injury res.";"{0} сопр. травм.";;"#000000";"#FFFFFF"
 "MechEngineer.Health.Short";"{0} Injury";"{0} травмы";;"#000000";"#FFFFFF"
 "MechEngineer.HeatDamage.Full";"{0} heat damage dealt";"{0} нагрева цели.";;"#000000";"#FFFFFF"

--- a/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.json
+++ b/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.json
@@ -58455,8 +58455,8 @@
     },
     {
       "id": "MechEngineer.Health.Full",
-      "original": "{0} Bonus HP.",
-      "prevOriginal": "{0} Bonus HP",
+      "original": "{0} Bonus Health.",
+      "prevOriginal": "{0} Bonus Health",
       "content": "Сопротивление {0} травмам.",
       "localizatorComment": "",
       "systemComment": "",

--- a/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.json
+++ b/InstallOptions/Localization/CustomLocalization-RU/Localization/RogueTech/RU/RT Core/LocalizationDef.json
@@ -58455,8 +58455,8 @@
     },
     {
       "id": "MechEngineer.Health.Full",
-      "original": "{0} Injuries resisted.",
-      "prevOriginal": "{0} Injuries resisted",
+      "original": "{0} Bonus HP.",
+      "prevOriginal": "{0} Bonus HP",
       "content": "Сопротивление {0} травмам.",
       "localizatorComment": "",
       "systemComment": "",


### PR DESCRIPTION
Injuries Resisted is a somewhat misleading description on items as they don't use the injury resist mechanic. What they actually do is add temporary bonus HP for the duration of the combat which is consumed before pilot HP when taking injuries.

We've agreed on Bonus HP being the shortest and still accurate description.

Also fixed some of the Bonus Health entries missing the + sign.