### PR TITLE
Gave Lum Manufacturing to offset Clanspace having none.

### DIFF
--- a/Core/InnerSphereMap/StarSystems/starsystemdef_Lum.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_Lum.json
@@ -19,6 +19,7 @@
       "planet_feature_gasgiant",
       "planet_pop_medium",
       "planet_civ_innersphere",
+      "planet_industry_manufacturing",
       "planet_other_battlefield",
       "planet_faction_clansnowraven"
     ],

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_StranaMechty.json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_StranaMechty.json
@@ -17,7 +17,7 @@
       "planet_climate_terran",
       "planet_feature_moon03",
       "planet_other_moon",
-      "planet_pop_medium",
+      "planet_pop_large",
       "planet_other_megacity",
       "planet_other_capital",
       "planet_civ_innersphere",

--- a/Core/InnerSphereMap/StarSystems/starsystemdef_York(Clan).json
+++ b/Core/InnerSphereMap/StarSystems/starsystemdef_York(Clan).json
@@ -19,7 +19,7 @@
       "planet_other_floatingworld",
       "planet_feature_moon01",
       "planet_other_moon",
-      "planet_pop_small",
+      "planet_pop_large",
       "planet_civ_innersphere",
       "planet_other_battlefield",
       "planet_faction_locals"


### PR DESCRIPTION
Game York and Strana mechty Large pop to offset only babylon having large pop, mainly for NI surgery